### PR TITLE
Fix uv tool install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The recommended workflow is:
 1. Install the tool once:
 
 ```bash
-uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-init
+uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-standard-kit
 ```
 
 That gives you:

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -19,7 +19,7 @@ Do not clone the standards repository as the base of a product repository.
 1. Install the tool once:
 
 ```bash
-uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-init
+uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-standard-kit
 ```
 
 2. Create and enter an empty target repository or working directory.


### PR DESCRIPTION
## Summary
- fix the documented `uv tool install` command to use the package name instead of the console script name
- keep the install flow aligned with how `uv` resolves tools from a Git source

## Verification
- `uv tool install --refresh --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-standard-kit`