### PR TITLE
Support repo-init repo-name directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,19 @@ That gives you:
 - `repo-init`
 - `repo-add-package`
 
-2. Create and enter an empty target repository or working directory.
-3. Run the bootstrap tool in that directory:
+2. Either create and enter an empty target repository or working directory, or
+   run `repo-init` from the parent directory with `--repo-name` so it creates
+   the repository folder for you.
+3. Run the bootstrap tool:
 
 ```bash
 repo-init --profile python-single
+```
+
+Or from the parent directory:
+
+```bash
+repo-init --profile python-single --repo-name widget-service
 ```
 
 4. Review the generated `AGENTS.md` and `README.md`.
@@ -78,7 +86,8 @@ If you prefer HTTPS instead of SSH, use the same command shape with the HTTPS
 Git URL for this repository.
 
 `--repo-name` is optional. By default, `repo-init` infers the repository name
-from the target directory name.
+from the target directory name. If you provide `--repo-name` without
+`--output-dir`, `repo-init` creates `./<repo-name>` and bootstraps there.
 `--description` is also optional and can be refined later in `README.md`.
 If the target directory is not yet a Git repository, `repo-init` initializes
 one automatically on `main` before installing pre-commit hooks. You can add or

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -22,7 +22,9 @@ Do not clone the standards repository as the base of a product repository.
 uv tool install --from "git+ssh://git@github.com/JayTeeBat/repo-bootstrap-kit.git" repo-bootstrap-kit
 ```
 
-2. Create and enter an empty target repository or working directory.
+2. Either create and enter an empty target directory, or run `repo-init` from the
+   parent directory with `--repo-name` so it creates the repository folder for
+   you.
 3. Run `repo-init` with the Python profile and repository metadata.
 4. Review generated `AGENTS.md`, `README.md`, and package naming.
 5. Run the generated repository quality gates.
@@ -39,6 +41,14 @@ From inside the empty target directory:
 ```bash
 repo-init \
   --profile python-single
+```
+
+Or from the parent directory, let `repo-init` create the repository folder:
+
+```bash
+repo-init \
+  --profile python-single \
+  --repo-name widget-service
 ```
 
 After generation:
@@ -58,6 +68,14 @@ From inside the empty workspace directory, bootstrap the workspace shell:
 ```bash
 repo-init \
   --profile python-workspace
