### PR TITLE
State the GitHub plan prerequisite for enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ the changes listed under **Adopters must**.
   repository needs GitHub Team or higher. On GitHub Free a private repository
   cannot require any check and is not aligned with the specification. Recorded
   in `docs/adr/0001-enforcement-requires-a-paid-github-plan.md`.
+- `docs/adr/` and `docs/diagrams/` in this repository, which its own canonical
+  layout in `docs/repo-layout.md` prescribes and both starter kits generate for
+  every new repository, but which it did not have.
 - `LICENSE`, and the matching `license` metadata in `pyproject.toml`.
 - `CHANGELOG.md` with the compatibility policy above.
 - Expected generated trees for both profiles in `docs/bootstrap-workflow.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ the changes listed under **Adopters must**.
   repository must protect `main` with the `quality` status check required,
   at least one approving review, and administrator bypass disabled. Includes
   a `gh api` command to verify the configuration.
+- A platform prerequisite in §10: requiring a status check on a private
+  repository needs GitHub Team or higher. On GitHub Free a private repository
+  cannot require any check and is not aligned with the specification. Recorded
+  in `docs/adr/0001-enforcement-requires-a-paid-github-plan.md`.
 - `LICENSE`, and the matching `license` metadata in `pyproject.toml`.
 - `CHANGELOG.md` with the compatibility policy above.
 - Expected generated trees for both profiles in `docs/bootstrap-workflow.md`,
@@ -78,7 +82,8 @@ the changes listed under **Adopters must**.
 
 - Configure branch protection on `main` as specified in
   `docs/quality-gates.md` §10. This is the only change that can move a
-  previously aligned repository out of alignment.
+  previously aligned repository out of alignment. Private repositories require
+  GitHub Team or higher to do so; see the platform prerequisite in §10.
 - Update any reference to `spec.md` to `docs/quality-gates.md`.
 - Bump `actions/checkout` to `v5` in `.github/workflows/quality.yml`.
 - Confirm `uv run pre-commit run --all-files` runs in CI. Repositories

--- a/docs/adr/0001-enforcement-requires-a-paid-github-plan.md
+++ b/docs/adr/0001-enforcement-requires-a-paid-github-plan.md
@@ -1,0 +1,66 @@
+# ADR-0001: Enforcement Requires A Paid GitHub Plan
+
+## Status
+
+Accepted — 2026-08-18
+
+## Context
+
+`docs/quality-gates.md` §9 has always defined merge criteria, but until v0.3.0
+the standard shipped no way to make them binding. A workflow that runs on every
+pull request still permits a merge when it fails, so the gates were advisory.
+§10 was added to close that gap by requiring branch protection on `main`.
+
+While preparing to apply that configuration to this repository, both the branch
+protection and the repository rulesets endpoints returned `403`:
+
+```text
+GET /repos/FP-DevTools/repo-standard-kit/branches/main/protection
+GET /repos/FP-DevTools/repo-standard-kit/rulesets
+403 Upgrade to GitHub Pro or make this repository public to enable this feature.
+```
+
+The token holds `admin: true` on the repository, so this is a plan limitation
+rather than a permissions problem. The organization is on the GitHub Free plan
+and owns 15 private repositories. Required status checks on private
+repositories need GitHub Team or higher.
+
+The consequence is that §10 as written could not be satisfied by any repository
+it governs, including this one. Left unaddressed, the standard would define a
+requirement that makes every adopting repository non-compliant by definition.
+
+## Decision
+
+State the plan as an explicit precondition rather than weakening the
+requirement.
+
+`docs/quality-gates.md` §10 now documents that a private repository on GitHub
+Free cannot require a status check, that no configuration closes the gap, and
+that such a repository is not aligned with the specification.
+
+Enforcement is not softened to "where supported". A `SHOULD` would let every
+repository claim alignment while leaving the gates advisory, which is the
+condition §10 exists to end.
+
+The plan upgrade is not being pursued at this time. Pilot adoption proceeds
+with gates advisory and enforcement recorded as a known, bounded gap.
+
+## Consequences
+
+- The standard is honest about what it requires, and the upgrade becomes a
+  visible decision with a named owner rather than a silent gap.
+- Until the plan changes, repositories adopting this standard on private
+  repositories — including this one — are not fully aligned. Gate failures are
+  visible in CI but do not block a merge.
+- Pilot findings about gate ergonomics remain valid, since the gates still run.
+  Findings about enforcement do not, and should be revisited after any upgrade.
+- The exact settings and their verification command are documented, so applying
+  them is mechanical on the day the plan supports it.
+- Public repositories are unaffected; branch protection is available to them on
+  every plan.
+
+## Revisit When
+
+The organization moves to GitHub Team or higher, or a decision is taken to keep
+enforcement permanently advisory — in which case §10 needs rewriting rather than
+this ADR amending.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,8 @@
+# Diagrams
+
+Store workflow and architecture diagrams here when the repository needs durable
+visual documentation.
+
+For this repository that means the bootstrap flow and the relationship between
+the normative documents, the templates, and the starter kits — add them here
+when a diagram would explain the standard faster than prose does.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -248,6 +248,27 @@ on every pull request still permits a merge if nothing requires it to pass.
 Every repository adopting this specification shall protect `main` so the
 mandatory gates are binding rather than advisory.
 
+### Platform prerequisite
+
+Requiring a status check on a **private** repository needs GitHub Team or
+higher for an organization, or GitHub Pro for a personal account. On the
+GitHub Free plan a private repository cannot require any status check, and
+neither branch protection nor repository rulesets are available:
+
+```text
+GET /repos/{owner}/{repo}/branches/main/protection
+403 Upgrade to GitHub Pro or make this repository public to enable this feature.
+```
+
+No configuration closes this gap. A private repository on GitHub Free can run
+every gate in this document and still permit a merge when they fail, which
+means it does not meet section 9 and is **not aligned** with this
+specification.
+
+Treat a plan that supports branch protection as a precondition for adopting
+this standard on private repositories, not as an implementation detail to
+settle later. Public repositories have branch protection on every plan.
+
 ### Required branch protection
 
 On GitHub, protect `main` with:
@@ -275,6 +296,9 @@ gh api repos/<owner>/<repo>/branches/main/protection \
 
 The `quality` check shall appear in `checks`, `reviews` shall be at least `1`,
 and `enforce_admins` shall be `true`.
+
+A `403` response means the repository is on a plan that does not support
+branch protection; see the platform prerequisite above.
 
 A repository that cannot produce this configuration is not aligned with this
 specification, regardless of whether its workflow passes.


### PR DESCRIPTION
## Why

Applying the branch protection that §10 requires — merged in #13 — revealed that **it cannot be satisfied**. Both endpoints return `403` on this repository with an `admin: true` token:

```
GET /repos/FP-DevTools/repo-standard-kit/branches/main/protection   → 403
GET /repos/FP-DevTools/repo-standard-kit/rulesets                   → 403
"Upgrade to GitHub Pro or make this repository public to enable this feature."

