### PR TITLE
Require an explicit ref input for the compliance reusable workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -5,11 +5,12 @@ on:
     inputs:
       ref:
         description: >-
-          repo-standard-kit ref to install. Defaults to the ref this reusable
-          workflow was itself called at, so a caller pinning
-          `uses: .../compliance.yml@vX.Y.Z` needs nothing further.
+          repo-standard-kit ref to install. Must match the ref pinned in
+          `uses: .../compliance.yml@ref` — GitHub Actions does not expose a
+          reliable way for a called reusable workflow to read that pin from
+          inside itself, so the caller states it explicitly.
         type: string
-        default: ""
+        required: true
       strict:
         description: "Treat 'should' findings as failures too."
         type: boolean
@@ -34,18 +35,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Resolve repo-standard-kit ref
-        id: resolve-ref
-        shell: bash
-        run: |
-          ref="${{ inputs.ref }}"
-          if [ -z "$ref" ]; then
-            ref="${GITHUB_WORKFLOW_REF#*@}"
-            ref="${ref#refs/tags/}"
-            ref="${ref#refs/heads/}"
-          fi
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-
       - name: Run repo-check
         shell: bash
         run: |
@@ -56,4 +45,4 @@ jobs:
           if [ "${{ inputs.check-enforcement }}" = "true" ]; then
             args+=(--check-enforcement)
           fi
-          uvx --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@${{ steps.resolve-ref.outputs.ref }}" repo-check "${args[@]}"
+          uvx --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@${{ inputs.ref }}" repo-check "${args[@]}"

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -76,11 +76,15 @@ on:
 jobs:
   compliance:
     uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@v0.4.0
+    with:
+      ref: v0.4.0
 ```
 
-The called workflow installs `repo-check` at the same ref it was called
-with, so nothing needs to be kept in sync by hand. Pass `with: { ref: ... }`
-to override that resolution if it ever proves unreliable, and `with: {
+`ref` is required and must match the pin in `uses:`. GitHub Actions does not
+give a called reusable workflow a reliable way to read that pin from inside
+itself — an earlier version of this workflow tried the `GITHUB_WORKFLOW_REF`
+self-resolution trick and it silently installed the wrong ref in a live
+cross-repo test, so the caller states it explicitly instead. Add `with: {
 strict: true }` or `with: { check-enforcement: true }` to opt into the
 stricter modes described above.
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -380,7 +380,17 @@ def test_compliance_workflow_is_reusable_and_pinned_to_setup_uv() -> None:
     assert "workflow_call" in workflow[True]
     assert workflow["permissions"] == {"contents": "read"}
 
+    # `ref` must be required, with no default: a called reusable workflow has
+    # no reliable way to read its own `uses: ...@ref` pin from the inside, so
+    # the caller states it explicitly instead of this workflow guessing.
+    ref_input = workflow[True]["workflow_call"]["inputs"]["ref"]
+    assert ref_input["required"] is True
+    assert "default" not in ref_input
+
     text = workflow_path.read_text(encoding="utf-8")
     assert "astral-sh/setup-uv@v5" in text
     assert "actions/checkout@v5" in text
-    assert "git+https://github.com/FP-DevTools/repo-standard-kit.git" in text
+    assert (
+        "git+https://github.com/FP-DevTools/repo-standard-kit.git@${{ inputs.ref }}"
+        in text
+    )


### PR DESCRIPTION
## Summary

Fixes a real bug in `.github/workflows/compliance.yml`, found by actually running it cross-repo rather than just reading it — see the "verification" section of #24 for context on why this needed a live test.

**The bug:** the workflow tried to self-resolve the ref it was called at via `GITHUB_WORKFLOW_REF`, so a caller could pin `uses: .../compliance.yml@vX.Y.Z` without repeating the version. In a live test — a scratch repo (`FP-DevTools/repo-check-smoketest`) calling `uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@develop` — that variable resolved to the **caller's own branch ref (`main`)**, not the ref the reusable workflow was invoked at (`develop`). It silently tried to install `repo-standard-kit@main`, which doesn't have the `repo-check` script yet, and `uvx` correctly failed:

```
An executable named `repo-check` is not provided by package `repo-standard-kit`.
```

GitHub Actions has no reliable way for a called reusable workflow to read its own `uses:...@ref` pin from the inside. **The fix**: `ref` is now a required input; the caller states it explicitly, matching their `uses:` pin. `docs/compliance.md` and the test in `tests/test_compliance.py` are updated to match, and the docs now explain *why* the simpler approach was rejected, since it's the kind of thing someone will be tempted to "simplify" back in later.

### Verification

Re-ran the same live cross-repo test against this fix branch (`uses: .../compliance.yml@fix/compliance-workflow-ref-resolution`, `with: { ref: fix/compliance-workflow-ref-resolution }`): it now installs the correct ref and reports real findings against the scratch repo (`RSK001`, `RSK006`, `RSK007`, `RSK008`, `RSK009` as `shall`; `RSK012` as `should`) — job exits 1 for the right reason (violations found), not an install failure. This closes out Phase 4's "done when" criterion for the CI workflow surface.

## Test plan

- [x] `uv run pytest` (82 passed)
- [x] `uv run ruff format --check .` / `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pre-commit run --all-files`
- [x] Live cross-repo GitHub Actions run against a scratch repo (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)