### PR TITLE
Stop the version-pin example going stale every release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ the changes listed under **Adopters must**.
 
 ## [Unreleased]
 
+### Fixed
+
+- The `uvx --from ...@vX.Y.Z` pin examples in `README.md` and
+  `docs/bootstrap-workflow.md` now match the package version. They had gone
+  stale on every release so far, so a test asserts them against
+  `pyproject.toml` rather than relying on remembering to bump them.
+
 ## [0.3.0] - 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then:
 Pin a standards version by adding a Git ref:
 
 ```bash
-uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.2.0" repo-init --profile python-single --repo-name widget-service
+uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.3.0" repo-init --profile python-single --repo-name widget-service
 ```
 
 For repeated use, install the tool once. That puts `repo-init` and

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -47,7 +47,7 @@ uv tool install --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.g
 Pin a standards version by adding a Git ref:
 
 ```bash
-uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.2.0" repo-init --profile python-single --repo-name widget-service
+uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.3.0" repo-init --profile python-single --repo-name widget-service
 ```
 
 The generated repository derives its `AGENTS.md`, CI workflow, `pyproject.toml`,

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -686,3 +686,23 @@ def test_every_cited_spec_section_exists() -> None:
             if int(cited) not in existing:
                 dangling.append(f"{path.relative_to(REPO_ROOT)} cites §{cited}")
     assert not dangling, f"dangling spec citations: {dangling}"
+
+
+def test_version_pin_examples_match_the_package_version() -> None:
+    """Docs show a pinned install; the pin must be this version, not a stale one.
+
+    This example has silently gone stale on every release so far. Asserting it
+    against pyproject.toml turns "remember to bump the docs" into a gate.
+    """
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    version_match = re.search(r'^version = "([^"]+)"', pyproject, re.MULTILINE)
+    assert version_match, "could not read version from pyproject.toml"
+    version = version_match.group(1)
+
+    stale: list[str] = []
+    for name in ("README.md", "docs/bootstrap-workflow.md"):
+        text = (REPO_ROOT / name).read_text(encoding="utf-8")
+        for pinned in re.findall(r"repo-standard-kit\.git@v([0-9][^\"\s]*)", text):
+            if pinned != version:
+                stale.append(f"{name} pins v{pinned}, package is {version}")
+    assert not stale, f"stale version-pin examples: {stale}"


### PR DESCRIPTION
## A recurring drift, now gated

`README.md` and `docs/bootstrap-workflow.md` show a pinned install example. It has gone stale on **every release so far**:

| When | State |
|---|---|
| Before PR #12 | pinned `@v0.1.0` — a tag that never existed after the rename |
| PR #12 | bumped to `@v0.2.0` |
| Tagging `v0.3.0` today | stale again, within minutes |

Three occurrences of the same defect means the process is the problem, not the individual bump.

## What this does

Bumps both examples to `@v0.3.0`, and adds a test asserting the pinned version matches `pyproject.toml`. Remembering to update the docs becomes a gate instead of a habit.

Verified it bites — reverting one pin to `@v0.2.0`:

```
FAILED tests/test_version_pin_examples_match_the_package_version
1 failed, 49 passed
```

## Note on the v0.3.0 tag

`v0.3.0` was already tagged and pushed before this was caught, so it ships the stale `@v0.2.0` example. The example still resolves — `v0.2.0` exists — so this is corrected forward rather than by moving a published tag, which adopters may already have fetched.

Worth folding the doc bump into the release routine: the `Change Control Notes` in `AGENTS.md` already require the package version to track the tag, and this test now extends that to the docs.

## Test plan

- [x] `uv sync --locked`
- [x] `uv run pre-commit run --all-files` — all passed
- [x] `uv run ruff format --check .` / `ruff check .` / `ty check`
- [x] `uv run pytest` — **50 passed** (49 before)
- [x] `uv build`
- [x] Negative test above; restoring returns to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)