### PR TITLE
Add pre-commit and reusable-CI consumption surfaces for repo-check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,59 @@
+name: Compliance
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: >-
+          repo-standard-kit ref to install. Defaults to the ref this reusable
+          workflow was itself called at, so a caller pinning
+          `uses: .../compliance.yml@vX.Y.Z` needs nothing further.
+        type: string
+        default: ""
+      strict:
+        description: "Treat 'should' findings as failures too."
+        type: boolean
+        default: false
+      check-enforcement:
+        description: >-
+          Also check branch protection (§10). Needs gh and auth in the
+          caller's job.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  repo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Resolve repo-standard-kit ref
+        id: resolve-ref
+        shell: bash
+        run: |
+          ref="${{ inputs.ref }}"
+          if [ -z "$ref" ]; then
+            ref="${GITHUB_WORKFLOW_REF#*@}"
+            ref="${ref#refs/tags/}"
+            ref="${ref#refs/heads/}"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Run repo-check
+        shell: bash
+        run: |
+          args=(--format text)
+          if [ "${{ inputs.strict }}" = "true" ]; then
+            args+=(--strict)
+          fi
+          if [ "${{ inputs.check-enforcement }}" = "true" ]; then
+            args+=(--check-enforcement)
+          fi
+          uvx --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@${{ steps.resolve-ref.outputs.ref }}" repo-check "${args[@]}"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: repo-check
+  name: repo-check
+  description: >-
+    Verify a repository's structural alignment with repo-standard-kit
+    (https://github.com/FP-DevTools/repo-standard-kit).
+  entry: repo-check
+  language: python
+  pass_filenames: false
+  always_run: true

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -30,6 +30,60 @@ Options:
 Exit codes: `0` aligned, `1` a `shall` rule was violated (or a `should` rule
 under `--strict`), `2` usage error.
 
+## Consumption Surfaces
+
+Three ways to run `repo-check` against a repository, from lowest to highest
+commitment.
+
+### Ad hoc
+
+No setup: the command shown above, or pinned to a released version:
+
+```bash
+uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v0.4.0" repo-check
+```
+
+### Local pre-commit hook
+
+This repository ships `.pre-commit-hooks.yaml`, so `pre-commit` can install
+and run `repo-check` without the consuming repository declaring it as a
+dependency. Add to the consuming repository's `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/FP-DevTools/repo-standard-kit
+    rev: v0.4.0
+    hooks:
+      - id: repo-check
+```
+
+Pin `rev` to a released tag and bump it deliberately — `pre-commit
+autoupdate` turns that into a one-line PR. The hook always runs (it inspects
+the whole tree, not the files staged in a commit) and does not fail the
+commit for `should` findings unless `args: [--strict]` is added.
+
+### Reusable CI workflow
+
+This repository's `.github/workflows/compliance.yml` triggers on
+`workflow_call`. A consuming repository adds its own workflow that calls it:
+
+```yaml
+name: Compliance
+
+on:
+  pull_request:
+
+jobs:
+  compliance:
+    uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@v0.4.0
+```
+
+The called workflow installs `repo-check` at the same ref it was called
+with, so nothing needs to be kept in sync by hand. Pass `with: { ref: ... }`
+to override that resolution if it ever proves unreliable, and `with: {
+strict: true }` or `with: { check-enforcement: true }` to opt into the
+stricter modes described above.
+
 ## How It Stays Honest
 
 The rule catalogue is not hand-maintained prose duplicating the spec. It is

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 from conftest import REPO_ROOT
 
 from repo_standard.compliance import cli
@@ -355,3 +356,31 @@ def test_repo_check_console_script_runs_end_to_end(tmp_path: Path) -> None:
     )
     assert result.returncode == 1
     assert "RSK001" in result.stdout
+
+
+# --- consumption surfaces -----------------------------------------------
+
+
+def test_pre_commit_hooks_manifest_declares_repo_check() -> None:
+    manifest = yaml.safe_load(
+        (REPO_ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8")
+    )
+    [hook] = manifest
+    assert hook["id"] == "repo-check"
+    assert hook["entry"] == "repo-check"
+    assert hook["language"] == "python"
+    assert hook["pass_filenames"] is False
+    assert hook["always_run"] is True
+
+
+def test_compliance_workflow_is_reusable_and_pinned_to_setup_uv() -> None:
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "compliance.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    # PyYAML parses the bare `on:` key as boolean True.
+    assert "workflow_call" in workflow[True]
+    assert workflow["permissions"] == {"contents": "read"}
+
+    text = workflow_path.read_text(encoding="utf-8")
+    assert "astral-sh/setup-uv@v5" in text
+    assert "actions/checkout@v5" in text
+    assert "git+https://github.com/FP-DevTools/repo-standard-kit.git" in text


### PR DESCRIPTION
## Summary

Phase 4 of the [repo-check rollout plan](https://claude.ai/code/artifact/976713c4-484d-4449-8e4f-e432a2c90198): two of the three consumption surfaces for the `repo-check` library merged in #22 (the ad hoc `uvx` surface already worked — it's just the console script).

- **`.pre-commit-hooks.yaml`** — lets a consuming repository add `repo: https://github.com/FP-DevTools/repo-standard-kit` + `rev: vX.Y.Z` to its own `.pre-commit-config.yaml` without declaring `repo-standard-kit` as a project dependency. `pre-commit` installs it into an isolated hook environment via the standard PEP 517 build (`uv_build`) and calls the `repo-check` entry point.
- **`.github/workflows/compliance.yml`** — a `workflow_call` reusable workflow. A caller pins `uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@vX.Y.Z`; the workflow resolves that same ref from its own `GITHUB_WORKFLOW_REF` and installs `repo-check` at it, so nothing needs to be kept in sync by hand. `with: { ref: ... }` overrides that resolution if it's ever unreliable; `strict` and `check-enforcement` inputs map to the CLI flags.
- **`docs/compliance.md`** — documents all three surfaces (ad hoc, pre-commit, CI) in one place, ad hoc → most commitment order.

### Verification

- Live-tested the pre-commit surface end to end: pointed a scratch repo's `.pre-commit-config.yaml` at this checkout (`repo: file:///...`, `rev: <this branch's HEAD sha>`), ran `pre-commit run --all-files`, and confirmed it installed the package into an isolated environment and correctly reported findings against an empty repo (exit 1) — this is the mechanism, git doesn't distinguish a local path from a GitHub URL for hook resolution.
- Simulated the `GITHUB_WORKFLOW_REF` parsing logic against tag, branch, and SHA-shaped values by hand; all three resolve correctly.
- `uv run repo-check . --strict` against this repo itself still reports only the two documented self-application exceptions (`RSK005`, `RSK011`) — no new findings from the added files.
- Added `tests/test_compliance.py` coverage asserting the hook manifest's shape and the workflow's `workflow_call` trigger, pinned action versions, and install URL.

### What this PR does *not* include

- **Starter-kit and template wiring** ("generated repositories check themselves from birth") — deferred. It needs a version-pin mechanism inside the starter-kit placeholder templating system that doesn't exist yet (the existing 6 placeholders don't include a kit-version token), which is more invasive to `repo_init.py` than this PR's scope.
- **A live cross-repo GitHub Actions run.** This repo can't call its own reusable workflow from itself in a way that proves the "another repository" case; that needs an actual second repo invoking `uses: .../compliance.yml@<ref>` on GitHub. Flagging this as the one part of Phase 4's "done when" criterion not fully closed here.

## Test plan

- [x] `uv sync --locked`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run ruff format --check .` / `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (82 passed)
- [x] `uv build`
- [x] Live pre-commit smoke test against a scratch repo (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)