### PR TITLE
Simplify repo-init UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Run from repository root:
 4. `uv run ruff check .`
 5. `uv run ty check`
 6. `uv run pytest`
-7. `uv run repo-init --profile python --repo-name demo-repo --package-name demo_repo --description "Bootstrap validation" --output-dir /tmp/demo-repo --no-install`
+7. `uv run repo-init --profile python-single --output-dir /tmp/demo-repo --no-install`
 
 ## Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Git URL for this repository.
 `--repo-name` is optional. By default, `repo-init` infers the repository name
 from the target directory name.
 `--description` is also optional and can be refined later in `README.md`.
+If the target directory is not yet a Git repository, `repo-init` initializes
+one automatically before installing pre-commit hooks. You can add or change the
+remote afterward.
 
 ## Current Profiles
 
@@ -92,7 +95,8 @@ from the target directory name.
 
 Use this repository in one of two ways:
 
-- New repository: bootstrap from `starter-kits/python/` via `repo-init`
+- New repository: bootstrap from `starter-kits/python-single/` or
+  `starter-kits/python-workspace/` via `repo-init`
 - Existing repository: adapt the repo to match the standard and populate
   `AGENTS.md` using `templates/AGENTS.md`
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ That gives you:
 
 ```bash
 repo-init \
-  --profile python-single \
-  --repo-name my-service \
-  --description "Short repo purpose"
+  --profile python-single
 ```
 
 4. Review the generated `AGENTS.md` and `README.md`.
@@ -79,6 +77,10 @@ repository. Generate or template the target repository separately.
 
 If you prefer HTTPS instead of SSH, use the same command shape with the HTTPS
 Git URL for this repository.
+
+`--repo-name` is optional. By default, `repo-init` infers the repository name
+from the target directory name.
+`--description` is also optional and can be refined later in `README.md`.
 
 ## Current Profiles
 

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -34,9 +34,7 @@ From inside the empty target directory:
 
 ```bash
 repo-init \
-  --profile python-single \
-  --repo-name widget-api \
-  --description "Receive and validate widget payloads"
+  --profile python-single
 ```
 
 After generation:
@@ -55,9 +53,7 @@ From inside the empty workspace directory, bootstrap the workspace shell:
 
 ```bash
 repo-init \
-  --profile python-workspace \
-  --repo-name widget-platform \
-  --description "Workspace for widget services and libraries"
+  --profile python-workspace
 ```
 
 Then add the first package from the workspace root:
@@ -76,11 +72,11 @@ Git URL for this repository.
 Required:
 
 - `--profile`
-- `--repo-name`
-- `--description`
 
 Optional:
 
+- `--repo-name`
+- `--description`
 - `--package-name`
 - `--repo-type`
 - `--python-version`
@@ -97,3 +93,8 @@ The generated repository should contain:
 - a standard single-package or workspace layout
 - a README with the repository purpose and workflow entry points
 - no unresolved template placeholders
+
+By default, `repo-init` infers the repository name from the target directory.
+Use `--repo-name` only when you want to override that inferred name.
+By default, `repo-init` uses a placeholder description that you can refine
+later in `README.md`.

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -28,6 +28,10 @@ uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git
 5. Run the generated repository quality gates.
 6. Make the initial commit on `main`.
 
+If the target directory is not yet a Git repository, `repo-init` initializes
+one automatically before installing pre-commit hooks. Add or change the remote
+afterward as needed.
+
 ### Golden Path: Single Package
 
 From inside the empty target directory:
@@ -98,3 +102,6 @@ By default, `repo-init` infers the repository name from the target directory.
 Use `--repo-name` only when you want to override that inferred name.
 By default, `repo-init` uses a placeholder description that you can refine
 later in `README.md`.
+By default, `repo-init` also initializes Git when needed so hook installation
+works in a fresh directory. Use `--no-install` if you want bootstrap to stop
+before environment setup and hook installation.

--- a/examples/python-service/walkthrough.md
+++ b/examples/python-service/walkthrough.md
@@ -9,9 +9,7 @@ Run this from an empty target directory:
 
 ```bash
 repo-init \
-  --profile python-single \
-  --repo-name widget-api \
-  --description "Receive, validate, and store widget payloads"
+  --profile python-single
 ```
 
 ## Expected Generated Files

--- a/examples/python-service/walkthrough.md
+++ b/examples/python-service/walkthrough.md
@@ -36,7 +36,8 @@ Check these files first:
 ## Golden Path After Bootstrap
 
 1. Run `uv sync`
