### PR TITLE
Close the remaining gate-chain consistency gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ Agents must not:
 
 1. Update the normative docs first when changing the standard.
 2. Update templates and starter kits in the same change.
-3. Validate the bootstrap tool against a temporary output directory.
+3. Validate bootstrap behavior with `uv run pytest`, which generates into a
+   temporary directory rather than a fixed path.
 4. Keep changes small and focused by concern.
 
 ## Quality Gates
@@ -54,7 +55,11 @@ Run from repository root:
 5. `uv run ty check`
 6. `uv run pytest`
 7. `uv build`
-8. `uv run repo-init --profile python-single --output-dir /tmp/demo-repo --no-install`
+
+This is exactly the chain in `docs/quality-gates.md`; this repository adds no
+gates of its own. Bootstrap behavior needs no separate manual step — `uv run
+pytest` exercises the `repo-init` and `repo-add-package` entry points end to
+end in a temporary directory, on every platform.
 
 ## Coding Standards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ the changes listed under **Adopters must**.
   drifting silently.
 - Tests asserting that every shipped and generated `AGENTS.md` carries all
   ten required sections, and that neither profile adds or relaxes a gate.
+- Tests asserting that every shipped `AGENTS.md` states the exact gate chain,
+  and that the README template defers to `AGENTS.md` rather than keeping a
+  second copy of it.
 - A `Change Control Notes` section in this repository's own `AGENTS.md`,
   which the contract required and it was missing.
 
@@ -70,6 +73,12 @@ the changes listed under **Adopters must**.
   repository runs for itself; generated repositories were receiving `@v4`.
 - Both Python profiles defer to `docs/quality-gates.md` for the gate chain
   instead of restating it.
+- The README template's Quality Gates section defers to `AGENTS.md` instead of
+  restating the chain as a competing authority. The common-commands table and
+  setup steps are unchanged.
+- This repository's own gate chain no longer carries an eighth step that
+  bootstrapped into a hardcoded `/tmp` path. It was not portable, and `uv run
+  pytest` already exercises the CLI end to end in a temporary directory.
 
 ### Removed
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -134,20 +134,14 @@ standards drift.
 
 ### Quality Gates
 
-These are mandatory before merge and run in CI on every PR to `main`
-(`.github/workflows/quality.yml`). Run them locally first:
+The mandatory gate chain is listed in `AGENTS.md`, which is the one place this
+repository states it, and runs in CI on every PR to `main`
+(`.github/workflows/quality.yml`). Run it locally before pushing.
 
-1. `uv sync --locked`
-2. `uv run pre-commit run --all-files`
-3. `uv run ruff format --check .`
-4. `uv run ruff check .`
-5. `uv run ty check`
-6. `uv run pytest`
-7. `uv build`
-
-No PR merges into `main` unless all mandatory gates pass. Temporary
-exemptions require explicit justification in the PR and maintainer approval,
-and must stay time-limited.
+No PR merges into `main` unless all mandatory gates pass, and branch protection
+enforces that rather than convention — see the
+[quality-gates spec][quality-gates]. Temporary exemptions require explicit
+justification in the PR and maintainer approval, and must stay time-limited.
 
 ### Dependency Management
 

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -620,3 +620,44 @@ def test_profiles_neither_add_nor_relax_gates() -> None:
         assert not restated, (
             f"profiles/{profile}.md restates gates instead of deferring: {restated}"
         )
