### PR TITLE
Bring #16 and #17 onto main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ Agents must not:
 
 1. Update the normative docs first when changing the standard.
 2. Update templates and starter kits in the same change.
-3. Validate the bootstrap tool against a temporary output directory.
+3. Validate bootstrap behavior with `uv run pytest`, which generates into a
+   temporary directory rather than a fixed path.
 4. Keep changes small and focused by concern.
 
 ## Quality Gates
@@ -54,7 +55,11 @@ Run from repository root:
 5. `uv run ty check`
 6. `uv run pytest`
 7. `uv build`
-8. `uv run repo-init --profile python-single --output-dir /tmp/demo-repo --no-install`
+
+This is exactly the chain in `docs/quality-gates.md`; this repository adds no
+gates of its own. Bootstrap behavior needs no separate manual step — `uv run
+pytest` exercises the `repo-init` and `repo-add-package` entry points end to
+end in a temporary directory, on every platform.
 
 ## Coding Standards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ the changes listed under **Adopters must**.
 - Tests asserting that every shipped `AGENTS.md` states the exact gate chain,
   and that the README template defers to `AGENTS.md` rather than keeping a
   second copy of it.
+- A "How to read this document" note in `docs/quality-gates.md` stating that
+  its numbered sections and normative keywords are deliberate, so that other
+  documents can cite it precisely, and that new sections are appended rather
+  than inserted.
+- Tests asserting that the spec's sections stay sequentially numbered and that
+  every `§N` citation in the repository resolves to a real section.
 - A `Change Control Notes` section in this repository's own `AGENTS.md`,
   which the contract required and it was missing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ the changes listed under **Adopters must**.
   drifting silently.
 - Tests asserting that every shipped and generated `AGENTS.md` carries all
   ten required sections, and that neither profile adds or relaxes a gate.
+- Tests asserting that every shipped `AGENTS.md` states the exact gate chain,
+  and that the README template defers to `AGENTS.md` rather than keeping a
+  second copy of it.
 - A `Change Control Notes` section in this repository's own `AGENTS.md`,
   which the contract required and it was missing.
 
@@ -70,6 +73,12 @@ the changes listed under **Adopters must**.
   repository runs for itself; generated repositories were receiving `@v4`.
 - Both Python profiles defer to `docs/quality-gates.md` for the gate chain
   instead of restating it.
+- The README template's Quality Gates section defers to `AGENTS.md` instead of
+  restating the chain as a competing authority. The common-commands table and
+  setup steps are unchanged.
+- This repository's own gate chain no longer carries an eighth step that
+  bootstrapped into a hardcoded `/tmp` path. It was not portable, and `uv run
+  pytest` already exercises the CLI end to end in a temporary directory.
 
 ### Removed
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,5 +1,15 @@
 # Quality Gates Specification
 
+> **How to read this document.** This is a specification, not guidance, and it
+> is written differently from the rest of `docs/` on purpose. Sections are
+> numbered so other documents can cite them precisely — `§10` in `CHANGELOG.md`
+> and in the ADRs means this document's section 10, and those references stay
+> valid as the text around them changes. "Shall" marks a requirement; "should"
+> marks a recommendation. The companion documents indexed by
+> `docs/repo-standard.md` are guidance and use plain imperative voice instead.
+> Renumbering a section here breaks existing citations, so add new sections at
+> the end rather than inserting them.
+
 ## 1. Purpose
 
 This specification defines the minimum quality requirements for repositories

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -72,6 +72,11 @@ including its `README.md`, templates, and starter kits, implements them.
 
 Where a companion document conflicts with this one, this document governs.
 
+`docs/quality-gates.md` is a specification: its sections are numbered so they
+can be cited precisely, and it uses "shall" and "should" as normative keywords.
+Every other document here is guidance and uses plain imperative voice. The
+difference is deliberate, not drift.
+
 ## Required `AGENTS.md` Sections
 
 Every target repository should include:

--- a/templates/README.md
+++ b/templates/README.md
@@ -134,20 +134,14 @@ standards drift.
 
 ### Quality Gates
 
-These are mandatory before merge and run in CI on every PR to `main`
-(`.github/workflows/quality.yml`). Run them locally first:
+The mandatory gate chain is listed in `AGENTS.md`, which is the one place this
+repository states it, and runs in CI on every PR to `main`
+(`.github/workflows/quality.yml`). Run it locally before pushing.
 
-1. `uv sync --locked`
-2. `uv run pre-commit run --all-files`
-3. `uv run ruff format --check .`
-4. `uv run ruff check .`
-5. `uv run ty check`
-6. `uv run pytest`
-7. `uv build`
-
-No PR merges into `main` unless all mandatory gates pass. Temporary
-exemptions require explicit justification in the PR and maintainer approval,
-and must stay time-limited.
+No PR merges into `main` unless all mandatory gates pass, and branch protection
+enforces that rather than convention — see the
+[quality-gates spec][quality-gates]. Temporary exemptions require explicit
+justification in the PR and maintainer approval, and must stay time-limited.
 
 ### Dependency Management
 

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -620,3 +620,44 @@ def test_profiles_neither_add_nor_relax_gates() -> None:
         assert not restated, (
             f"profiles/{profile}.md restates gates instead of deferring: {restated}"
         )
