### PR TITLE
Document the gate spec's conventions instead of harmonizing them away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ the changes listed under **Adopters must**.
 - Tests asserting that every shipped `AGENTS.md` states the exact gate chain,
   and that the README template defers to `AGENTS.md` rather than keeping a
   second copy of it.
+- A "How to read this document" note in `docs/quality-gates.md` stating that
+  its numbered sections and normative keywords are deliberate, so that other
+  documents can cite it precisely, and that new sections are appended rather
+  than inserted.
+- Tests asserting that the spec's sections stay sequentially numbered and that
+  every `§N` citation in the repository resolves to a real section.
 - A `Change Control Notes` section in this repository's own `AGENTS.md`,
   which the contract required and it was missing.
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,5 +1,15 @@
 # Quality Gates Specification
 
+> **How to read this document.** This is a specification, not guidance, and it
+> is written differently from the rest of `docs/` on purpose. Sections are
+> numbered so other documents can cite them precisely — `§10` in `CHANGELOG.md`
+> and in the ADRs means this document's section 10, and those references stay
+> valid as the text around them changes. "Shall" marks a requirement; "should"
+> marks a recommendation. The companion documents indexed by
+> `docs/repo-standard.md` are guidance and use plain imperative voice instead.
+> Renumbering a section here breaks existing citations, so add new sections at
+> the end rather than inserting them.
+
 ## 1. Purpose
 
 This specification defines the minimum quality requirements for repositories

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -72,6 +72,11 @@ including its `README.md`, templates, and starter kits, implements them.
 
 Where a companion document conflicts with this one, this document governs.
 
+`docs/quality-gates.md` is a specification: its sections are numbered so they
+can be cited precisely, and it uses "shall" and "should" as normative keywords.
+Every other document here is guidance and uses plain imperative voice. The
+difference is deliberate, not drift.
+
 ## Required `AGENTS.md` Sections
 
 Every target repository should include:

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -661,3 +661,28 @@ def test_readme_template_defers_to_agents_for_the_gate_chain() -> None:
     assert "AGENTS.md" in section, (
         "the Quality Gates section must point at AGENTS.md for the chain"
     )
+
+
+def test_quality_gates_sections_are_sequentially_numbered() -> None:
+    """Other documents cite this spec by section number; numbering must stay stable."""
+    text = (REPO_ROOT / "docs" / "quality-gates.md").read_text(encoding="utf-8")
+    numbers = [int(n) for n in re.findall(r"^##\s+(\d+)\.\s", text, re.MULTILINE)]
+    assert numbers, "quality-gates.md lost its numbered sections"
+    assert numbers == list(range(1, len(numbers) + 1)), (
+        f"sections must run 1..N with no gaps or reordering, got {numbers}"
+    )
+
+
+def test_every_cited_spec_section_exists() -> None:
+    """A §N reference anywhere in the repo must resolve to a real section."""
+    spec = (REPO_ROOT / "docs" / "quality-gates.md").read_text(encoding="utf-8")
+    existing = {int(n) for n in re.findall(r"^##\s+(\d+)\.\s", spec, re.MULTILINE)}
+
+    dangling: list[str] = []
+    for path in REPO_ROOT.rglob("*.md"):
+        if any(part in {".venv", "dist", "node_modules"} for part in path.parts):
+            continue
+        for cited in re.findall(r"§(\d+)", path.read_text(encoding="utf-8")):
+            if int(cited) not in existing:
+                dangling.append(f"{path.relative_to(REPO_ROOT)} cites §{cited}")
+    assert not dangling, f"dangling spec citations: {dangling}"


### PR DESCRIPTION
Finding **9** from the readiness audit — the last open item.

> **Stacked on #16**, which is stacked on #15. GitHub retargets automatically as each lands.

## The obvious fix was wrong

The finding was that `docs/quality-gates.md` alone uses numbered sections, horizontal rules and RFC "shall", where every other document uses unnumbered headings and plain imperative — it read as imported rather than authored alongside the rest.

Harmonizing it would have been a mistake. **Those section numbers are load-bearing: 13 references cite them** — `§10` and `§5` in `CHANGELOG.md`, `§9`/`§10` throughout the ADR, and internal cross-references inside the spec. Removing the numbering breaks every one, and costs downstream repositories a stable way to cite the standard they are held to.

## Resolved by making the difference deliberate

The spec now opens with a short note: it is a specification, sections are numbered so they can be cited precisely, "shall" marks a requirement and "should" a recommendation, and **new sections are appended rather than inserted** so existing citations stay valid.

`docs/repo-standard.md` says the same from the entry point, so a reader meets the distinction before reaching the document that uses it.

This turns an apparent inconsistency into a stated convention — and the convention is a genuinely better outcome than uniformity would have been.

## Two tests keep the promise

| Guard | Catches |
|---|---|
| `test_quality_gates_sections_are_sequentially_numbered` | A section inserted mid-document, silently renumbering everything after it |
| `test_every_cited_spec_section_exists` | A `§N` citation anywhere in the repo that no longer resolves |

Verified both bite:

```
renumber §11 → §13   FAILED test_quality_gates_sections_are_sequentially_numbered
cite §99             FAILED test_every_cited_spec_section_exists
```

## Test plan

- [x] `uv sync --locked`
- [x] `uv run pre-commit run --all-files` — all passed
- [x] `uv run ruff format --check .` / `ruff check .` / `ty check`
- [x] `uv run pytest` — **49 passed** (47 before)
- [x] `uv build`
- [x] Both negative tests above; restoring returns the suite to green

With this, **all 13 original findings plus the 3 found during remediation are addressed** — except enforcement, which is blocked on the GitHub plan rather than on anything in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)