-2. Run `uv run pre-commit install`
+2. Run `uv run pre-commit install` if you bootstrapped with `--no-install`
+   or if you want to reinstall the hooks later
 3. Run `uv run pre-commit run --all-files`
 4. Run `uv run ty check`
 5. Run `uv run pytest`

--- a/examples/python-workspace/walkthrough.md
+++ b/examples/python-workspace/walkthrough.md
@@ -6,9 +6,7 @@ From inside the empty workspace directory:
 
 ```bash
 repo-init \
-  --profile python-workspace \
-  --repo-name widget-platform \
-  --description "Workspace for widget services and libraries"
+  --profile python-workspace
 ```
 
 ## Add First Package

--- a/src/repo_standard/repo_init.py
+++ b/src/repo_standard/repo_init.py
@@ -8,10 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-PROFILE_ALIASES = {
-    "python": "python-single",
-}
-
 PLACEHOLDERS = {
     "__REPO_NAME__": "repo_name",
     "__PACKAGE_NAME__": "package_name",
@@ -27,13 +23,11 @@ def build_parser() -> argparse.ArgumentParser:
         description="Create a new repository from the standard starter kits."
     )
     parser.add_argument(
-        "--profile",
-        choices=["python", "python-single", "python-workspace"],
-        required=True,
+        "--profile", choices=["python-single", "python-workspace"], required=True
     )
-    parser.add_argument("--repo-name", required=True)
+    parser.add_argument("--repo-name")
     parser.add_argument("--package-name")
-    parser.add_argument("--description", required=True)
+    parser.add_argument("--description", default="Describe this repository.")
     parser.add_argument(
         "--repo-type",
         choices=["service", "library", "cli"],
@@ -52,10 +46,6 @@ def build_parser() -> argparse.ArgumentParser:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return build_parser().parse_args(argv)
-
-
-def normalize_profile(profile: str) -> str:
-    return PROFILE_ALIASES.get(profile, profile)
 
 
 def validate_package_name(package_name: str) -> None:
@@ -83,8 +73,17 @@ def infer_package_name(repo_name: str) -> str:
     return candidate
 
 
+def infer_repo_name(output_dir: Path) -> str:
+    repo_name = output_dir.resolve().name
+    if not repo_name:
+        raise ValueError(
+            "Could not infer a repository name from the target directory; "
+            "pass --repo-name explicitly."
+        )
+    return repo_name
+
+
 def resolve_starter_dir(profile: str, repo_root: Path | None = None) -> Path:
-    profile = normalize_profile(profile)
     if repo_root is not None:
         candidate = repo_root / "starter-kits" / profile
         if candidate.exists():
@@ -183,7 +182,6 @@ def bootstrap_repo(
     output_dir: Path,
     no_install: bool,
 ) -> Path:
-    profile = normalize_profile(profile)
     if profile == "python-single":
         package_name = package_name or infer_package_name(repo_name)
         validate_package_name(package_name)
@@ -218,11 +216,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo_root = Path(__file__).resolve().parents[2]
     output_dir = Path(args.output_dir).resolve()
+    repo_name = args.repo_name or infer_repo_name(output_dir)
 
     bootstrap_repo(
         repo_root=repo_root,
         profile=args.profile,
-        repo_name=args.repo_name,
+        repo_name=repo_name,
         package_name=args.package_name,
         description=args.description,
         repo_type=args.repo_type,
@@ -231,7 +230,7 @@ def main(argv: list[str] | None = None) -> int:
         output_dir=output_dir,
         no_install=args.no_install,
     )
-    print(f"Bootstrapped {args.repo_name} into {output_dir}")
+    print(f"Bootstrapped {repo_name} into {output_dir}")
     return 0
 
 

--- a/src/repo_standard/repo_init.py
+++ b/src/repo_standard/repo_init.py
@@ -153,20 +153,47 @@ def update_python_version(output_dir: Path, python_version: str) -> None:
     pyproject_path.write_text(text, encoding="utf-8")
 
 
+def has_git_repository(output_dir: Path) -> bool:
+    return (output_dir / ".git").exists()
+
+
+def ensure_git_repository(output_dir: Path) -> None:
+    if has_git_repository(output_dir):
+        return
+    try:
+        subprocess.run(["git", "init"], cwd=output_dir, check=True)
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            "Git is required to install pre-commit hooks automatically. "
+            "Install Git or rerun with --no-install."
+        ) from error
+    print(
+        "Initialized a local Git repository so pre-commit hooks can be "
+        "installed. Add or change the remote later as needed.",
+        file=sys.stderr,
+    )
+
+
 def run_optional_installs(output_dir: Path) -> None:
