### PR TITLE
Close v1.0 policy and enforcement blockers

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -143,6 +143,9 @@ remediation. Markdown explains policy but supplies no executable values.
 - RSK020 evaluates the quality job's effective permissions. RSK021 requires
   full SHA pins for remote actions and reusable workflows in every job in the
   quality workflow; local and Docker actions are exempt.
+- RSK014 checks pull request reviews, stale approval dismissal, required status
+  checks, strict up-to-date branches, conversation resolution, and
+  administrator enforcement when platform checks are requested.
 
 ## What This Cannot Check
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -141,8 +141,8 @@ remediation. Markdown explains policy but supplies no executable values.
 - AGENTS.md remains a heading and literal-contract check. There is no
   subjective prose scoring.
 - RSK020 evaluates the quality job's effective permissions. RSK021 requires
-  full SHA pins for remote actions and reusable workflows; local and Docker
-  actions are exempt.
+  full SHA pins for remote actions and reusable workflows in every job in the
+  quality workflow; local and Docker actions are exempt.
 
 ## What This Cannot Check
 

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -262,9 +262,9 @@ Remediation: Set effective quality-job permissions to contents read with no writ
 - Enforcement: `structural`
 - Check kind: `github_workflow_pins`
 
-Rationale: Full commit pins prevent upstream tag movement from changing trusted code.
+Rationale: Full commit pins prevent upstream tag movement from changing trusted workflow code.
 
-Remediation: Pin every remote action and reusable workflow to a 40-character SHA.
+Remediation: Pin every remote action and reusable workflow in the quality workflow to a 40-character SHA.
 
 ## Retired Rule IDs
 

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -180,7 +180,7 @@ Remediation: Add docs/adr/ and an ADR template or first decision record.
 
 Rationale: Passing workflows are advisory unless merges require them.
 
-Remediation: Protect main with quality checks, review, and administrator enforcement.
+Remediation: Protect main with pull request reviews, stale approval dismissal, strict quality checks, conversation resolution, and administrator enforcement.
 
 ### RSK015: Ruff line length uses the recommended baseline
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -115,10 +115,10 @@ commands, and equivalent command formatting are normalized before comparison.
 
 RSK020 enforces at the **required** level that the quality job's effective
 permissions include `contents: read` and no write permission. RSK021 enforces
-at the **required** level that every remote action and reusable workflow used
-by that job is pinned to a full 40-character commit SHA. Local `./` actions and
-`docker://` references are exempt. Keep a version comment next to each SHA so
-Dependabot updates remain understandable.
+at the **required** level that every remote action and reusable workflow
+referenced by the quality workflow is pinned to a full 40-character commit
+SHA. Local `./` actions and `docker://` references are exempt. Keep a version
+comment next to each SHA so Dependabot updates remain understandable.
 
 ### Environment reproducibility
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,14 +1,15 @@
 # Quality Gates Specification
 
-> **How to read this document.** This is a specification, not guidance, and it
-> is written differently from the rest of `docs/` on purpose. Sections are
-> numbered so other documents can cite them precisely — `§10` in `CHANGELOG.md`
-> and in the ADRs means this document's section 10, and those references stay
-> valid as the text around them changes. "Shall" marks a requirement; "should"
-> marks a recommendation. The companion documents indexed by
-> `docs/repo-standard.md` are guidance and use plain imperative voice instead.
-> Renumbering a section here breaks existing citations, so add new sections at
-> the end rather than inserting them.
+This document is part of the normative repository standard.
+
+Its numbered sections provide stable cross-reference targets. The normative
+keywords defined in `docs/repo-standard.md` apply here. Renumbering a section
+breaks existing citations, so add new sections at the end rather than inserting
+them.
+
+Machine-enforced values and check configuration are defined by
+`policy/base.yaml` and `policy/profiles/`. This document explains the intent and
+required behavior; it is not parsed to derive executable policy.
 
 ## 1. Purpose
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -314,15 +314,21 @@ once, so open an initial pull request before configuring protection.
 ```bash
 gh api repos/<owner>/<repo>/branches/main/protection \
   --jq '{checks: .required_status_checks.contexts,
+         strict: .required_status_checks.strict,
          reviews: .required_pull_request_reviews.required_approving_review_count,
+         dismiss_stale: .required_pull_request_reviews.dismiss_stale_reviews,
+         conversation_resolution: .required_conversation_resolution.enabled,
          enforce_admins: .enforce_admins.enabled}'
 ```
 
 The `quality` check shall appear in `checks`, `reviews` shall be at least `1`,
