### PR TITLE
Initialize bootstrapped repos on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Git URL for this repository.
 from the target directory name.
 `--description` is also optional and can be refined later in `README.md`.
 If the target directory is not yet a Git repository, `repo-init` initializes
-one automatically before installing pre-commit hooks. You can add or change the
-remote afterward.
+one automatically on `main` before installing pre-commit hooks. You can add or
+change the remote afterward.
 
 ## Current Profiles
 

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -29,8 +29,8 @@ uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git
 6. Make the initial commit on `main`.
 
 If the target directory is not yet a Git repository, `repo-init` initializes
-one automatically before installing pre-commit hooks. Add or change the remote
-afterward as needed.
+one automatically on `main` before installing pre-commit hooks. Add or change
+the remote afterward as needed.
 
 ### Golden Path: Single Package
 
@@ -102,6 +102,6 @@ By default, `repo-init` infers the repository name from the target directory.
 Use `--repo-name` only when you want to override that inferred name.
 By default, `repo-init` uses a placeholder description that you can refine
 later in `README.md`.
-By default, `repo-init` also initializes Git when needed so hook installation
-works in a fresh directory. Use `--no-install` if you want bootstrap to stop
-before environment setup and hook installation.
+By default, `repo-init` also initializes Git on `main` when needed so hook
+installation works in a fresh directory. Use `--no-install` if you want
+bootstrap to stop before environment setup and hook installation.

--- a/src/repo_standard/repo_init.py
+++ b/src/repo_standard/repo_init.py
@@ -157,18 +157,31 @@ def has_git_repository(output_dir: Path) -> bool:
     return (output_dir / ".git").exists()
 
 
+def initialize_git_repository(output_dir: Path) -> None:
+    try:
+        subprocess.run(
+            ["git", "init", "--initial-branch=main"], cwd=output_dir, check=True
+        )
+        return
+    except FileNotFoundError:
+        raise
+    except subprocess.CalledProcessError:
+        subprocess.run(["git", "init"], cwd=output_dir, check=True)
+        subprocess.run(["git", "branch", "-m", "main"], cwd=output_dir, check=True)
+
+
 def ensure_git_repository(output_dir: Path) -> None:
     if has_git_repository(output_dir):
         return
     try:
-        subprocess.run(["git", "init"], cwd=output_dir, check=True)
+        initialize_git_repository(output_dir)
     except FileNotFoundError as error:
         raise RuntimeError(
             "Git is required to install pre-commit hooks automatically. "
             "Install Git or rerun with --no-install."
         ) from error
     print(
-        "Initialized a local Git repository so pre-commit hooks can be "
+        "Initialized a local Git repository on main so pre-commit hooks can be "
         "installed. Add or change the remote later as needed.",
         file=sys.stderr,
     )

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -12,6 +12,7 @@ from repo_standard.repo_init import (
     ensure_output_dir,
     infer_package_name,
     infer_repo_name,
+    initialize_git_repository,
     main,
     run_optional_installs,
     validate_package_name,
@@ -119,8 +120,30 @@ def test_ensure_git_repository_initializes_when_missing(
 
     ensure_git_repository(tmp_path)
 
-    assert calls == [(["git", "init"], tmp_path)]
-    assert "Initialized a local Git repository" in capsys.readouterr().err
+    assert calls == [(["git", "init", "--initial-branch=main"], tmp_path)]
+    assert "Initialized a local Git repository on main" in capsys.readouterr().err
+
+
+def test_initialize_git_repository_falls_back_when_initial_branch_flag_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(command: list[str], *, cwd: Path, check: bool) -> None:
+        assert check is True
+        calls.append((command, cwd))
+        if command == ["git", "init", "--initial-branch=main"]:
+            raise subprocess.CalledProcessError(returncode=129, cmd=command)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    initialize_git_repository(tmp_path)
+
+    assert calls == [
+        (["git", "init", "--initial-branch=main"], tmp_path),
+        (["git", "init"], tmp_path),
+        (["git", "branch", "-m", "main"], tmp_path),
+    ]
 
 
 def test_ensure_git_repository_skips_existing_repo(
@@ -163,10 +186,10 @@ def test_run_optional_installs_initializes_git_before_pre_commit(
 
     assert calls == [
         (["uv", "sync"], tmp_path),
-        (["git", "init"], tmp_path),
+        (["git", "init", "--initial-branch=main"], tmp_path),
         (["uv", "run", "pre-commit", "install"], tmp_path),
     ]
-    assert "Initialized a local Git repository" in capsys.readouterr().err
+    assert "Initialized a local Git repository on main" in capsys.readouterr().err
 
 
 def test_run_optional_installs_skips_git_init_inside_existing_repo(


### PR DESCRIPTION
## Summary
- initialize fresh bootstrapped repositories on `main` instead of inheriting Git's default branch
- fall back cleanly for older Git versions that do not support `--initial-branch`
- document the `main` behavior in the bootstrap flow

## Verification
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest`
- real bootstrap into a fresh directory followed by `git branch --show-current`