-    commands = [
-        ["uv", "sync"],
-        ["uv", "run", "pre-commit", "install"],
-    ]
-    for command in commands:
-        try:
-            subprocess.run(command, cwd=output_dir, check=True)
-        except FileNotFoundError:
-            print(
-                f"Skipped {' '.join(command)} because the executable was not found.",
-                file=sys.stderr,
-            )
-            return
+    try:
+        subprocess.run(["uv", "sync"], cwd=output_dir, check=True)
+    except FileNotFoundError:
+        print(
+            "Skipped uv sync because the executable was not found.",
+            file=sys.stderr,
+        )
+        return
+
+    ensure_git_repository(output_dir)
+    try:
+        subprocess.run(
+            ["uv", "run", "pre-commit", "install"], cwd=output_dir, check=True
+        )
+    except FileNotFoundError:
+        print(
+            "Skipped uv run pre-commit install because the executable was not found.",
+            file=sys.stderr,
+        )
 
 
 def bootstrap_repo(

--- a/src/repo_standard/starter_kits/python-single/README.md
+++ b/src/repo_standard/starter_kits/python-single/README.md
@@ -10,7 +10,8 @@ This repository contains the `__PACKAGE_NAME__` Python project.
 
 1. Review `AGENTS.md` and confirm the repo-specific scope and constraints.
 2. Run `uv sync`.
-3. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
 4. Run `uv run pre-commit run --all-files`.
 5. Run `uv run ty check`.
 6. Run `uv run pytest`.

--- a/src/repo_standard/starter_kits/python-workspace/README.md
+++ b/src/repo_standard/starter_kits/python-workspace/README.md
@@ -11,7 +11,8 @@ projects under `packages/`.
 
 1. Review `AGENTS.md`.
 2. Run `uv sync`.
-3. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
 4. Run `uv run pre-commit run --all-files`.
 5. Run `uv run ty check`.
 6. Run `uv run pytest`.

--- a/src/repo_standard/starter_kits/python/README.md
+++ b/src/repo_standard/starter_kits/python/README.md
@@ -10,7 +10,8 @@ This repository contains the `__PACKAGE_NAME__` Python project.
 
 1. Review `AGENTS.md` and confirm the repo-specific scope and constraints.
 2. Run `uv sync`.
-3. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
 4. Run `uv run pre-commit run --all-files`.
 5. Run `uv run ty check`.
 6. Run `uv run pytest`.

--- a/starter-kits/python-single/README.md
+++ b/starter-kits/python-single/README.md
@@ -10,7 +10,8 @@ This repository contains the `__PACKAGE_NAME__` Python project.
 
 1. Review `AGENTS.md` and confirm the repo-specific scope and constraints.
 2. Run `uv sync`.
-3. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
 4. Run `uv run pre-commit run --all-files`.
 5. Run `uv run ty check`.
 6. Run `uv run pytest`.

--- a/starter-kits/python-workspace/README.md
+++ b/starter-kits/python-workspace/README.md
@@ -11,7 +11,8 @@ projects under `packages/`.
 
 1. Review `AGENTS.md`.
 2. Run `uv sync`.
-3. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
 4. Run `uv run pre-commit run --all-files`.
 5. Run `uv run ty check`.
 6. Run `uv run pytest`.

--- a/starter-kits/python/README.md
+++ b/starter-kits/python/README.md
@@ -10,7 +10,8 @@ This repository contains the `__PACKAGE_NAME__` Python project.
 
 1. Review `AGENTS.md` and confirm the repo-specific scope and constraints.
 2. Run `uv sync`.
-3. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
 4. Run `uv run pre-commit run --all-files`.
 5. Run `uv run ty check`.
 6. Run `uv run pytest`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from repo_standard.repo_init import (
     bootstrap_repo,
+    ensure_git_repository,
     ensure_no_unresolved_placeholders,
     ensure_output_dir,
     infer_package_name,
     infer_repo_name,
     main,
+    run_optional_installs,
     validate_package_name,
 )
 
@@ -101,6 +104,89 @@ def test_infer_package_name_normalizes_repo_name() -> None:
 
 def test_infer_repo_name_uses_target_directory_name(tmp_path: Path) -> None:
     assert infer_repo_name(tmp_path / "widget-platform") == "widget-platform"
+
+
+def test_ensure_git_repository_initializes_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(command: list[str], *, cwd: Path, check: bool) -> None:
+        assert check is True
+        calls.append((command, cwd))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ensure_git_repository(tmp_path)
+
+    assert calls == [(["git", "init"], tmp_path)]
+    assert "Initialized a local Git repository" in capsys.readouterr().err
+
+
+def test_ensure_git_repository_skips_existing_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / ".git").mkdir()
+
+    def fail_run(command: list[str], *, cwd: Path, check: bool) -> None:
+        raise AssertionError(f"subprocess.run should not be called: {command}")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+
+    ensure_git_repository(tmp_path)
+
+
+def test_ensure_git_repository_raises_clear_error_when_git_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def missing_git(command: list[str], *, cwd: Path, check: bool) -> None:
+        raise FileNotFoundError(command[0])
+
+    monkeypatch.setattr(subprocess, "run", missing_git)
+
+    with pytest.raises(RuntimeError, match="Install Git or rerun with --no-install"):
+        ensure_git_repository(tmp_path)
+
+
+def test_run_optional_installs_initializes_git_before_pre_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(command: list[str], *, cwd: Path, check: bool) -> None:
+        assert check is True
+        calls.append((command, cwd))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_optional_installs(tmp_path)
+
+    assert calls == [
+        (["uv", "sync"], tmp_path),
+        (["git", "init"], tmp_path),
+        (["uv", "run", "pre-commit", "install"], tmp_path),
+    ]
+    assert "Initialized a local Git repository" in capsys.readouterr().err
+
+
+def test_run_optional_installs_skips_git_init_inside_existing_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / ".git").mkdir()
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(command: list[str], *, cwd: Path, check: bool) -> None:
+        assert check is True
+        calls.append((command, cwd))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_optional_installs(tmp_path)
+
+    assert calls == [
+        (["uv", "sync"], tmp_path),
+        (["uv", "run", "pre-commit", "install"], tmp_path),
+    ]
 
 
 def test_ensure_output_dir_rejects_non_empty_directory(tmp_path: Path) -> None:

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -9,6 +9,7 @@ from repo_standard.repo_init import (
     ensure_no_unresolved_placeholders,
     ensure_output_dir,
     infer_package_name,
+    infer_repo_name,
     main,
     validate_package_name,
 )
