### PR TITLE
Rename repo to repo-bootstrap-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# repo-standard-kit
+# repo-bootstrap-kit
 
 Portable development standards, starter kits, and bootstrap tooling for modern
 software repositories.
@@ -52,7 +52,7 @@ The recommended workflow is:
 1. Install the tool once:
 
 ```bash
-uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-standard-kit
+uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-bootstrap-kit.git" repo-bootstrap-kit
 ```
 
 That gives you:
@@ -102,9 +102,9 @@ Use this repository in one of two ways:
 
 ## Golden Path Example
 
-See [examples/python-service/walkthrough.md](/home/thomazo/dev/repo-standard-kit/examples/python-service/walkthrough.md)
+See [examples/python-service/walkthrough.md](examples/python-service/walkthrough.md)
 for a concrete service-oriented bootstrap flow and the expected generated shape.
-See [examples/python-workspace/walkthrough.md](/home/thomazo/dev/repo-standard-kit/examples/python-workspace/walkthrough.md)
+See [examples/python-workspace/walkthrough.md](examples/python-workspace/walkthrough.md)
 for the workspace bootstrap and package-add flow.
 
 ## Design Principles

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -19,7 +19,7 @@ Do not clone the standards repository as the base of a product repository.
 1. Install the tool once:
 
 ```bash
-uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-standard-kit.git" repo-standard-kit
+uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-bootstrap-kit.git" repo-bootstrap-kit
 ```
 
 2. Create and enter an empty target repository or working directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "repo-standard-kit"
+name = "repo-bootstrap-kit"
 version = "0.1.0"
 description = "Portable development standards, starter kits, and bootstrap tooling for software repositories."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 ]
 
 [[package]]
-name = "repo-standard-kit"
+name = "repo-bootstrap-kit"
 version = "0.1.0"
 source = { editable = "." }
 


### PR DESCRIPTION
## Summary
- rename the packaged project from `repo-standard-kit` to `repo-bootstrap-kit`
- update bootstrap install references to the renamed GitHub repository
- replace machine-specific README walkthrough links with relative links

## Validation
- `uv --allow-insecure-host pypi.org --allow-insecure-host files.pythonhosted.org sync`
- `uv --allow-insecure-host pypi.org --allow-insecure-host files.pythonhosted.org run pytest`
- `uv --allow-insecure-host pypi.org --allow-insecure-host files.pythonhosted.org run repo-init --profile python-single --output-dir /tmp/repo-bootstrap-kit-validate --no-install`