+```
+
+Or from the parent directory:
+
+```bash
+repo-init \
+  --profile python-workspace \
+  --repo-name widget-platform
 ```
 
 Then add the first package from the workspace root:
@@ -99,7 +117,10 @@ The generated repository should contain:
 - no unresolved template placeholders
 
 By default, `repo-init` infers the repository name from the target directory.
-Use `--repo-name` only when you want to override that inferred name.
+If you pass `--repo-name` without `--output-dir`, `repo-init` creates
+`./<repo-name>` and bootstraps into that new directory. If you pass both,
+`--output-dir` remains the explicit target and `--repo-name` overrides only the
+rendered repository metadata.
 By default, `repo-init` uses a placeholder description that you can refine
 later in `README.md`.
 By default, `repo-init` also initializes Git on `main` when needed so hook

--- a/src/repo_standard/repo_init.py
+++ b/src/repo_standard/repo_init.py
@@ -37,7 +37,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--author", default="")
     parser.add_argument(
         "--output-dir",
-        default=".",
+        default=None,
         help="Target directory. Defaults to the current working directory.",
     )
     parser.add_argument("--no-install", action="store_true")
@@ -52,6 +52,13 @@ def validate_package_name(package_name: str) -> None:
     if not package_name.isidentifier():
         raise ValueError(
             f"--package-name must be a valid Python identifier (got {package_name!r})"
+        )
+
+
+def validate_repo_name(repo_name: str) -> None:
+    if "/" in repo_name or "\\" in repo_name or repo_name in {".", ".."}:
+        raise ValueError(
+            f"--repo-name must be a repository name, not a path (got {repo_name!r})"
         )
 
 
@@ -81,6 +88,15 @@ def infer_repo_name(output_dir: Path) -> str:
             "pass --repo-name explicitly."
         )
     return repo_name
+
+
+def resolve_output_dir(output_dir_arg: str | None, repo_name: str | None) -> Path:
+    if output_dir_arg is not None:
+        return Path(output_dir_arg).resolve()
+    if repo_name is not None:
+        validate_repo_name(repo_name)
+        return (Path.cwd() / repo_name).resolve()
+    return Path.cwd().resolve()
 
 
 def resolve_starter_dir(profile: str, repo_root: Path | None = None) -> Path:
@@ -255,7 +271,9 @@ def bootstrap_repo(
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo_root = Path(__file__).resolve().parents[2]
-    output_dir = Path(args.output_dir).resolve()
+    output_dir = resolve_output_dir(args.output_dir, args.repo_name)
+    if args.repo_name is not None:
+        validate_repo_name(args.repo_name)
     repo_name = args.repo_name or infer_repo_name(output_dir)
 
     bootstrap_repo(

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -14,8 +14,10 @@ from repo_standard.repo_init import (
     infer_repo_name,
     initialize_git_repository,
     main,
+    resolve_output_dir,
     run_optional_installs,
     validate_package_name,
+    validate_repo_name,
 )
 
 
@@ -105,6 +107,29 @@ def test_infer_package_name_normalizes_repo_name() -> None:
 
 def test_infer_repo_name_uses_target_directory_name(tmp_path: Path) -> None:
     assert infer_repo_name(tmp_path / "widget-platform") == "widget-platform"
+
+
+def test_validate_repo_name_rejects_path_like_values() -> None:
+    with pytest.raises(ValueError, match="must be a repository name, not a path"):
+        validate_repo_name("foo/bar")
+
+
+def test_resolve_output_dir_uses_repo_name_when_output_dir_not_provided(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert resolve_output_dir(None, "widget-platform") == tmp_path / "widget-platform"
+
+
+def test_resolve_output_dir_prefers_explicit_output_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert resolve_output_dir("custom-target", "widget-platform") == (
+        tmp_path / "custom-target"
+    )
 
 
 def test_ensure_git_repository_initializes_when_missing(
@@ -268,6 +293,70 @@ def test_main_infers_repo_name_from_output_dir(tmp_path: Path) -> None:
     assert "# inferred-service" in readme_text
     assert (output_dir / "src" / "inferred_service" / "__init__.py").exists()
     assert "Describe this repository." in readme_text
+
+
+def test_main_creates_repo_named_directory_when_repo_name_is_provided(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "--profile",
+            "python-single",
+            "--repo-name",
+            "demo-service",
+            "--no-install",
+        ]
+    )
+
+    output_dir = tmp_path / "demo-service"
+    assert exit_code == 0
+    assert (output_dir / "AGENTS.md").exists()
+    assert (output_dir / "src" / "demo_service" / "__init__.py").exists()
+    readme_text = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "# demo-service" in readme_text
+
+
+def test_main_uses_explicit_output_dir_when_repo_name_is_also_provided(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "custom-target"
+
+    exit_code = main(
+        [
+            "--profile",
+            "python-single",
+            "--repo-name",
+            "demo-service",
+            "--output-dir",
+            str(output_dir),
+            "--no-install",
+        ]
+    )
+
+    assert exit_code == 0
+    assert (output_dir / "AGENTS.md").exists()
+    assert (output_dir / "src" / "demo_service" / "__init__.py").exists()
+    readme_text = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "# demo-service" in readme_text
+
+
+def test_main_rejects_path_like_repo_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="must be a repository name, not a path"):
+        main(
+            [
+                "--profile",
+                "python-single",
+                "--repo-name",
+                "foo/bar",
+                "--no-install",
+            ]
+        )
 
 
 def test_main_infers_workspace_repo_name_from_current_directory(


### PR DESCRIPTION
## Summary
- allow `repo-init --repo-name` to create `./<repo-name>` when `--output-dir` is omitted
- keep explicit `--output-dir` precedence and reject path-like repo names
- document the new bootstrap flow in the README and bootstrap workflow docs

## Verification
- uv sync
- uv run pre-commit run --all-files
- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest
- uv tool run --from "git+ssh://git@github.com/FP-DevTools/repo-bootstrap-kit.git@feat/repo-init-repo-name-dir" repo-init --profile python-single --repo-name demo-repo-init --no-install
- uv tool run --from "git+ssh://git@github.com/FP-DevTools/repo-bootstrap-kit.git@feat/repo-init-repo-name-dir" repo-init --profile python-single --repo-name demo-repo-full
- (generated repo) uv run pytest