@@ -98,6 +99,10 @@ def test_infer_package_name_normalizes_repo_name() -> None:
     assert infer_package_name("widget-api") == "widget_api"
 
 
+def test_infer_repo_name_uses_target_directory_name(tmp_path: Path) -> None:
+    assert infer_repo_name(tmp_path / "widget-platform") == "widget-platform"
+
+
 def test_ensure_output_dir_rejects_non_empty_directory(tmp_path: Path) -> None:
     output_dir = tmp_path / "existing"
     output_dir.mkdir()
@@ -124,14 +129,55 @@ def test_main_bootstraps_into_current_working_directory(
         [
             "--profile",
             "python-single",
-            "--repo-name",
-            "empty-dir-app",
-            "--description",
-            "Empty directory bootstrap",
             "--no-install",
         ]
     )
 
     assert exit_code == 0
     assert (tmp_path / "AGENTS.md").exists()
-    assert (tmp_path / "src" / "empty_dir_app" / "__init__.py").exists()
+    inferred_package = tmp_path.name.replace("-", "_")
+    assert (tmp_path / "src" / inferred_package / "__init__.py").exists()
+    readme_text = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "Describe this repository." in readme_text
+
+
+def test_main_infers_repo_name_from_output_dir(tmp_path: Path) -> None:
+    output_dir = tmp_path / "inferred-service"
+
+    exit_code = main(
+        [
+            "--profile",
+            "python-single",
+            "--output-dir",
+            str(output_dir),
+            "--no-install",
+        ]
+    )
+
+    assert exit_code == 0
+    readme_text = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "# inferred-service" in readme_text
+    assert (output_dir / "src" / "inferred_service" / "__init__.py").exists()
+    assert "Describe this repository." in readme_text
+
+
+def test_main_infers_workspace_repo_name_from_current_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace_dir = tmp_path / "widget-platform"
+    workspace_dir.mkdir()
+    monkeypatch.chdir(workspace_dir)
+
+    exit_code = main(
+        [
+            "--profile",
+            "python-workspace",
+            "--no-install",
+        ]
+    )
+
+    assert exit_code == 0
+    readme_text = (workspace_dir / "README.md").read_text(encoding="utf-8")
+    assert "# widget-platform" in readme_text
+    assert (workspace_dir / "packages" / ".gitkeep").exists()
+    assert "Describe this repository." in readme_text


### PR DESCRIPTION
## Summary
- make `repo-init` infer the repo name from the target directory when omitted
- make `--description` optional with a placeholder default
- remove the legacy `python` profile alias so only `python-single` and `python-workspace` remain

## Verification
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest`