### PR TITLE
Restructure repo as portable dev standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.1
+    hooks:
+      - id: ruff-check
+      - id: ruff-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,103 +1,91 @@
-# AGENTS.md Template
+# AGENTS.md
 
-Use this file as a starting point for repository-level agent instructions.
-Copy into a target repository as `AGENTS.md`, then replace placeholders.
+## Repository Purpose
 
-## Purpose
-This file defines agent-facing operating rules for this repository.
-It refines workspace defaults from `DEVELOPMENT-CONTEXT.md` with repo-specific instructions.
-
-## Scope
-Applies to all agent work in this repository.
-
-## Precedence
-1. Safety/security constraints from workspace context are minimum requirements.
-2. This repository `AGENTS.md` defines local implementation rules.
-3. If a conflict exists, follow this file for repo behavior unless it weakens workspace safety/security standards.
+This repository defines portable standards, starter kits, and bootstrap tooling
+for creating and maintaining software repositories with clear human and agent
+operating boundaries.
 
 ## Repository Context
-- Repository name: `<REPO_NAME>`
-- Primary language(s): `<LANGUAGES>`
-- Runtime/build system: `<RUNTIME_OR_BUILD_SYSTEM>`
+
+- Primary focus: repository standards and Python-first starter assets
+- Secondary focus: future JavaScript/TypeScript profile scaffolding
 - Key directories:
-- Source: `<SRC_PATH>`
-- Tests: `<TEST_PATH>`
-- Docs: `<DOCS_PATH>`
-- Entry points/services: `<ENTRYPOINTS>`
+  - `src/`: implementation code for bootstrap tooling
+  - `tests/`: automated verification for the tooling
+  - `docs/`: normative standards
+  - `profiles/`: language-specific standards
+  - `templates/`: reusable file templates
+  - `starter-kits/`: starter repository skeletons
+  - `examples/`: concrete filled examples
 
-## Standard Workflow
-1. Read this `AGENTS.md` first.
-2. Implement the requested feature or change.
-3. Run all repository quality gates.
-4. Update documentation cleanly.
-5. Commit only if all quality gates pass.
+## Human And Agent Responsibilities
 
-## Engineering Guidelines
-- Design clean APIs with explicit boundaries.
-- Prefer maintainable and extendable code.
-- Minimize coupling and isolate responsibilities.
-- Keep public interfaces stable unless a breaking change is approved.
+Humans own:
 
-## Toolchain Standards
-- Python-heavy repositories should default to Astral tooling.
-- Strong typing is expected across production code.
-- Preferred tools: `uv`, `ruff`, `ty`.
-- Repo-specific additions: `<ADDITIONAL_TOOLS>`
+- product direction for the standard
+- approval of breaking changes to the standard contract
+- release and publication decisions
+- language-profile expansion decisions
+
+Agents own:
+
+- writing and updating the standards docs
+- maintaining templates and starter assets
+- implementing bootstrap tooling
+- keeping examples aligned with the standard
+
+Agents must not:
+
+- invent profile rules that are not documented in the standard
+- weaken the documented quality baseline without explicit instruction
+- add a first-class language profile without complete documentation and starter
+  assets
+
+## Workflow
+
+1. Update the normative docs first when changing the standard.
+2. Update templates, starter kits, and examples in the same change.
+3. Validate the bootstrap tool against a temporary output directory.
+4. Keep changes small and focused by concern.
 
 ## Quality Gates
-Run from repository root unless explicitly documented otherwise.
 
-Default baseline:
+Run from repository root:
+
 1. `uv sync`
-2. `ruff format --check .`
-3. `ruff check .`
-4. `ty check`
-5. `pytest`
+2. `uv run pre-commit run --all-files`
+3. `uv run ruff format --check .`
+4. `uv run ruff check .`
+5. `uv run ty check`
+6. `uv run pytest`
+7. `uv run repo-init --profile python --repo-name demo-repo --package-name demo_repo --description "Bootstrap validation" --output-dir /tmp/demo-repo --no-install`
 
-Repository overrides/additions:
-1. `<CUSTOM_GATE_1>`
-2. `<CUSTOM_GATE_2>`
+## Coding Standards
+
+- Keep reusable Python logic under `src/`
+- Keep `tools/` wrappers thin and orchestration-focused
+- Type production function signatures
+- Keep starter assets and tests aligned with the documented standard
 
 ## Testing Policy
-- Logic changes require unit tests.
-- API/integration/data-flow changes require integration tests where boundaries are crossed.
-- Bug fixes require regression coverage.
-- If a required test type is impractical, explain the rationale in PR notes.
 
-## API Compatibility Rules
-- Prefer backward-compatible changes by default.
-- Breaking changes require migration notes and explicit version impact.
-- Deprecations require documentation of replacement path before removal.
+- Changes to bootstrap behavior require automated tests in `tests/`
+- Bug fixes require regression coverage
+- Generated starter output must be validated when the starter changes
 
-## Dependency And Versioning Policy
-- Use pinned or constrained dependency versions as appropriate.
-- Keep dependencies updated on a regular cadence.
-- Validate major upgrades with compatibility review and tests.
+## Repository Layout
 
-## Security Baseline
-- Never commit secrets, tokens, or credentials.
-- Use approved secret management and environment configuration.
-- Do not log sensitive data.
-- Run security/static checks included in quality gates.
+- `src/`: bootstrap implementation
+- `tests/`: automated tests
+- `docs/`: normative standards
+- `profiles/`: language-specific profiles
+- `templates/`: reusable templates
+- `starter-kits/`: starter repo skeletons
+- `examples/`: filled examples
 
-## Documentation Standards
-- `README.md` is user-facing documentation.
-- `AGENTS.md` is agent-facing operational guidance.
-- Use `.puml` for workflow diagrams when process changes or complexity warrants it.
+## Documentation Rules
 
-## Commit And PR Conventions
-- Keep commits focused and scoped.
-- Use clear commit messages that explain intent and impact.
-- PR descriptions should include summary, testing evidence, and documentation impact.
-- Do not merge with failing quality gates.
-
-## Architecture Decision Records
-- Create ADRs for major design decisions and tradeoffs.
-- ADR content should include context, options, decision, and consequences.
-- ADR location: `<ADR_PATH>`
-
-## Definition Of Done
-- Requested change is implemented.
-- Quality gates pass.
-- Relevant docs are updated (`README.md`, `AGENTS.md`, `.puml`, ADRs when needed).
-- Change is ready to merge or committed per repository process.
+- Changes to standards must update the corresponding document in `docs/`
+- Changes to templates or starter kits must keep examples consistent
+- New operating rules belong in docs before they appear in starter assets