+
+
+@pytest.mark.parametrize(
+    "agents_path",
+    [
+        Path("AGENTS.md"),
+        Path("templates/AGENTS.md"),
+        *(
+            starter_kit_dir(p).relative_to(REPO_ROOT) / "AGENTS.md"
+            for p in STARTER_KIT_PROFILES
+        ),
+    ],
+    ids=["repo-root", "template", "starter-single", "starter-workspace"],
+)
+def test_shipped_agents_files_state_the_exact_gate_chain(agents_path: Path) -> None:
+    """The contract requires exact gate commands in AGENTS.md; hold each copy to it."""
+    text = (REPO_ROOT / agents_path).read_text(encoding="utf-8")
+    missing = [c for c in mandatory_ci_commands() if c not in text]
+    assert not missing, f"{agents_path} omits mandatory gates: {missing}"
+
+
+def test_readme_template_defers_to_agents_for_the_gate_chain() -> None:
+    """The README template's Quality Gates section points at AGENTS.md.
+
+    Onboarding aids elsewhere in the template - the common-commands table, the
+    setup steps - may name individual commands. What must not exist is a second
+    authoritative copy of the chain competing with the one AGENTS.md carries.
+    """
+    text = (REPO_ROOT / "templates" / "README.md").read_text(encoding="utf-8")
+    heading = "### Quality Gates"
+    assert heading in text, "templates/README.md lost its Quality Gates section"
+    section = text.split(heading, 1)[1].split("\n### ", 1)[0]
+
+    restated = [c for c in mandatory_ci_commands() if c in section]
+    assert not restated, (
+        "templates/README.md restates the gate chain instead of deferring to "
+        f"AGENTS.md: {restated}"
+    )
+    assert "AGENTS.md" in section, (
+        "the Quality Gates section must point at AGENTS.md for the chain"
+    )


### PR DESCRIPTION
Findings **8, 12 and 16** from the readiness audit.

> **Stacked on #15.** GitHub will retarget to `main` once #15 lands.

## 8 — the kit's own chain was not portable

`AGENTS.md` gate 8 bootstrapped into a hardcoded `/tmp/demo-repo`, which does not run cleanly on Windows — while *"Portable: no workspace-specific filesystem assumptions"* is the **first design principle** in the README.

**Removed rather than made portable.** The step duplicated what the suite already does: six tests exercise the `repo-init` CLI end to end through `tmp_path`, on every platform. The chain is now exactly the seven gates `docs/quality-gates.md` defines, with no local additions — which is also what both profiles already claim about themselves.

## 12 — the README template was a competing authority

`templates/README.md` stated the gate chain as a second numbered list, competing with the copy the contract requires in `AGENTS.md`. It now defers.

**The common-commands table and setup steps keep their command references.** Those are onboarding aids, not a specification — a newcomer reasonably wants to see `uv run pytest` in a table of what to run. Stripping them would make the template worse without removing a second source of truth.

## 16 — three shipped files were still unenforced

#14 made the chain self-verifying for CI workflows and generated output, but its assertion never reached the kit's own `AGENTS.md`, `templates/AGENTS.md`, or `templates/README.md` — three files restating the chain with nothing checking them.

Extended the assertion to every shipped `AGENTS.md`, plus one holding the README template to its deferral.

## Verified against the drift it exists to catch

Added an eighth gate to `docs/quality-gates.md` and updated nothing else:

```
FAILED test_bootstrap_repo_renders_python_workspace_starter
FAILED test_quality_workflows_use_mandatory_ci_gate_set
FAILED test_gate_chain_is_defined_by_the_normative_document
FAILED test_shipped_agents_files_state_the_exact_gate_chain[repo-root]
FAILED test_shipped_agents_files_state_the_exact_gate_chain[template]
FAILED test_shipped_agents_files_state_the_exact_gate_chain[starter-single]
FAILED test_shipped_agents_files_state_the_exact_gate_chain[starter-workspace]
8 failed, 39 passed
```

**Before this change, the `repo-root` and `template` copies passed that mutation silently.**

## Test plan

- [x] `uv sync --locked`
- [x] `uv run pre-commit run --all-files` — all passed
- [x] `uv run ruff format --check .` / `ruff check .` / `ty check`
- [x] `uv run pytest` — **47 passed** (42 before)
- [x] `uv build`
- [x] Negative test above; restoring the spec returns the suite to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)