orgs/FP-DevTools → plan: free, owned_private_repos: 15
```

This is a plan limitation, not a permissions problem. Required status checks on a **private** repository need GitHub Team or higher.

So §10 as merged defines a requirement that **no repository it governs can meet** — including this one. Left alone, the standard would make every adopting repository non-compliant by definition.

## What this does

States the plan as an explicit **precondition** rather than softening the requirement.

§10 gains a *Platform prerequisite* section documenting that a private repository on GitHub Free cannot require any status check, that no configuration closes the gap, and that such a repository is **not aligned** with the specification. The verification section now explains what a `403` means.

**Enforcement is deliberately not softened to "where supported".** A `SHOULD` would let every repository claim alignment while leaving the gates advisory — which is precisely the condition §10 exists to end. Better an honest unmet requirement than a satisfied meaningless one.

## Decision record

`docs/adr/0001-enforcement-requires-a-paid-github-plan.md` records the decision not to pursue the upgrade now and to pilot with gates advisory, including what to revisit if the plan changes.

That also creates the `docs/adr/` directory — which this repository's own `docs/repo-layout.md` prescribes as canonical, both starter kits generate for every new repo, and this repo did not have. Partially closes finding 6 from the readiness audit.

## Standing gap

Until the plan changes, this repository and the org's other private repositories run every gate but do not block on failure. That is now documented rather than implied.

## Test plan

- [x] `uv run pre-commit run --all-files` — all passed
- [x] `uv run ruff format --check .` / `ruff check .` / `ty check`
- [x] `uv run pytest` — 34 passed
- [x] `uv build`
- [x] `docs/quality-gates.md` section numbering still consistent; no line exceeds the 88-column wrap

## Sequencing

Independent of #14 — both branch from `main` and touch different files. Recommend this lands before tagging `v0.3.0`, so the tag does not ship a requirement nothing can satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)