--- a/DEVELOPMENT-CONTEXT.md
+++ b/DEVELOPMENT-CONTEXT.md
@@ -1,81 +1,12 @@
 # Development Context
 
-## Purpose
-This document defines workspace-wide development context and engineering operating standards for all work under `/home/thomazo/dev`.
+This file is retained as a compatibility pointer for prior consumers of this
+repository.
 
-## Scope
-These standards apply to all repositories in this workspace unless a repository-level `AGENTS.md` explicitly overrides them.
+The portable repository standard now lives in:
 
-## Standard Workflow
-1. Read `AGENTS.md` first.
-2. Implement the requested feature or change.
-3. Run all required quality gates.
-4. Update documentation cleanly.
-5. Commit only if all quality gates pass.
+- `docs/repo-standard.md`
+- `profiles/python.md`
+- `docs/bootstrap-workflow.md`
 
-## Engineering Guidelines
-- Design clean APIs with clear boundaries.
-- Prioritize maintainable implementations.
-- Favor extendable architecture and low coupling.
-
-## Toolchain Standards
-- Default assumption: Python-heavy repositories.
-- Strong typing is expected across the codebase.
-- Use Astral tooling by default: `uv`, `ruff`, and `ty`.
-
-## Quality Gates (Default Commands)
-Run these commands from the repository root unless that repository's `AGENTS.md` defines replacements:
-1. `uv sync`
-2. `ruff format --check .`
-3. `ruff check .`
-4. `ty check`
-5. `pytest`
-
-## Repository Override Policy
-- Repository-level `AGENTS.md` may refine or extend these defaults when needed for local architecture and tooling.
-- Workspace-level safety and security expectations are minimum standards and must not be weakened by repo overrides.
-- If repo guidance conflicts with this file, follow repo `AGENTS.md` for implementation details and this file for shared baseline principles.
-
-## Testing Policy
-- Logic changes require unit tests.
-- API, integration, or data-flow changes require integration tests when boundaries are involved.
-- Bug fixes require a regression test that fails before the fix and passes after it.
-- If a required test type is not practical, document the reason in the change notes.
-
-## API Compatibility Rules
-- Prefer backward-compatible changes for existing interfaces.
-- Breaking changes require explicit versioning impact notes and migration guidance in docs.
-- Deprecations should be announced in docs before removal, with a clear replacement path.
-
-## Dependency And Versioning Policy
-- Prefer pinned or constrained dependency versions appropriate to each repository's package management strategy.
-- Keep dependencies current with regular maintenance updates.
-- Major version upgrades require a short compatibility review and test validation before merge.
-
-## Security Baseline
-- Never commit secrets, tokens, or credentials.
-- Use environment variables or approved secret-management paths for sensitive values.
-- Avoid logging sensitive data (credentials, tokens, PII, production identifiers).
-- Run dependency and static checks included in repository quality gates.
-
-## Commit And PR Conventions
-- Use clear, scoped commit messages that describe intent and impact.
-- Keep commits focused and logically grouped.
-- PR descriptions should include: summary, testing evidence, and documentation impact.
-- Do not merge with failing quality gates.
-
-## Architecture Decision Records
-- Create an ADR for significant architectural decisions, major tradeoffs, or breaking design shifts.
-- ADRs should capture context, options considered, decision, and consequences.
-- Store ADRs in the repository's documented architecture/docs location.
-
-## Documentation Standards
-- `AGENTS.md` is agent-facing operational guidance.
-- `README.md` is user-facing documentation.
-- Use `.puml` files to document workflows when needed.
-
-## Definition Of Done
-- The requested change is implemented.
-- Quality gates pass.
-- Relevant documentation is updated (`README.md`, `AGENTS.md`, and workflow `.puml` files when applicable).
-- The change is committed.
+Use those documents instead of treating this file as the primary standard.

--- a/README.md
+++ b/README.md
@@ -1,59 +1,89 @@
-# development-context-master
+# repo-development-standard
 
-Baseline workspace development standards and operating policy.
+Portable development standards, starter kits, and bootstrap tooling for modern
+software repositories.
 
-## What This Repository Provides
+## Purpose
 
-This repository maintains a canonical development context document that can be used as the root policy for a multi-repo workspace.
+This repository defines a practical operating model for building repositories
+with humans and agents working together. It is designed to make good defaults
+easy to adopt when creating a new repository and easy to reference when
+maintaining an existing one.
 
-Primary artifact:
-- `DEVELOPMENT-CONTEXT.md`: workspace-wide workflow, engineering guidelines, tooling defaults, quality gates, documentation policy, and definition of done.
+This repository provides:
 
-## Intended Usage
+- normative documentation for repository development standards
+- a required `AGENTS.md` contract for repository-level guidance
+- a complete Python profile with quality gates and coding standards
+- a trunk-based collaboration workflow for parallel development
+- a standard Python repository layout
+- starter-kit assets for new repositories
+- a thin bootstrap tool for generating a new repository from the starter kit
+- a JavaScript/TypeScript profile scaffold for later expansion
 
-Use this repository when you want a single source of truth for how development should be performed across multiple repositories.
+## What Is Normative
 
-Typical use cases:
-- Bootstrapping a new workspace with consistent engineering standards.
-- Aligning agent and human contributors on shared workflow and quality expectations.
-- Standardizing Python-heavy development with Astral tooling (`uv`, `ruff`, `ty`).
+The normative source documents are:
 
-## Policy Model (Precedence)
+- `docs/repo-standard.md`
+- `docs/agent-operating-model.md`
+- `docs/git-workflow.md`
+- `docs/repo-layout.md`
+- `docs/bootstrap-workflow.md`
+- `profiles/python.md`
 
-The model is intentionally two-level:
-1. Workspace baseline in `DEVELOPMENT-CONTEXT.md`.
-2. Repository-specific overrides in each repo `AGENTS.md`.
+Templates and starter kits implement those standards, but the documents above
+define the intent and rules.
 
-Repository `AGENTS.md` can refine implementation details, but should not weaken workspace-level safety and security expectations.
+## Repository Layout
 