-and `enforce_admins` shall be `true`.
+and `strict`, `dismiss_stale`, `conversation_resolution`, and `enforce_admins`
+shall all be `true`.
 
-A `403` response means the repository is on a plan that does not support
-branch protection; see the platform prerequisite above.
+A `403` response carrying the documented upgrade message means the repository
+is on a plan that does not support branch protection; see the platform
+prerequisite above. Other authentication, authorization, and network failures
+leave enforcement evidence indeterminate.
 
 A repository that cannot produce this configuration is not aligned with this
 specification, regardless of whether its workflow passes.

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -285,10 +285,15 @@ rules:
       kind: branch_protection
       config:
         branch: main
-        status_check: quality
+        required_status_checks:
+          - quality
         minimum_reviews: 1
+        dismiss_stale_approvals: true
+        require_up_to_date: true
+        require_conversation_resolution: true
+        enforce_admins: true
     rationale: Passing workflows are advisory unless merges require them.
-    remediation: Protect main with quality checks, review, and administrator enforcement.
+    remediation: Protect main with pull request reviews, stale approval dismissal, strict quality checks, conversation resolution, and administrator enforcement.
 
   - id: RSK015
     title: Ruff line length uses the recommended baseline

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -398,6 +398,5 @@ rules:
       kind: github_workflow_pins
       config:
         path: .github/workflows/quality.yml
-        job: quality
-    rationale: Full commit pins prevent upstream tag movement from changing trusted code.
-    remediation: Pin every remote action and reusable workflow to a 40-character SHA.
+    rationale: Full commit pins prevent upstream tag movement from changing trusted workflow code.
+    remediation: Pin every remote action and reusable workflow in the quality workflow to a 40-character SHA.

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -708,16 +708,19 @@ def _branch_protection(context: CheckContext, config: dict[str, Any]) -> list[Is
             )
         ]
     if result.returncode != 0:
-        status = (
-            "violation"
-            if re.search(r"\b(?:403|404)\b", result.stderr)
-            else "indeterminate"
+        stderr = result.stderr.strip()
+        unsupported = re.search(
+            r"branch not protected|upgrade to github pro|"
+            r"branch protection (?:is )?not available",
+            stderr,
+            re.IGNORECASE,
         )
+        status = "violation" if unsupported else "indeterminate"
         return [
             Issue(
                 ".",
-                f"Branch protection query failed: {result.stderr.strip()}",
-                result.stderr.strip(),
+                f"Branch protection query failed: {stderr}",
+                stderr,
                 "configured protection",
                 status=status,
             )
@@ -734,31 +737,185 @@ def _branch_protection(context: CheckContext, config: dict[str, Any]) -> list[Is
                 status="indeterminate",
             )
         ]
-    issues = []
-    contexts = protection.get("required_status_checks", {}).get("contexts", [])
-    if config["status_check"] not in contexts:
+    if not isinstance(protection, dict):
+        return [
+            Issue(
+                ".",
+                "Platform response root was not an object.",
+                protection,
+                "branch protection object",
+                status="indeterminate",
+            )
+        ]
+
+    branch = config["branch"]
+    issues: list[Issue] = []
+
+    review_protection = protection.get("required_pull_request_reviews")
+    if review_protection is None:
         issues.append(
             Issue(
                 ".",
-                "Required status check is absent.",
-                contexts,
-                config["status_check"],
+                f"{branch} does not require pull request reviews.",
+                review_protection,
+                "pull request review protection",
             )
         )
-    reviews = protection.get("required_pull_request_reviews", {}).get(
-        "required_approving_review_count", 0
-    )
-    if reviews < config["minimum_reviews"]:
+    elif not isinstance(review_protection, dict):
         issues.append(
             Issue(
                 ".",
-                "Too few approving reviews are required.",
-                reviews,
-                config["minimum_reviews"],
+                "Could not interpret pull request review protection.",
+                review_protection,
+                "pull request review protection object",
+                status="indeterminate",
             )
         )
-    if not protection.get("enforce_admins", {}).get("enabled", False):
-        issues.append(Issue(".", "Administrators may bypass protection.", False, True))
+    else:
+        reviews = review_protection.get("required_approving_review_count")
+        if isinstance(reviews, bool) or not isinstance(reviews, int):
+            issues.append(
+                Issue(
+                    ".",
+                    "Could not interpret required approving review count.",
+                    reviews,
+                    config["minimum_reviews"],
+                    status="indeterminate",
+                )
+            )
+        elif reviews < config["minimum_reviews"]:
+            issues.append(
+                Issue(
+                    ".",
+                    f"{branch} requires too few approving reviews.",
+                    reviews,
+                    config["minimum_reviews"],
+                )
+            )
+        dismiss_stale = review_protection.get("dismiss_stale_reviews")
+        if not isinstance(dismiss_stale, bool):
+            issues.append(
+                Issue(
+                    ".",
+                    "Could not interpret stale approval dismissal.",
+                    dismiss_stale,
+                    config["dismiss_stale_approvals"],
+                    status="indeterminate",
+                )
+            )
+        elif dismiss_stale != config["dismiss_stale_approvals"]:
+            issues.append(
+                Issue(
+                    ".",
+                    f"{branch} does not dismiss stale approvals.",
+                    dismiss_stale,
+                    config["dismiss_stale_approvals"],
+                )
+            )
+
+    status_checks = protection.get("required_status_checks")
+    if status_checks is None:
+        issues.append(
+            Issue(
+                ".",
+                f"{branch} does not require status checks.",
+                status_checks,
+                config["required_status_checks"],
+            )
+        )
+    elif not isinstance(status_checks, dict):
+        issues.append(
+            Issue(
+                ".",
+                "Could not interpret required status checks.",
+                status_checks,
+                "required status checks object",
+                status="indeterminate",
+            )
+        )
+    else:
+        contexts = status_checks.get("contexts")
+        if not isinstance(contexts, list) or not all(
+            isinstance(context, str) for context in contexts
+        ):
+            issues.append(
+                Issue(
+                    ".",
+                    "Could not interpret required status check contexts.",
+                    contexts,
+                    config["required_status_checks"],
+                    status="indeterminate",
+                )
+            )
+        else:
+            missing_contexts = [
+                context
+                for context in config["required_status_checks"]
+                if context not in contexts
+            ]
+            if missing_contexts:
+                issues.append(
+                    Issue(
+                        ".",
+                        f"{branch} omits required status checks: "
+                        f"{', '.join(missing_contexts)}.",
+                        contexts,
+                        config["required_status_checks"],
+                    )
+                )
+        strict = status_checks.get("strict")
+        if not isinstance(strict, bool):
+            issues.append(
+                Issue(
+                    ".",
+                    "Could not interpret the up-to-date branch requirement.",
+                    strict,
+                    config["require_up_to_date"],
+                    status="indeterminate",
+                )
+            )
+        elif strict != config["require_up_to_date"]:
+            issues.append(
+                Issue(
+                    ".",
+                    f"{branch} does not require branches to be up to date.",
+                    strict,
+                    config["require_up_to_date"],
+                )
+            )
+
+    for response_key, config_key, message in (
+        (
+            "required_conversation_resolution",
+            "require_conversation_resolution",
+            f"{branch} does not require conversation resolution.",
+        ),
+        (
+            "enforce_admins",
+            "enforce_admins",
+            f"{branch} allows administrator bypass.",
+        ),
+    ):
+        setting = protection.get(response_key)
+        if setting is None:
+            issues.append(Issue(".", message, False, config[config_key]))
+            continue
+        if not isinstance(setting, dict) or not isinstance(
+            setting.get("enabled"), bool
+        ):
+            issues.append(
+                Issue(
+                    ".",
+                    f"Could not interpret {response_key.replace('_', ' ')}.",
+                    setting,
+                    {"enabled": config[config_key]},
+                    status="indeterminate",
+                )
+            )
+            continue
+        enabled = setting["enabled"]
+        if enabled != config[config_key]:
+            issues.append(Issue(".", message, enabled, config[config_key]))
     return issues
 
 

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -306,7 +306,7 @@ def _trigger_present(on_value: Any, trigger: str) -> bool:
     return False
 
 
-def _workflow_job(
+def _workflow_jobs(
     context: CheckContext, config: dict[str, Any]
 ) -> tuple[YamlDocument | None, dict[str, Any] | None, list[Issue]]:
     path = context.root / config["path"]
@@ -328,7 +328,32 @@ def _workflow_job(
             ],
         )
     jobs = document.data.get("jobs")
-    if not isinstance(jobs, dict) or not isinstance(jobs.get(config["job"]), dict):
+    if not isinstance(jobs, dict):
+        return (
+            document,
+            None,
+            [
+                Issue(
+                    config["path"],
+                    "Workflow jobs must be a mapping.",
+                    jobs,
+                    "mapping",
+                    document.line("jobs"),
+                )
+            ],
+        )
+    return document, jobs, []
+
+
+def _workflow_job(
+    context: CheckContext, config: dict[str, Any]
+) -> tuple[YamlDocument | None, dict[str, Any] | None, list[Issue]]:
+    document, jobs, errors = _workflow_jobs(context, config)
+    if errors:
+        return document, None, errors
+    assert document is not None
+    assert jobs is not None
+    if not isinstance(jobs.get(config["job"]), dict):
         return (
             document,
             None,
@@ -822,14 +847,11 @@ def _immutable_reference(reference: str) -> bool:
 
 
 def _github_workflow_pins(context: CheckContext, config: dict[str, Any]) -> list[Issue]:
-    document, job, errors = _workflow_job(context, config)
+    document, jobs, errors = _workflow_jobs(context, config)
     if errors:
-        return []
+        return errors
     assert document is not None
-    assert job is not None
-    assert isinstance(document.data, dict)
-    jobs = document.data.get("jobs")
-    assert isinstance(jobs, dict)
+    assert jobs is not None
     references: list[tuple[str, int | None]] = []
     for job_id, workflow_job in jobs.items():
         if not isinstance(job_id, str) or not isinstance(workflow_job, dict):

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -456,8 +456,14 @@
       "check": {
         "config": {
           "branch": "main",
+          "dismiss_stale_approvals": true,
+          "enforce_admins": true,
           "minimum_reviews": 1,
-          "status_check": "quality"
+          "require_conversation_resolution": true,
+          "require_up_to_date": true,
+          "required_status_checks": [
+            "quality"
+          ]
         },
         "kind": "branch_protection"
       },
@@ -469,7 +475,7 @@
         "python-workspace"
       ],
       "rationale": "Passing workflows are advisory unless merges require them.",
-      "remediation": "Protect main with quality checks, review, and administrator enforcement.",
+      "remediation": "Protect main with pull request reviews, stale approval dismissal, strict quality checks, conversation resolution, and administrator enforcement.",
       "source": {
         "document": "docs/quality-gates.md",
         "section": "10. Enforcement"

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -619,7 +619,6 @@
     {
       "check": {
         "config": {
-          "job": "quality",
           "path": ".github/workflows/quality.yml"
         },
         "kind": "github_workflow_pins"
@@ -631,8 +630,8 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "Full commit pins prevent upstream tag movement from changing trusted code.",
-      "remediation": "Pin every remote action and reusable workflow to a 40-character SHA.",
+      "rationale": "Full commit pins prevent upstream tag movement from changing trusted workflow code.",
+      "remediation": "Pin every remote action and reusable workflow in the quality workflow to a 40-character SHA.",
       "source": {
         "document": "docs/quality-gates.md",
         "section": "5. CI Pull Request Gates"

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -38,7 +38,7 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
     "branch_protection": ({"branch", "status_check", "minimum_reviews"}, set()),
     "repo_metadata": ({"path", "standard_major"}, set()),
     "github_workflow_permissions": ({"path", "job"}, set()),
-    "github_workflow_pins": ({"path", "job"}, set()),
+    "github_workflow_pins": ({"path"}, set()),
 }
 
 

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -35,7 +35,18 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
     "ruff_line_length": ({"path", "value"}, set()),
     "ruff_select": ({"path", "values"}, set()),
     "no_placeholders": ({"placeholders"}, set()),
-    "branch_protection": ({"branch", "status_check", "minimum_reviews"}, set()),
+    "branch_protection": (
+        {
+            "branch",
+            "required_status_checks",
+            "minimum_reviews",
+            "dismiss_stale_approvals",
+            "require_up_to_date",
+            "require_conversation_resolution",
+            "enforce_admins",
+        },
+        set(),
+    ),
     "repo_metadata": ({"path", "standard_major"}, set()),
     "github_workflow_permissions": ({"path", "job"}, set()),
     "github_workflow_pins": ({"path"}, set()),
@@ -209,7 +220,6 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         "pattern",
         "backend",
         "branch",
-        "status_check",
         "job",
         "trigger",
         "standard_major",
@@ -221,6 +231,7 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         "values",
         "paths",
         "required_select",
+        "required_status_checks",
         "allow_missing_profiles",
     ):
         if key in config:
@@ -236,8 +247,15 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         for token, field in placeholders.items():
             _string(token, f"{location}.placeholders key")
             _string(field, f"{location}.placeholders.{token}")
-    if "require_line_length" in config:
-        _boolean(config["require_line_length"], f"{location}.require_line_length")
+    for key in (
+        "require_line_length",
+        "dismiss_stale_approvals",
+        "require_up_to_date",
+        "require_conversation_resolution",
+        "enforce_admins",
+    ):
+        if key in config:
+            _boolean(config[key], f"{location}.{key}")
     for key in ("value", "minimum_reviews"):
         if key in config:
             _integer(config[key], f"{location}.{key}")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -219,6 +219,13 @@ def test_every_typed_check_kind_has_exactly_one_runtime_handler() -> None:
     assert set(CHECK_SCHEMAS) == set(CHECK_HANDLERS)
 
 
+def test_rsk021_policy_is_workflow_scoped() -> None:
+    assert POLICY.rule("RSK021").check.config == {
+        "path": ".github/workflows/quality.yml"
+    }
+    assert CHECK_SCHEMAS["github_workflow_pins"] == ({"path"}, set())
+
+
 def test_standard_package_version_and_source_distribution_inputs_agree() -> None:
     pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     pyproject = tomllib.loads(pyproject_text)
@@ -404,6 +411,7 @@ def test_sha_local_and_docker_action_references_are_accepted(tmp_path: Path) -> 
 def test_rsk021_scans_every_job_in_the_quality_workflow(tmp_path: Path) -> None:
     root = _minimal_repo(tmp_path)
     path = root / ".github" / "workflows" / "quality.yml"
+    sha = "b" * 40
     with path.open("a", encoding="utf-8") as stream:
         stream.write(
             "  auxiliary:\n"
@@ -412,6 +420,11 @@ def test_rsk021_scans_every_job_in_the_quality_workflow(tmp_path: Path) -> None:
             "      - uses: owner/tool@main\n"
         )
     assert "RSK021" in _rule_ids(check_repo(root, POLICY))
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("owner/tool@main", f"owner/tool@{sha}"),
+        encoding="utf-8",
+    )
+    assert "RSK021" not in _rule_ids(check_repo(root, POLICY))
 
 
 # --- pre-commit structure -------------------------------------------------

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -591,9 +591,7 @@ def _mock_branch_protection_query(
     ("mutate", "message"),
     [
         (
-            lambda response: response.update(
-                {"required_pull_request_reviews": None}
-            ),
+            lambda response: response.update({"required_pull_request_reviews": None}),
             "main does not require pull request reviews.",
         ),
         (
@@ -658,9 +656,7 @@ def test_fully_compliant_branch_protection_passes(
     _mock_branch_protection_query(
         monkeypatch, stdout=json.dumps(_compliant_branch_protection())
     )
-    assert "RSK014" not in _rule_ids(
-        check_repo(root, POLICY, include_platform=True)
-    )
+    assert "RSK014" not in _rule_ids(check_repo(root, POLICY, include_platform=True))
 
 
 def test_malformed_branch_protection_json_is_indeterminate(

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -226,6 +226,18 @@ def test_rsk021_policy_is_workflow_scoped() -> None:
     assert CHECK_SCHEMAS["github_workflow_pins"] == ({"path"}, set())
 
 
+def test_rsk014_policy_represents_every_required_protection_property() -> None:
+    assert POLICY.rule("RSK014").check.config == {
+        "branch": "main",
+        "required_status_checks": ["quality"],
+        "minimum_reviews": 1,
+        "dismiss_stale_approvals": True,
+        "require_up_to_date": True,
+        "require_conversation_resolution": True,
+        "enforce_admins": True,
+    }
+
+
 def test_standard_package_version_and_source_distribution_inputs_agree() -> None:
     pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     pyproject = tomllib.loads(pyproject_text)
@@ -421,7 +433,9 @@ def test_rsk021_scans_every_job_in_the_quality_workflow(tmp_path: Path) -> None:
         )
     assert "RSK021" in _rule_ids(check_repo(root, POLICY))
     path.write_text(
-        path.read_text(encoding="utf-8").replace("owner/tool@main", f"owner/tool@{sha}"),
+        path.read_text(encoding="utf-8").replace(
+            "owner/tool@main", f"owner/tool@{sha}"
+        ),
         encoding="utf-8",
     )
     assert "RSK021" not in _rule_ids(check_repo(root, POLICY))
@@ -526,6 +540,170 @@ def test_rule_applicability_filters_by_resolved_profile(tmp_path: Path) -> None:
 
 
 # --- exceptions, output, command errors, and dogfood ---------------------
+
+
+def _compliant_branch_protection() -> dict[str, object]:
+    return {
+        "required_pull_request_reviews": {
+            "required_approving_review_count": 1,
+            "dismiss_stale_reviews": True,
+        },
+        "required_status_checks": {"contexts": ["quality"], "strict": True},
+        "required_conversation_resolution": {"enabled": True},
+        "enforce_admins": {"enabled": True},
+    }
+
+
+def _mock_branch_protection_query(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> None:
+    def fake_run(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["git", "remote", "get-url"]:
+            return subprocess.CompletedProcess(
+                command, 0, "https://github.com/org/repo.git\n", ""
+            )
+        assert command[:2] == ["gh", "api"]
+        return subprocess.CompletedProcess(command, returncode, stdout, stderr)
+
+    monkeypatch.setattr(checks.subprocess, "run", fake_run)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda response: response.update(
+                {"required_pull_request_reviews": None}
+            ),
+            "main does not require pull request reviews.",
+        ),
+        (
+            lambda response: response["required_pull_request_reviews"].update(
+                {"required_approving_review_count": 0}
+            ),
+            "main requires too few approving reviews.",
+        ),
+        (
+            lambda response: response["required_pull_request_reviews"].update(
+                {"dismiss_stale_reviews": False}
+            ),
+            "main does not dismiss stale approvals.",
+        ),
+        (
+            lambda response: response["required_status_checks"].update(
+                {"contexts": []}
+            ),
+            "main omits required status checks: quality.",
+        ),
+        (
+            lambda response: response["required_status_checks"].update(
+                {"strict": False}
+            ),
+            "main does not require branches to be up to date.",
+        ),
+        (
+            lambda response: response["required_conversation_resolution"].update(
+                {"enabled": False}
+            ),
+            "main does not require conversation resolution.",
+        ),
+        (
+            lambda response: response["enforce_admins"].update({"enabled": False}),
+            "main allows administrator bypass.",
+        ),
+    ],
+)
+def test_each_required_branch_protection_property_is_enforced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Callable[[dict[str, object]], None],
+    message: str,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    response = _compliant_branch_protection()
+    mutate(response)
+    _mock_branch_protection_query(monkeypatch, stdout=json.dumps(response))
+    findings = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert [finding.message for finding in findings] == [message]
+    assert findings[0].status == "violation"
+
+
+def test_fully_compliant_branch_protection_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_branch_protection_query(
+        monkeypatch, stdout=json.dumps(_compliant_branch_protection())
+    )
+    assert "RSK014" not in _rule_ids(
+        check_repo(root, POLICY, include_platform=True)
+    )
+
+
+def test_malformed_branch_protection_json_is_indeterminate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_branch_protection_query(monkeypatch, stdout="{")
+    [finding] = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert finding.status == "indeterminate"
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "gh: authentication required (HTTP 401)",
+        "gh: failed to connect to api.github.com",
+        "gh: Resource not accessible by personal access token (HTTP 403)",
+    ],
+)
+def test_branch_protection_auth_and_network_failures_are_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stderr: str,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_branch_protection_query(monkeypatch, stderr=stderr, returncode=1)
+    [finding] = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert finding.status == "indeterminate"
+
+
+def test_unsupported_branch_protection_response_is_a_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_branch_protection_query(
+        monkeypatch,
+        stderr=(
+            "gh: Upgrade to GitHub Pro or make this repository public to enable "
+            "this feature. (HTTP 403)"
+        ),
+        returncode=1,
+    )
+    [finding] = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert finding.status == "violation"
 
 
 def test_only_known_nonempty_ignore_reasons_suppress(tmp_path: Path) -> None:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -215,6 +215,19 @@ def test_generated_policy_artifacts_are_current_and_deterministic() -> None:
     ) == render_reference(source)
 
 
+def test_quality_gates_uses_the_shared_normative_vocabulary() -> None:
+    text = (REPO_ROOT / "docs" / "quality-gates.md").read_text(encoding="utf-8")
+    assert "This document is part of the normative repository standard." in text
+    assert "it is not parsed to derive executable policy." in text
+    obsolete_wording = (
+        "This is a specification, not guidance",
+        "written differently from the rest of `docs/`",
+        "are guidance and use plain imperative voice instead",
+        "quality-gates is the only specification",
+    )
+    assert not any(phrase in text for phrase in obsolete_wording)
+
+
 def test_every_typed_check_kind_has_exactly_one_runtime_handler() -> None:
     assert set(CHECK_SCHEMAS) == set(CHECK_HANDLERS)
 


### PR DESCRIPTION
## Summary

- align RSK021's policy schema, checker traversal, tests, and documentation on workflow-wide immutable action and reusable-workflow pins
- expand RSK014's explicit policy configuration and platform checker to enforce every mandatory section 10 branch-protection property with property-specific findings
- preserve violation versus indeterminate evidence semantics for GitHub responses
- normalize the quality-gates preamble with the shared normative document hierarchy
- regenerate compiled policy and the normative policy reference

## Root cause

The v1 policy surfaces had drifted: RSK021 still carried a quality-job field despite workflow-wide traversal, RSK014 represented and checked only part of the normative branch-protection contract, and the quality-gates preamble retained the superseded single-specification vocabulary.

## Impact

Adopters now receive consistent policy, generated documentation, and runtime enforcement. Mutable remote references in any quality-workflow job fail RSK021. RSK014 reports each missing protection property independently and never treats unavailable or malformed platform evidence as success.

## Validation

- `uv sync --locked`
- `uv run pre-commit run --all-files`
- `uv run pytest` — 127 passed
- `uv build`
- `uv run repo-check .`
- focused cross-layer audit for RSK006, RSK007, RSK014, RSK019, RSK020, and RSK021
- fresh `python-single` and `python-workspace` bootstraps:
  - explicit profile metadata verified
  - `contents: read` and full-SHA Actions pins verified
  - repo-check exited successfully (only the intentional non-blocking RSK018 license placeholder remained)
  - workflow-equivalent sync, pre-commit, pytest, and applicable build commands passed

Before the `v1.0.0` tag exists, the generated pre-commit hook cannot fetch that release ref. For the pre-tag execution check only, the temporary generated repositories used local commit `afd6f9b` as the hook source; the committed starter remains pinned to `v1.0.0`, and tests verify that pin matches the package version.

## Live enforcement evidence

`uv run repo-check . --check-enforcement` successfully queried GitHub and found five real settings gaps on `main`:

- approving reviews: 0, expected at least 1
- stale approval dismissal: disabled
- required `quality` status check: absent
- conversation resolution: disabled
- administrator enforcement: disabled

These repository settings must be configured before tagging v1.0.0; this PR intentionally does not mutate them.