+
+
+@pytest.mark.parametrize(
+    "agents_path",
+    [
+        Path("AGENTS.md"),
+        Path("templates/AGENTS.md"),
+        *(
+            starter_kit_dir(p).relative_to(REPO_ROOT) / "AGENTS.md"
+            for p in STARTER_KIT_PROFILES
+        ),
+    ],
+    ids=["repo-root", "template", "starter-single", "starter-workspace"],
+)
+def test_shipped_agents_files_state_the_exact_gate_chain(agents_path: Path) -> None:
+    """The contract requires exact gate commands in AGENTS.md; hold each copy to it."""
+    text = (REPO_ROOT / agents_path).read_text(encoding="utf-8")
+    missing = [c for c in mandatory_ci_commands() if c not in text]
+    assert not missing, f"{agents_path} omits mandatory gates: {missing}"
+
+
+def test_readme_template_defers_to_agents_for_the_gate_chain() -> None:
+    """The README template's Quality Gates section points at AGENTS.md.
+
+    Onboarding aids elsewhere in the template - the common-commands table, the
+    setup steps - may name individual commands. What must not exist is a second
+    authoritative copy of the chain competing with the one AGENTS.md carries.
+    """
+    text = (REPO_ROOT / "templates" / "README.md").read_text(encoding="utf-8")
+    heading = "### Quality Gates"
+    assert heading in text, "templates/README.md lost its Quality Gates section"
+    section = text.split(heading, 1)[1].split("\n### ", 1)[0]
+
+    restated = [c for c in mandatory_ci_commands() if c in section]
+    assert not restated, (
+        "templates/README.md restates the gate chain instead of deferring to "
+        f"AGENTS.md: {restated}"
+    )
+    assert "AGENTS.md" in section, (
+        "the Quality Gates section must point at AGENTS.md for the chain"
+    )

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -661,3 +661,28 @@ def test_readme_template_defers_to_agents_for_the_gate_chain() -> None:
     assert "AGENTS.md" in section, (
         "the Quality Gates section must point at AGENTS.md for the chain"
     )
+
+
+def test_quality_gates_sections_are_sequentially_numbered() -> None:
+    """Other documents cite this spec by section number; numbering must stay stable."""
+    text = (REPO_ROOT / "docs" / "quality-gates.md").read_text(encoding="utf-8")
+    numbers = [int(n) for n in re.findall(r"^##\s+(\d+)\.\s", text, re.MULTILINE)]
+    assert numbers, "quality-gates.md lost its numbered sections"
+    assert numbers == list(range(1, len(numbers) + 1)), (
+        f"sections must run 1..N with no gaps or reordering, got {numbers}"
+    )
+
+
+def test_every_cited_spec_section_exists() -> None:
+    """A §N reference anywhere in the repo must resolve to a real section."""
+    spec = (REPO_ROOT / "docs" / "quality-gates.md").read_text(encoding="utf-8")
+    existing = {int(n) for n in re.findall(r"^##\s+(\d+)\.\s", spec, re.MULTILINE)}
+
+    dangling: list[str] = []
+    for path in REPO_ROOT.rglob("*.md"):
+        if any(part in {".venv", "dist", "node_modules"} for part in path.parts):
+            continue
+        for cited in re.findall(r"§(\d+)", path.read_text(encoding="utf-8")):
+            if int(cited) not in existing:
+                dangling.append(f"{path.relative_to(REPO_ROOT)} cites §{cited}")
+    assert not dangling, f"dangling spec citations: {dangling}"


### PR DESCRIPTION
## What happened

#16 and #17 are both marked **merged**, but their content never reached `main`. They merged into each other's base branches instead:

| PR | Merged at | Into | Reached main? |
|---|---|---|---|
| #15 | 10:04:31 | `main` | ✅ |
| #16 | 10:05:59 | `docs/enforcement-plan-prerequisite` | ❌ |
| #17 | 10:06:59 | `fix/gate-chain-consistency` | ❌ |

They were a stack: #17 → #16 → #15 → main. GitHub only auto-retargets a stacked PR when its base branch is **deleted** on merge. #15 was merged without deleting its branch, so `docs/enforcement-plan-prerequisite` still existed and #16 happily merged into it — a branch that was already stale relative to `main`. #17 then merged into #16's branch. Both PRs report success; neither changed `main`.

`main` was left with 42 tests and findings 8, 9, 12 and 16 still open, despite all three PRs showing as merged.

## What this PR does

Cherry-picks the two work commits onto `main`. Nothing is rewritten — these are the same changes reviewed in #16 and #17.

- `d656424` — findings 8, 12, 16 (from #16)
- `e485971` — finding 9 (from #17)

A rebase was tried first and conflicted, because #15 was squash-merged so its individual commits no longer match by patch id. Cherry-picking the two commits applied cleanly with no conflicts.

## Verified on this branch

| Finding | Check |
|---|---|
| 6 | `docs/adr/` and `docs/diagrams/` both present |
| 8 | no `/tmp/demo-repo` in `AGENTS.md` |
| 9 | convention note in the spec and at the entry point |
| 12 | `templates/README.md` defers to `AGENTS.md` |
| 16 | both new gate-chain assertions present |

- [x] `uv sync --locked`
- [x] `uv run pre-commit run --all-files` — all passed
- [x] `uv run ruff format --check .` / `ruff check .` / `ty check`
- [x] `uv run pytest` — **49 passed** (42 on `main` today)
- [x] `uv build`

## To avoid this next time

Either merge stacked PRs **bottom-up with branch deletion enabled**, or retarget each to `main` manually before merging. I can also flatten future stacks into a single PR if you'd rather not manage the ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)