-## Quick Start
+- `docs/`: standards and operating guidance
+- `profiles/`: language or repo-type specific standards
+- `templates/`: reusable templates for repo-level files
+- `starter-kits/`: copyable repository skeletons
+- `src/repo_standard/`: packaged bootstrap implementation
+- `examples/`: filled examples showing the standard in practice
 
-1. Keep `DEVELOPMENT-CONTEXT.md` at the workspace root.
-2. Update the `Scope` section path to match your local workspace.
-3. In each repository, add or update `AGENTS.md` with project-specific rules.
-4. Ensure user-facing guidance lives in each repo `README.md`.
-5. Add workflow diagrams as `.puml` files where process clarity is needed.
+## Bootstrap A New Python Repository
 
-## Default Quality Gates
+The recommended workflow is:
 
-Unless a repository defines replacements in its `AGENTS.md`, run:
+1. Create an empty target repository or working directory.
+2. Run the bootstrap tool:
 
 ```bash
-uv sync
-ruff format --check .
-ruff check .
-ty check
-pytest
+uv run repo-init \
+  --profile python \
+  --repo-name my-service \
+  --package-name my_service \
+  --description "Short repo purpose" \
+  --output-dir ../my-service
 ```
 
-## Maintenance Guidelines
+3. Review the generated `AGENTS.md` and `README.md`.
+4. Run the quality gates in the generated repository.
+5. Make the initial commit on `main`.
 
-- Keep `DEVELOPMENT-CONTEXT.md` concise, enforceable, and tool-accurate.
-- Update this repository when workflow, tooling, or policy standards change.
-- Treat changes as governance changes: document rationale clearly in commit/PR descriptions.
+Do not clone this standards repository as the starting point for a product
+repository. Generate or template the target repository separately.
 
-## Related Documentation Roles
+## Current Profiles
 
-- `AGENTS.md`: agent-facing operational instructions.
-- `README.md`: user-facing usage and onboarding documentation.
-- `.puml`: workflow/process diagrams.
+- `python`: first-class, complete, and opinionated
+- `javascript-typescript`: scaffold only for future expansion
+
+## Adoption Paths
+
+Use this repository in one of two ways:
+
+- New repository: bootstrap from `starter-kits/python/` via `repo-init`
+- Existing repository: adapt the repo to match the standard and populate
+  `AGENTS.md` using `templates/AGENTS.md`
+
+## Design Principles
+
+- Portable: no workspace-specific filesystem assumptions
+- Practical: exact commands and concrete file layouts, not abstract policy only
+- Collaborative: explicit human and agent responsibility boundaries
+- Typed: strong typing expectations for Python code
+- Small-batch: trunk-based PR workflow for parallel work

--- a/docs/agent-operating-model.md
+++ b/docs/agent-operating-model.md
@@ -1,0 +1,43 @@
+# Agent Operating Model
+
+## Goal
+
+Define clear decision boundaries between humans and agents so implementation
+work can move quickly without ambiguity or accidental overreach.
+
+## Human Responsibilities
+
+Humans own:
+
+- product scope and intent
+- security exceptions and secret handling
+- merge and release authority
+- production access and production operations sign-off
+- approval of breaking API, schema, or migration changes
+- architectural exceptions to the documented standard
+
+## Agent Responsibilities
+
+Agents own:
+
+- implementation within documented repository boundaries
+- tests, regression coverage, and local verification
+- documentation updates tied to behavior changes
+- starter-kit and template maintenance
+- surfacing risks, missing decisions, and unclear contracts
+
+## Shared Expectations
+
+- Keep code, tests, and docs aligned
+- Prefer small, reviewable changes
+- Make operational boundaries explicit
+- Do not rely on undocumented local knowledge
+
+## Agent Prohibitions
+
+Agents must not:
+
+- bypass documented quality gates
+- weaken typing or test expectations without explicit instruction
+- make security, release, or breaking-change decisions alone
+- modify out-of-scope systems without explicit approval

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -1,0 +1,49 @@
+# Bootstrap Workflow
+
+## Goal
+
+Create new repositories that begin aligned with the standard by default instead
+of relying on manual copy-paste and post-hoc cleanup.
+
+## Default Bootstrap Model
+
+Use a template-plus-initializer approach:
+
+- starter kit provides the file and directory skeleton
+- bootstrap tool fills repository-specific metadata and paths
+
+Do not clone the standards repository as the base of a product repository.
+
+## Recommended New Repository Flow
+
+1. Create an empty target repository or working directory.
+2. Run `repo-init` with the Python profile and repository metadata.
+3. Review generated `AGENTS.md`, `README.md`, and package naming.
+4. Run the generated repository quality gates.
+5. Make the initial commit on `main`.
+
+## `repo-init` Inputs
+
+Required:
+
+- `--profile`
+- `--repo-name`
+- `--package-name`
+- `--description`
+
+Optional:
+
+- `--repo-type`
+- `--python-version`
+- `--author`
+- `--output-dir`
+- `--no-install`
+
+## Expected Output
+
+The generated repository should contain:
+
+- a concrete `AGENTS.md`
+- baseline Python tooling files
+- a standard `src/` and `tests/` layout
+- a README with the repository purpose and workflow entry points

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,33 @@
+# Git Workflow
+
+## Default Model
+
+Use trunk-based development with pull requests.
+
+## Branching Rules
+
+- `main` is the only long-lived integration branch
+- work happens on short-lived branches
+- use one branch per objective
+- branch prefixes:
+  - `feat/`
+  - `fix/`
+  - `refactor/`
+  - `docs/`
+  - `chore/`
+
+## Parallel Collaboration
+
+- prefer small PRs over long-lived branches
+- use stacked PRs when a larger change needs sequencing
+- rebase private branches frequently to reduce drift
+- avoid multiple concurrent branches changing the same subsystem without
+  coordination
+- use feature flags or additive changes for incomplete work
+
+## History Rules
+
+- rebasing private branches is allowed
+- rewriting shared branches is not allowed
+- merge through reviewed PRs only
+- cut releases from `main` with tags

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -1,0 +1,33 @@
+# Repository Layout
+
+## Canonical Python Layout
+
+Use this layout by default for Python repositories:
+
+- `AGENTS.md`
+- `README.md`
+- `pyproject.toml`
+- `.pre-commit-config.yaml`
+- `src/<package_name>/`
+- `tests/`
+- `docs/adr/`
+- `docs/diagrams/`
+- `scripts/`
+- `examples/` when useful
+
+## Directory Responsibilities
+
+- `src/`: production code only
+- `tests/`: test code only
+- `docs/`: durable project knowledge
+- `docs/adr/`: architecture decisions
+- `docs/diagrams/`: workflow or architecture diagrams
+- `scripts/`: developer or operational helpers, not core business logic
+- `examples/`: user-facing or integration examples when they add value
+
+## Scope Boundaries
+
+- Reusable logic belongs in `src/`
+- Scripts may orchestrate but should not own durable domain logic
+- Tests should exercise public behavior and integration boundaries
+- Docs should explain workflows, contracts, and decisions that matter over time

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -1,0 +1,61 @@
+# Repository Development Standard
+
+## Purpose
+
+This standard defines the baseline operating model for a software repository
+developed by humans and agents together. It focuses on practical repository
+structure, collaboration workflow, quality gates, coding standards, and
+repository-level guidance through `AGENTS.md`.
+
+## Applicability
+
+This standard is intended to be portable. A repository may adopt it directly or
+adapt it through its own `AGENTS.md`, but the resulting guidance must remain
+concrete and actionable.
+
+## Repository Contract
+
+Every repository adopting this standard should provide:
+
+- a concrete `AGENTS.md`
+- a user-facing `README.md`
+- exact quality-gate commands
+- a documented repository layout
+- clear API, schema, or migration rules where relevant
+
+## Core Rules
+
+- Use a trunk-based PR workflow by default.
+- Keep public interfaces stable unless a deliberate breaking change is approved.
+- Document exact quality-gate commands in the repository's `AGENTS.md`.
+- Treat typing, tests, and docs as part of the implementation, not optional
+  polish.
+- Keep operational boundaries explicit: product intent and release authority
+  remain human-owned.
+
+## Required Companion Documents
+
+Use these documents together:
+
+- `docs/agent-operating-model.md`
+- `docs/git-workflow.md`
+- `docs/repo-layout.md`
+- `docs/bootstrap-workflow.md`
+- `profiles/python.md`
+
+## Required `AGENTS.md` Sections
+
+Every target repository should include:
+
+1. Repository Purpose
+2. Repository Context
+3. Human And Agent Responsibilities
+4. Workflow
+5. Quality Gates
+6. Coding Standards
+7. Testing Policy
+8. Documentation Rules
+9. Repository Layout
+10. Change Control Notes
+
+Committed copies must not contain placeholders or generic filler text.

