### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,20 @@ the changes listed under **Adopters must**.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-18
+
 ### Fixed
 
 - The `uvx --from ...@vX.Y.Z` pin examples in `README.md` and
   `docs/bootstrap-workflow.md` now match the package version. They had gone
   stale on every release so far, so a test asserts them against
-  `pyproject.toml` rather than relying on remembering to bump them.
+  `pyproject.toml` rather than relying on remembering to bump them. The
+  `v0.3.0` tag ships the stale example; this corrects it forward rather than
+  moving a published tag.
+
+### Adopters must
+
+- Nothing. This is a documentation correction with no effect on alignment.
 
 ## [0.3.0] - 2026-08-18
 
@@ -129,7 +137,8 @@ the changes listed under **Adopters must**.
 Initial standard, Python starter kits, and the `repo-init` and
 `repo-add-package` bootstrap tools.
 
-[Unreleased]: https://github.com/FP-DevTools/repo-standard-kit/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/FP-DevTools/repo-standard-kit/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/FP-DevTools/repo-standard-kit/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/FP-DevTools/repo-standard-kit/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/FP-DevTools/repo-standard-kit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/FP-DevTools/repo-standard-kit/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then:
 Pin a standards version by adding a Git ref:
 
 ```bash
-uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.3.0" repo-init --profile python-single --repo-name widget-service
+uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.3.1" repo-init --profile python-single --repo-name widget-service
 ```
 
 For repeated use, install the tool once. That puts `repo-init` and

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -47,7 +47,7 @@ uv tool install --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.g
 Pin a standards version by adding a Git ref:
 
 ```bash
-uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.3.0" repo-init --profile python-single --repo-name widget-service
+uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.3.1" repo-init --profile python-single --repo-name widget-service
 ```
 
 The generated repository derives its `AGENTS.md`, CI workflow, `pyproject.toml`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo-standard-kit"
-version = "0.3.0"
+version = "0.3.1"
 description = "Portable development standards, starter kits, and bootstrap tooling for software repositories."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -367,7 +367,7 @@ wheels = [
 
 [[package]]
 name = "repo-standard-kit"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Why a patch release

`v0.3.0` was tagged before #19 merged, so its snapshot still contains the stale `@v0.2.0` pin example that #19 exists to fix:

```
v0.3.0  →  7bb6039   docs still pin @v0.2.0
main    →  0ee5645   #19 fixed it
```

Rather than move a published tag — which #19's description and `docs/adr/0001` both argue against — this corrects it forward.

## Compatibility

**PATCH** under the policy in `CHANGELOG.md`: a documentation correction with no effect on whether an adopting repository is aligned. The **Adopters must** section is deliberately empty.

This is the first release cut under that policy, so it doubles as a check that the routine works.

## Note on the bump

The test added in #19 means a version bump is no longer a one-line change — `pyproject.toml` and both documented pins must move together or the suite fails. That is the intent: it is precisely why the example cannot silently go stale a fourth time.

Files moved together here: `pyproject.toml`, `uv.lock`, `README.md`, `docs/bootstrap-workflow.md`, `CHANGELOG.md`.

## Test plan

- [x] `uv lock` / `uv sync --locked`
- [x] `uv run pre-commit run --all-files` — all passed
- [x] `uv run ruff format --check .` / `ruff check .` / `ty check`
- [x] `uv run pytest` — **50 passed**, including the pin assertion against the new version
- [x] `uv build` — produces `repo_standard_kit-0.3.1`

Once merged I will tag `v0.3.1` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)