--- a/examples/python-lib/AGENTS.md
+++ b/examples/python-lib/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Repository Purpose
+
+`widget-core` provides a typed Python library for validating and transforming
+widget payloads used by internal services.
+
+## Repository Context
+
+- Repository name: `widget-core`
+- Primary language(s): `Python`
+- Runtime/build system: `uv` with `pyproject.toml`
+- Repository type: `library`
+- Key directories:
+  - `src/`: reusable library code
+  - `tests/`: unit and integration tests
+  - `docs/`: ADRs and public usage notes
+
+## Human And Agent Responsibilities
+
+Humans own:
+
+- release management
+- approval of public API breaking changes
+- security review for dependency changes
+
+Agents own:
+
+- implementation and refactors inside `src/`
+- tests for behavior and regressions
+- README and ADR updates when behavior changes
+
+## Workflow
+
+- Long-lived branch: `main`
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- Merge through reviewed PRs only
+- Keep PRs single-purpose
+
+## Quality Gates
+
+1. `uv sync`
+2. `uv run pre-commit run --all-files`
+3. `uv run ruff format --check .`
+4. `uv run ruff check .`
+5. `uv run ty check`
+6. `uv run pytest`
+
+## Coding Standards
+
+- Public APIs under `src/widget_core/` must remain backward compatible by
+  default
+- Type all public function signatures
+- Keep parsing I/O separate from domain transformations
+
+## Testing Policy
+
+- Add unit tests for transformation logic
+- Add regression tests for bug fixes
+- Add integration tests when file or network boundaries are introduced
+
+## Documentation Rules
+
+- Update `README.md` for public API usage changes
+- Add ADRs for significant architectural changes
+
+## Repository Layout
+
+- `src/`: library code
+- `tests/`: automated tests
+- `docs/`: durable project knowledge
+- `scripts/`: development helpers only
+
+## Change Control Notes
+
+Breaking changes to public symbols require migration notes in `README.md`.

--- a/examples/python-service/AGENTS.md
+++ b/examples/python-service/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+## Repository Purpose
+
+`widget-api` exposes a Python service for receiving, validating, and storing
+widget payloads.
+
+## Repository Context
+
+- Repository name: `widget-api`
+- Primary language(s): `Python`
+- Runtime/build system: `uv` with `pyproject.toml`
+- Repository type: `service`
+- Key directories:
+  - `src/`: service code
+  - `tests/`: unit and integration tests
+  - `docs/`: ADRs and operational workflows
+
+## Human And Agent Responsibilities
+
+Humans own:
+
+- production rollout decisions
+- secret handling and environment approvals
+- approval of API-breaking changes
+
+Agents own:
+
+- service implementation within repo boundaries
+- automated tests and regression coverage
+- docs updates for behavior changes
+
+## Workflow
+
+- Long-lived branch: `main`
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- Merge through reviewed PRs only
+- Prefer small PRs and additive changes
+
+## Quality Gates
+
+1. `uv sync`
+2. `uv run pre-commit run --all-files`
+3. `uv run ruff format --check .`
+4. `uv run ruff check .`
+5. `uv run ty check`
+6. `uv run pytest`
+
+## Coding Standards
+
+- Keep transport logic separate from domain logic
+- Type all production function signatures
+- Treat API schemas as stable by default
+
+## Testing Policy
+
+- Logic changes require unit tests
+- Handler and storage boundaries require integration tests
+- Bug fixes require regression tests
+
+## Documentation Rules
+
+- Update API usage docs when request/response behavior changes
+- Add ADRs for significant architecture or operational decisions
+
+## Repository Layout
+
+- `src/`: production service code
+- `tests/`: automated tests
+- `docs/`: runbooks, ADRs, and workflow docs
+- `scripts/`: development and operational helpers
+
+## Change Control Notes
+
+Request or response schema changes require explicit migration notes.

--- a/profiles/javascript-typescript.md
+++ b/profiles/javascript-typescript.md
@@ -1,0 +1,22 @@
+# JavaScript/TypeScript Profile
+
+## Status
+
+This profile is a scaffold for future expansion. It is intentionally not a
+first-class maintained profile yet.
+
+## Intended Scope
+
+When promoted to a first-class profile, this document should define:
+
+- package manager baseline
+- formatter and linter baseline
+- type-checking baseline
+- test runner baseline
+- standard repository layout
+- quality-gate commands
+
+## Current Rule
+
+Do not claim JavaScript/TypeScript support in starter kits until this profile is
+completed and maintained.

--- a/profiles/python.md
+++ b/profiles/python.md
@@ -1,0 +1,53 @@
+# Python Profile
+
+## Purpose
+
+This is the first-class engineering profile for repositories built with Python.
+
+## Required Toolchain
+
+- `uv` for environment and dependency management
+- `pre-commit` for local guardrails
+- `ruff` for formatting and linting
+- `ty` for type checking
+- `pytest` for tests
+
+## Baseline Quality Gates
+
+Run from repository root:
+
+1. `uv sync`
+2. `uv run pre-commit run --all-files`
+3. `uv run ruff format --check .`
+4. `uv run ruff check .`
+5. `uv run ty check`
+6. `uv run pytest`
+
+## Coding Standards
+
+- Type production function signatures
+- Type public APIs and configuration models
+- Minimize `Any` and justify it when needed
+- Keep I/O boundaries explicit
+- Separate side effects from business logic
+- Favor small modules with clear responsibilities
+- Treat public interfaces as stable by default
+
+## Testing Standards
+
+- Logic changes require unit tests
+- Boundary-crossing changes require integration tests
+- Bug fixes require regression tests
+
+## Packaging And Layout
+
+- Use `src/` layout
+- Configure toolchain in `pyproject.toml`
+- Keep scripts out of the production package unless they are product entry
+  points
+
+## Documentation Standards
+
+- Update README when setup or usage changes
+- Add ADRs for significant architecture decisions
+- Document durable workflows under `docs/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "repo-development-standard"
+version = "0.1.0"
+description = "Portable development standards, starter kits, and bootstrap tooling for software repositories."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.scripts]
+repo-init = "repo_standard.repo_init:main"
+
+[dependency-groups]
+dev = [
+  "pre-commit>=4.0.0",
+  "pytest>=8.0.0",
+  "ruff>=0.6.0",
+  "ty>=0.0.1a16",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/repo_standard"]
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "PT"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ty.src]
+include = ["src", "tests"]

--- a/src/repo_standard/__init__.py
+++ b/src/repo_standard/__init__.py
@@ -1,0 +1,1 @@
+"""Portable repo standards and bootstrap tooling."""

--- a/src/repo_standard/repo_init.py
+++ b/src/repo_standard/repo_init.py
@@ -1,0 +1,178 @@
+"""Bootstrap a new repository from a starter kit."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PLACEHOLDERS = {
+    "__REPO_NAME__": "repo_name",
+    "__PACKAGE_NAME__": "package_name",
+    "__DESCRIPTION__": "description",
+    "__REPO_TYPE__": "repo_type",
+    "__PYTHON_VERSION__": "python_version",
+    "__AUTHOR__": "author",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a new repository from the standard starter kits."
+    )
+    parser.add_argument("--profile", choices=["python"], required=True)
+    parser.add_argument("--repo-name", required=True)
+    parser.add_argument("--package-name", required=True)
+    parser.add_argument("--description", required=True)
+    parser.add_argument(
+        "--repo-type",
+        choices=["service", "library", "cli"],
+        default="library",
+    )
+    parser.add_argument("--python-version", default="3.12")
+    parser.add_argument("--author", default="")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--no-install", action="store_true")
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def validate_package_name(package_name: str) -> None:
+    if not package_name.isidentifier():
+        raise ValueError(
+            "--package-name must be a valid Python identifier "
+            f"(got {package_name!r})"
+        )
+
+
+def ensure_output_dir(output_dir: Path) -> None:
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise ValueError(
+            f"Output directory {output_dir} already exists and is not empty."
+        )
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def copy_starter(starter_dir: Path, output_dir: Path) -> None:
+    for item in starter_dir.iterdir():
+        destination = output_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, destination)
+        else:
+            shutil.copy2(item, destination)
+
+
+def render_text_files(output_dir: Path, values: dict[str, str]) -> None:
+    for path in output_dir.rglob("*"):
+        if "__pycache__" in path.parts or path.suffix == ".pyc":
+            continue
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for placeholder, key in PLACEHOLDERS.items():
+            text = text.replace(placeholder, values[key])
+        path.write_text(text, encoding="utf-8")
+
+
+def rename_package_dir(output_dir: Path, package_name: str) -> None:
+    source_dir = output_dir / "src" / "package_name"
+    if source_dir.exists():
+        source_dir.rename(output_dir / "src" / package_name)
+
+
+def update_python_version(output_dir: Path, python_version: str) -> None:
+    pyproject_path = output_dir / "pyproject.toml"
+    if not pyproject_path.exists():
+        return
+    text = pyproject_path.read_text(encoding="utf-8")
+    text = text.replace(
+        'requires-python = ">=3.12"',
+        f'requires-python = ">={python_version}"',
+    )
+    pyproject_path.write_text(text, encoding="utf-8")
+
+
+def run_optional_installs(output_dir: Path) -> None:
+    commands = [
+        ["uv", "sync"],
+        ["uv", "run", "pre-commit", "install"],
+    ]
+    for command in commands:
+        try:
+            subprocess.run(command, cwd=output_dir, check=True)
+        except FileNotFoundError:
+            print(
+                f"Skipped {' '.join(command)} because the executable was not found.",
+                file=sys.stderr,
+            )
+            return
+
+
+def bootstrap_repo(
+    *,
+    repo_root: Path,
+    profile: str,
+    repo_name: str,
+    package_name: str,
+    description: str,
+    repo_type: str,
+    python_version: str,
+    author: str,
+    output_dir: Path,
+    no_install: bool,
+) -> Path:
+    validate_package_name(package_name)
+
+    starter_dir = repo_root / "starter-kits" / profile
+    ensure_output_dir(output_dir)
+    copy_starter(starter_dir, output_dir)
+
+    values = {
+        "repo_name": repo_name,
+        "package_name": package_name,
+        "description": description,
+        "repo_type": repo_type,
+        "python_version": python_version,
+        "author": author,
+    }
+    render_text_files(output_dir, values)
+    rename_package_dir(output_dir, package_name)
+    update_python_version(output_dir, python_version)
+
+    if not no_install:
+        run_optional_installs(output_dir)
+
+    return output_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[2]
+    output_dir = Path(args.output_dir).resolve()
+
+    bootstrap_repo(
+        repo_root=repo_root,
+        profile=args.profile,
+        repo_name=args.repo_name,
+        package_name=args.package_name,
+        description=args.description,
+        repo_type=args.repo_type,
+        python_version=args.python_version,
+        author=args.author,
+        output_dir=output_dir,
+        no_install=args.no_install,
+    )
+    print(f"Bootstrapped {args.repo_name} into {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starter-kits/python/.pre-commit-config.yaml
+++ b/starter-kits/python/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.1
+    hooks:
+      - id: ruff-check
+      - id: ruff-format

--- a/starter-kits/python/AGENTS.md
+++ b/starter-kits/python/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+## Repository Purpose
+
+`__REPO_NAME__` exists to `__DESCRIPTION__`.
+
+## Repository Context
+
+- Repository name: `__REPO_NAME__`
+- Primary language(s): `Python`
+- Runtime/build system: `uv` with `pyproject.toml`
+- Repository type: `__REPO_TYPE__`
+- Key directories:
+  - `src/`: production package code
+  - `tests/`: automated tests
+  - `docs/`: durable repository knowledge
+
+## Human And Agent Responsibilities
+
+Humans own:
+
+- product scope and intent
+- merge and release authority
+- approval of breaking changes
+- security exceptions and secrets
+
+Agents own:
+
+- implementation within documented boundaries
+- tests and regression coverage
+- docs updates for behavior changes
+- running documented quality gates
+
+## Workflow
+
+- Long-lived branch: `main`
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- Merge through reviewed PRs only
+- Keep PRs focused and small
+
+## Quality Gates
+
+Run from repo root:
+
+1. `uv sync`
+2. `uv run pre-commit run --all-files`
+3. `uv run ruff format --check .`
+4. `uv run ruff check .`
+5. `uv run ty check`
+6. `uv run pytest`
+
+## Coding Standards
+
+- Type all production function signatures
+- Minimize `Any` and justify it when required
+- Keep I/O boundaries explicit
+- Separate side effects from business logic
+
+## Testing Policy
+
+- Logic changes require unit tests
+- Boundary changes require integration tests
+- Bug fixes require regression tests
+
+## Documentation Rules
+
+- Update `README.md` when setup or usage changes
+- Update `AGENTS.md` when operating rules change
+- Add ADRs for significant architecture decisions
+
+## Repository Layout
+
+- `src/`: production package code
+- `tests/`: automated tests
+- `docs/`: durable project knowledge
+- `scripts/`: developer helpers, not core business logic
+
+## Change Control Notes
+
+Document API, schema, or migration-specific rules here when the repository
+introduces them.

--- a/starter-kits/python/README.md
+++ b/starter-kits/python/README.md
@@ -1,0 +1,12 @@
+# __REPO_NAME__
+
+__DESCRIPTION__
+
+## Purpose
+
+This repository contains the `__PACKAGE_NAME__` Python project.
+
+## Development
+
+Repository workflow, quality gates, and coding standards are defined in
+`AGENTS.md`.

--- a/starter-kits/python/docs/adr/0001-template.md
+++ b/starter-kits/python/docs/adr/0001-template.md
@@ -1,0 +1,14 @@
+# ADR-0001: Initial Repository Setup
+
+## Context
+
+This repository was created from the Python starter kit.
+
+## Decision
+
+Adopt the default repository structure, toolchain, and workflow defined in
+`AGENTS.md`.
+
+## Consequences
+
+Future significant architecture changes should add new ADRs under `docs/adr/`.

--- a/starter-kits/python/docs/diagrams/README.md
+++ b/starter-kits/python/docs/diagrams/README.md
@@ -1,0 +1,4 @@
+# Diagrams
+
+Store workflow and architecture diagrams here when the repository needs durable
+visual documentation.

--- a/starter-kits/python/pyproject.toml
+++ b/starter-kits/python/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "__REPO_NAME__"
+version = "0.1.0"
+description = "__DESCRIPTION__"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[dependency-groups]
+dev = [
+  "pre-commit>=4.0.0",
+  "pytest>=8.0.0",
+  "ruff>=0.6.0",
+  "ty>=0.0.1a16",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "PT"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ty.src]
+include = ["src", "tests"]

--- a/starter-kits/python/src/package_name/__init__.py
+++ b/starter-kits/python/src/package_name/__init__.py
@@ -1,0 +1,2 @@
+"""__PACKAGE_NAME__ package."""
+

--- a/starter-kits/python/tests/test_smoke.py
+++ b/starter-kits/python/tests/test_smoke.py
@@ -1,0 +1,5 @@
+from __PACKAGE_NAME__ import __doc__
+
+
+def test_package_imports() -> None:
+    assert __doc__ is not None

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Repository Purpose
+
+Describe what this repository exists to do, for whom, and what is out of scope.
+
+## Repository Context
+
+- Repository name: `<repo-name>`
+- Primary language(s): `<languages>`
+- Runtime/build system: `<runtime>`
+- Key directories:
+  - `src/`: `<production-code-scope>`
+  - `tests/`: `<test-scope>`
+  - `docs/`: `<documentation-scope>`
+
+## Human And Agent Responsibilities
+
+Humans own:
+
+- product scope and intent
+- security exceptions and secret handling
+- merge and release authority
+- approval of breaking changes
+
+Agents own:
+
+- implementation within documented repo boundaries
+- tests and regression coverage
+- docs updates tied to behavior changes
+- running documented quality gates
+
+## Workflow
+
+- Long-lived branch: `main`
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- Merge via reviewed PRs only
+- Keep PRs small and single-purpose
+
+## Quality Gates
+
+Run from repo root:
+
+1. `<command-1>`
+2. `<command-2>`
+3. `<command-3>`
+
+## Coding Standards
+
+- Type all production function signatures
+- Keep I/O boundaries explicit
+- Separate durable logic from scripts
+- Preserve public interface stability by default
+
+## Testing Policy
+
+- Logic changes require unit tests
+- Boundary changes require integration tests
+- Bug fixes require regression tests
+
+## Documentation Rules
+
+- Update `README.md` when setup or usage changes
+- Update `AGENTS.md` when operating rules change
+- Add ADRs for significant architecture decisions
+
+## Repository Layout
+
+- `src/`: production code
+- `tests/`: tests
+- `docs/`: durable project knowledge
+- `scripts/`: developer or operational helpers
+
+## Change Control Notes
+
+Document any repo-specific API, schema, migration, or operational constraints.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,11 @@
+# <repo-name>
+
+<short-description>
+
+## Purpose
+
+Describe the repository purpose and primary use cases.
+
+## Development
+
+See `AGENTS.md` for repo-level workflow, quality gates, and coding standards.

--- a/templates/docs/adr/0001-template.md
+++ b/templates/docs/adr/0001-template.md
@@ -1,0 +1,13 @@
+# ADR-0001: <decision-title>
+
+## Context
+
+Describe the problem, forces, and constraints.
+
+## Decision
+
+Describe the chosen approach.
+
+## Consequences
+
+Describe the tradeoffs, benefits, and follow-up work.

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repo_standard.repo_init import (
+    bootstrap_repo,
+    ensure_output_dir,
+    validate_package_name,
+)
+
+
+def test_bootstrap_repo_renders_python_starter(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    output_dir = tmp_path / "demo-service"
+
+    bootstrap_repo(
+        repo_root=repo_root,
+        profile="python",
+        repo_name="demo-service",
+        package_name="demo_service",
+        description="Demo service",
+        repo_type="service",
+        python_version="3.12",
+        author="",
+        output_dir=output_dir,
+        no_install=True,
+    )
+
+    agents_text = (output_dir / "AGENTS.md").read_text(encoding="utf-8")
+    pyproject_text = (output_dir / "pyproject.toml").read_text(encoding="utf-8")
+    smoke_test_text = (output_dir / "tests" / "test_smoke.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "__REPO_NAME__" not in agents_text
+    assert "demo-service" in pyproject_text
+    assert "from demo_service import __doc__" in smoke_test_text
+    assert (output_dir / "src" / "demo_service" / "__init__.py").exists()
+    assert not (output_dir / "src" / "package_name").exists()
+
+
+def test_validate_package_name_rejects_invalid_identifier() -> None:
+    with pytest.raises(ValueError, match="valid Python identifier"):
+        validate_package_name("not-valid")
+
+
+def test_ensure_output_dir_rejects_non_empty_directory(tmp_path: Path) -> None:
+    output_dir = tmp_path / "existing"
+    output_dir.mkdir()
+    (output_dir / "marker.txt").write_text("x", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not empty"):
+        ensure_output_dir(output_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,280 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579, upload-time = "2026-03-01T20:04:12.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382, upload-time = "2026-03-01T20:04:11.439Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/67/09765eacf4e44413c4f8943ba5a317fcb9c7b447c3b8b0b7fce7e3090b0b/python_discovery-1.1.1.tar.gz", hash = "sha256:584c08b141c5b7029f206b4e8b78b1a1764b22121e21519b89dec56936e95b0a", size = 56016, upload-time = "2026-03-07T00:00:56.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/0f/2bf7e3b5a4a65f623cb820feb5793e243fad58ae561015ee15a6152f67a2/python_discovery-1.1.1-py3-none-any.whl", hash = "sha256:69f11073fa2392251e405d4e847d60ffffd25fd762a0dc4d1a7d6b9c3f79f1a3", size = 30732, upload-time = "2026-03-07T00:00:55.143Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "repo-development-standard"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "ruff", specifier = ">=0.6.0" },
+    { name = "ty", specifier = ">=0.0.1a16" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9b/840e0039e65fcf12758adf684d2289024d6140cde9268cc59887dc55189c/ruff-0.15.5.tar.gz", hash = "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2", size = 4574214, upload-time = "2026-03-05T20:06:34.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/20/5369c3ce21588c708bcbe517a8fbe1a8dfdb5dfd5137e14790b1da71612c/ruff-0.15.5-py3-none-linux_armv6l.whl", hash = "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c", size = 10478185, upload-time = "2026-03-05T20:06:29.093Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080", size = 10859201, upload-time = "2026-03-05T20:06:32.632Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010", size = 10184752, upload-time = "2026-03-05T20:06:40.312Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/ba49e2c3fa0395b3152bad634c7432f7edfc509c133b8f4529053ff024fb/ruff-0.15.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65", size = 10534857, upload-time = "2026-03-05T20:06:19.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/71/39234440f27a226475a0659561adb0d784b4d247dfe7f43ffc12dd02e288/ruff-0.15.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440", size = 10309120, upload-time = "2026-03-05T20:06:00.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/4140aa86a93df032156982b726f4952aaec4a883bb98cb6ef73c347da253/ruff-0.15.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204", size = 11047428, upload-time = "2026-03-05T20:05:51.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/4953e7e3287676f78fbe85e3a0ca414c5ca81237b7575bdadc00229ac240/ruff-0.15.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8", size = 11914251, upload-time = "2026-03-05T20:06:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/77/46/0f7c865c10cf896ccf5a939c3e84e1cfaeed608ff5249584799a74d33835/ruff-0.15.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681", size = 11333801, upload-time = "2026-03-05T20:05:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a", size = 11206821, upload-time = "2026-03-05T20:06:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0d/2132ceaf20c5e8699aa83da2706ecb5c5dcdf78b453f77edca7fb70f8a93/ruff-0.15.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca", size = 11133326, upload-time = "2026-03-05T20:06:25.655Z" },
+    { url = "https://files.pythonhosted.org/packages/72/cb/2e5259a7eb2a0f87c08c0fe5bf5825a1e4b90883a52685524596bfc93072/ruff-0.15.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd", size = 10510820, upload-time = "2026-03-05T20:06:37.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/20/b67ce78f9e6c59ffbdb5b4503d0090e749b5f2d31b599b554698a80d861c/ruff-0.15.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d", size = 10302395, upload-time = "2026-03-05T20:05:54.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e5/719f1acccd31b720d477751558ed74e9c88134adcc377e5e886af89d3072/ruff-0.15.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752", size = 10754069, upload-time = "2026-03-05T20:06:06.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/d1db14469e32d98f3ca27079dbd30b7b44dbb5317d06ab36718dee3baf03/ruff-0.15.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2", size = 11304315, upload-time = "2026-03-05T20:06:10.867Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/20/2ba8fd9493c89c41dfe9dbb73bc70a28b28028463bc0d2897ba8be36230a/ty-0.0.21.tar.gz", hash = "sha256:a4c2ba5d67d64df8fcdefd8b280ac1149d24a73dbda82fa953a0dff9d21400ed", size = 5297967, upload-time = "2026-03-06T01:57:13.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/70/edf38bb37517531681d1c37f5df64744e5ad02673c02eb48447eae4bea08/ty-0.0.21-py3-none-linux_armv6l.whl", hash = "sha256:7bdf2f572378de78e1f388d24691c89db51b7caf07cf90f2bfcc1d6b18b70a76", size = 10299222, upload-time = "2026-03-06T01:57:16.64Z" },
+    { url = "https://files.pythonhosted.org/packages/72/62/0047b0bd19afeefbc7286f20a5f78a2aa39f92b4d89853f0d7185ab89edc/ty-0.0.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7e9613994610431ab8625025bd2880dbcb77c5c9fabdd21134cda12d840a529d", size = 10130513, upload-time = "2026-03-06T01:57:29.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/20/0b93a9e91aaed23155780258cdfdb4726ef68b6985378ac069bc427291a0/ty-0.0.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56d3b198b64dd0a19b2b66e257deaed2ecea568e722ae5352f3c6fb62027f89d", size = 9605425, upload-time = "2026-03-06T01:57:27.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/9945e2fa2996a1287b1e1d7ce050e97e1f420233b271e770934bfa0880a0/ty-0.0.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d23d2c34f7a77d974bb08f0860ef700addc8a683d81a0319f71c08f87506cfd0", size = 10108298, upload-time = "2026-03-06T01:57:35.429Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e7/4ec52fcb15f3200826c9f048472c062549a05b0d1ef0b51f32d527b513c4/ty-0.0.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56b01fd2519637a4ca88344f61c96225f540c98ff18bca321d4eaa7bb0f7aa2f", size = 10121556, upload-time = "2026-03-06T01:57:03.242Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c0/ad457be2a8abea0f25549598bd098554540ced66229488daa0d558dad3c8/ty-0.0.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9de7e11c63c6afc40f3e9ba716374add171aee7fabc70b5146a510705c6d41b", size = 10603264, upload-time = "2026-03-06T01:56:52.134Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5b/2ecc7a2175243a4bcb72f5298ae41feabbb93b764bb0dc45722f3752c2c2/ty-0.0.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62f7f5b235c4f7876db305c36997aea07b7af29b1a068f373d0e2547e25f32ff", size = 11196428, upload-time = "2026-03-06T01:57:32.94Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f5/aff507d6a901f328ef96a298032b0c11aaaf950a146ed7dd3b5bf2cd3acf/ty-0.0.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8399f7c453a425291e6688efe430cfae7ab0ac4ffd50eba9f872bf878b54f6", size = 10866355, upload-time = "2026-03-06T01:56:57.831Z" },
+    { url = "https://files.pythonhosted.org/packages/be/30/822bbcb92d55b65989aa7ed06d9585f28ade9c9447369194ed4b0fb3b5b9/ty-0.0.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210e7568c9f886c4d01308d751949ee714ad7ad9d7d928d2ba90d329dd880367", size = 10738177, upload-time = "2026-03-06T01:57:11.256Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cc/46e7991b6469e93ac2c7e533a028983e402485580150ac864c56352a3a82/ty-0.0.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:53508e345b11569f78b21ba8e2b4e61df38a9754947fb3cd9f2ef574367338fb", size = 10079158, upload-time = "2026-03-06T01:57:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c2/0bbdadfbd008240f8f1a87dc877433cb3884436097926107ccf06e618199/ty-0.0.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:553e43571f4a35604c36cfd07d8b61a5eb7a714e3c67f8c4ff2cf674fefbaef9", size = 10150535, upload-time = "2026-03-06T01:57:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/2dbdb7b57b5362200ef0a39738ebd31331726328336def0143ac097ee59d/ty-0.0.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:666f6822e3b9200abfa7e95eb0ddd576460adb8d66b550c0ad2c70abc84a2048", size = 10319803, upload-time = "2026-03-06T01:57:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/72/84/70e52c0b7abc7c2086f9876ef454a73b161d3125315536d8d7e911c94ca4/ty-0.0.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0854d008347ce4a5fb351af132f660a390ab2a1163444d075251d43e6f74b9b", size = 10826239, upload-time = "2026-03-06T01:57:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8a/1f72480fd013bbc6cd1929002abbbcde9a0b08ead6a15154de9d7f7fa37e/ty-0.0.21-py3-none-win32.whl", hash = "sha256:bef3ab4c7b966bcc276a8ac6c11b63ba222d21355b48d471ea782c4104eee4e0", size = 9693196, upload-time = "2026-03-06T01:57:24.126Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/1104808b875c26c640e536945753a78562d606bef4e241d9dbf3d92477f6/ty-0.0.21-py3-none-win_amd64.whl", hash = "sha256:a709d576e5bea84b745d43058d8b9cd4f27f74a0b24acb4b0cbb7d3d41e0d050", size = 10668660, upload-time = "2026-03-06T01:56:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b8/25e0adc404bbf986977657b25318991f93097b49f8aea640d93c0b0db68e/ty-0.0.21-py3-none-win_arm64.whl", hash = "sha256:f72047996598ac20553fb7e21ba5741e3c82dee4e9eadf10d954551a5fe09391", size = 10104161, upload-time = "2026-03-06T01:57:06.072Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
+]


### PR DESCRIPTION
## Summary
- reposition the repository as a portable repo-development standard with normative docs, profiles, templates, starter kits, and examples
- add a Python-first packaged bootstrap tool and make this repo self-host the same Python quality and tooling standards it prescribes
- replace the old workspace-centric model with a portable bootstrap workflow driven by uv run repo-init

## Testing
- uv run ruff check .
- uv run ty check
- uv run pytest
- uv run pre-commit run --all-files
- uv run repo-init --profile python --repo-name packaged-init-demo --package-name packaged_init_demo --description 'Packaged init validation' --repo-type service --output-dir /tmp/packaged-init-demo --no-install
