### PR TITLE
fix(release): harden v1 enforcement checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,10 +58,10 @@ Run from repository root:
 3. `uv run pytest`
 4. `uv build`
 
-The quality workflow must grant effective `contents: read` permission with no
-write permissions, and pin every remote action or reusable workflow to a full
-40-character commit SHA. Keep version comments and GitHub Actions Dependabot
-configuration so those pins remain maintainable.
+The quality job's effective permissions must be exactly `contents: read`, and
+every remote action or reusable workflow must be pinned to a full 40-character
+commit SHA. Keep version comments and GitHub Actions Dependabot configuration
+so those pins remain maintainable.
 
 This is exactly the chain in `docs/quality-gates.md`; this repository adds no
 gates of its own. Bootstrap behavior needs no separate manual step — `uv run

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -141,9 +141,10 @@ remediation. Markdown explains policy but supplies no executable values.
   `pass_filenames`.
 - AGENTS.md remains a heading and literal-contract check. There is no
   subjective prose scoring.
-- RSK020 evaluates the quality job's effective permissions. RSK021 requires
-  full SHA pins for remote actions and reusable workflows in every job in the
-  quality workflow; local and Docker actions are exempt.
+- RSK020 requires the quality job's effective permissions to exactly match the
+  policy-owned `contents: read` mapping; extra read scopes and all write scopes
+  fail. RSK021 requires full SHA pins for remote actions and reusable workflows
+  in every job in the quality workflow; local and Docker actions are exempt.
 - RSK014 checks pull request reviews, stale approval dismissal, required status
   checks, strict up-to-date branches, conversation resolution, and
   administrator enforcement when platform checks are requested. If classic

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -15,7 +15,8 @@ Options:
 
 - `--format text|json` selects human-readable or stable machine output.
 - `--profile auto|python-single|python-workspace` selects an explicit override.
-- `--check-enforcement` also queries branch protection for RSK014.
+- `--check-enforcement` also queries classic branch protection or effective
+  active rulesets for RSK014.
 - `--strict` promotes recommended findings to failures.
 
 Exit code `0` means no blocking findings. Exit code `1` means a required rule
@@ -145,7 +146,9 @@ remediation. Markdown explains policy but supplies no executable values.
   quality workflow; local and Docker actions are exempt.
 - RSK014 checks pull request reviews, stale approval dismissal, required status
   checks, strict up-to-date branches, conversation resolution, and
-  administrator enforcement when platform checks are requested.
+  administrator enforcement when platform checks are requested. If classic
+  branch protection is absent, it evaluates active repository and organization
+  rulesets and requires visible, empty bypass actor lists.
 
 ## What This Cannot Check
 

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -250,9 +250,9 @@ Remediation: Add tool.repo-standard with a valid profile and standard = "1".
 - Enforcement: `structural`
 - Check kind: `github_workflow_permissions`
 
-Rationale: Quality checks need source read access and no repository write access.
+Rationale: The quality job only needs read access to repository contents; additional token scopes increase blast radius without supporting the gate chain.
 
-Remediation: Set effective quality-job permissions to contents read with no writes.
+Remediation: Set the quality job's effective permissions to exactly `contents: read`.
 
 ### RSK021: Quality workflow pins remote actions immutably
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -115,11 +115,21 @@ inside a shell-wrapper string do not count. Whitespace, comments, multiline
 commands, and equivalent command formatting are normalized before comparison.
 
 RSK020 enforces at the **required** level that the quality job's effective
-permissions include `contents: read` and no write permission. RSK021 enforces
-at the **required** level that every remote action and reusable workflow
-referenced by the quality workflow is pinned to a full 40-character commit
-SHA. Local `./` actions and `docker://` references are exempt. Keep a version
-comment next to each SHA so Dependabot updates remain understandable.
+`GITHUB_TOKEN` permissions are exactly:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Additional read or write scopes are not permitted unless the policy is
+deliberately changed in a future standard version. Job-level permissions
+override workflow-level permissions, so RSK020 evaluates the effective
+configuration for the `quality` job. RSK021 enforces at the **required** level
+that every remote action and reusable workflow referenced by the quality
+workflow is pinned to a full 40-character commit SHA. Local `./` actions and
+`docker://` references are exempt. Keep a version comment next to each SHA so
+Dependabot updates remain understandable.
 
 ### Environment reproducibility
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -269,9 +269,10 @@ Every repository adopting this specification shall protect `main` so the
 mandatory gates are binding rather than advisory.
 
 RSK014 checks this platform configuration at the **required** level only when
-`--check-enforcement` is explicitly requested. If the platform command cannot
-run or its response cannot be interpreted, `repo-check` returns an
-indeterminate command error; it never treats unavailable evidence as a pass.
+`--check-enforcement` is explicitly requested. It accepts classic branch
+protection or active repository and organization rulesets. If a platform
+command cannot run or its response cannot be interpreted, `repo-check` returns
+an indeterminate command error; it never treats unavailable evidence as a pass.
 
 ### Platform prerequisite
 
@@ -296,7 +297,8 @@ settle later. Public repositories have branch protection on every plan.
 
 ### Required branch protection
 
-On GitHub, protect `main` with:
+On GitHub, protect `main` with classic branch protection or active rulesets
+that enforce:
 
 - **Require a pull request before merging**, with at least one approving
   review and stale approvals dismissed on new commits.
@@ -306,6 +308,12 @@ On GitHub, protect `main` with:
 - **Require conversation resolution before merging**.
 - **Do not allow bypassing the above settings**, including for repository
   administrators.
+
+For rulesets, leave the bypass actor list empty. RSK014 evaluates all active
+rules returned for `main`, follows their repository or organization ruleset
+IDs, and verifies the detailed bypass actor lists. GitHub omits bypass actors
+when the caller cannot inspect them; that response is indeterminate, not a
+pass.
 
 A status check becomes selectable only after the workflow has run at least
 once, so open an initial pull request before configuring protection.
@@ -325,6 +333,19 @@ gh api repos/<owner>/<repo>/branches/main/protection \
 The `quality` check shall appear in `checks`, `reviews` shall be at least `1`,
 and `strict`, `dismiss_stale`, `conversation_resolution`, and `enforce_admins`
 shall all be `true`.
+
+When the classic endpoint reports `Branch not protected`, inspect the effective
+active rulesets instead:
+
+```bash
+gh api --paginate repos/<owner>/<repo>/rules/branches/main
+gh api repos/<owner>/<repo>/rulesets/<ruleset-id>
+```
+
+The effective rules shall provide the same review, status-check, strictness,
+and conversation-resolution settings, and every contributing ruleset shall
+have an empty `bypass_actors` list. Organization-owned rulesets use
+`gh api orgs/<organization>/rulesets/<ruleset-id>` for the detail query.
 
 A `403` response carrying the documented upgrade message means the repository
 is on a plan that does not support branch protection; see the platform

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -388,8 +388,13 @@ rules:
       config:
         path: .github/workflows/quality.yml
         job: quality
-    rationale: Quality checks need source read access and no repository write access.
-    remediation: Set effective quality-job permissions to contents read with no writes.
+        permissions:
+          contents: read
+    rationale: >-
+      The quality job only needs read access to repository contents; additional
+      token scopes increase blast radius without supporting the gate chain.
+    remediation: >-
+      Set the quality job's effective permissions to exactly `contents: read`.
 
   - id: RSK021
     title: Quality workflow pins remote actions immutably

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -673,6 +673,273 @@ def _git_remote_url(root: Path) -> str | None:
     return result.stdout.strip() or None
 
 
+def _gh_api(
+    context: CheckContext, endpoint: str, *, paginate: bool = False
+) -> tuple[subprocess.CompletedProcess[str] | None, Issue | None]:
+    command = ["gh", "api"]
+    if paginate:
+        command.extend(("--paginate", "--slurp"))
+    command.append(endpoint)
+    try:
+        result = subprocess.run(
+            command,
+            cwd=context.root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+        return None, (
+            Issue(
+                ".",
+                f"Platform command unavailable: {error}",
+                None,
+                "GitHub enforcement response",
+                status="indeterminate",
+            )
+        )
+    return result, None
+
+
+def _platform_query_failure(
+    message: str, stderr: str, expected: Any, *, unsupported_is_violation: bool = True
+) -> Issue:
+    unsupported = unsupported_is_violation and re.search(
+        r"upgrade to github pro|branch protection (?:is )?not available",
+        stderr,
+        re.IGNORECASE,
+    )
+    return Issue(
+        ".",
+        f"{message}: {stderr}",
+        stderr,
+        expected,
+        status="violation" if unsupported else "indeterminate",
+    )
+
+
+def _json_response(
+    result: subprocess.CompletedProcess[str], expected: str
+) -> tuple[Any | None, Issue | None]:
+    try:
+        return json.loads(result.stdout), None
+    except json.JSONDecodeError as error:
+        return None, (
+            Issue(
+                ".",
+                f"Platform response was not JSON: {error}",
+                result.stdout,
+                expected,
+                status="indeterminate",
+            )
+        )
+
+
+def _ruleset_detail_endpoint(
+    owner_repo: str, source_type: str, source: str, ruleset_id: int
+) -> str | None:
+    if source_type == "Repository":
+        repository = source if "/" in source else owner_repo
+        return f"repos/{repository}/rulesets/{ruleset_id}"
+    if source_type == "Organization":
+        return f"orgs/{source}/rulesets/{ruleset_id}"
+    return None
+
+
+def _ruleset_branch_protection(
+    context: CheckContext, owner_repo: str, config: dict[str, Any]
+) -> list[Issue]:
+    endpoint = f"repos/{owner_repo}/rules/branches/{config['branch']}"
+    result, error = _gh_api(context, endpoint, paginate=True)
+    if error is not None:
+        return [error]
+    assert result is not None
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        return [
+            _platform_query_failure(
+                "Ruleset query failed",
+                stderr,
+                "effective rules for branch",
+            )
+        ]
+    pages, error = _json_response(result, "paginated ruleset response")
+    if error is not None:
+        return [error]
+    if not isinstance(pages, list) or not all(isinstance(page, list) for page in pages):
+        return [
+            Issue(
+                ".",
+                "Effective rules response was not a paginated list.",
+                pages,
+                "list of rule pages",
+                status="indeterminate",
+            )
+        ]
+
+    rules = [rule for page in pages for rule in page]
+    relevant_rules: list[dict[str, Any]] = []
+    ruleset_sources: set[tuple[str, str, int]] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            return [
+                Issue(
+                    ".",
+                    "Could not interpret an effective ruleset rule.",
+                    rule,
+                    "rule object",
+                    status="indeterminate",
+                )
+            ]
+        if rule.get("type") not in {"pull_request", "required_status_checks"}:
+            continue
+        parameters = rule.get("parameters")
+        source_type = rule.get("ruleset_source_type")
+        source = rule.get("ruleset_source")
+        ruleset_id = rule.get("ruleset_id")
+        if (
+            not isinstance(parameters, dict)
+            or not isinstance(source_type, str)
+            or not isinstance(source, str)
+            or isinstance(ruleset_id, bool)
+            or not isinstance(ruleset_id, int)
+        ):
+            return [
+                Issue(
+                    ".",
+                    "Could not interpret effective ruleset metadata.",
+                    rule,
+                    "rule parameters and source metadata",
+                    status="indeterminate",
+                )
+            ]
+        relevant_rules.append(rule)
+        ruleset_sources.add((source_type, source, ruleset_id))
+
+    bypass_actors: list[Any] = []
+    for source_type, source, ruleset_id in sorted(ruleset_sources):
+        detail_endpoint = _ruleset_detail_endpoint(
+            owner_repo, source_type, source, ruleset_id
+        )
+        if detail_endpoint is None:
+            return [
+                Issue(
+                    ".",
+                    f"Unsupported ruleset source type: {source_type}.",
+                    source_type,
+                    "Repository or Organization",
+                    status="indeterminate",
+                )
+            ]
+        detail_result, detail_error = _gh_api(context, detail_endpoint)
+        if detail_error is not None:
+            return [detail_error]
+        assert detail_result is not None
+        if detail_result.returncode != 0:
+            stderr = detail_result.stderr.strip()
+            return [
+                _platform_query_failure(
+                    "Ruleset detail query failed",
+                    stderr,
+                    "ruleset bypass actors",
+                    unsupported_is_violation=False,
+                )
+            ]
+        detail, detail_error = _json_response(detail_result, "ruleset detail response")
+        if detail_error is not None:
+            return [detail_error]
+        actors = detail.get("bypass_actors") if isinstance(detail, dict) else None
+        if not isinstance(actors, list):
+            return [
+                Issue(
+                    ".",
+                    "Could not obtain ruleset bypass actors.",
+                    actors,
+                    "bypass actor list",
+                    status="indeterminate",
+                )
+            ]
+        bypass_actors.extend(actors)
+
+    pull_request_rules = [
+        rule for rule in relevant_rules if rule["type"] == "pull_request"
+    ]
+    status_check_rules = [
+        rule for rule in relevant_rules if rule["type"] == "required_status_checks"
+    ]
+    review_counts: list[int] = []
+    dismiss_stale: list[bool] = []
+    conversation_resolution: list[bool] = []
+    for rule in pull_request_rules:
+        parameters = rule["parameters"]
+        reviews = parameters.get("required_approving_review_count")
+        stale = parameters.get("dismiss_stale_reviews_on_push")
+        resolution = parameters.get("required_review_thread_resolution")
+        if (
+            isinstance(reviews, bool)
+            or not isinstance(reviews, int)
+            or not isinstance(stale, bool)
+            or not isinstance(resolution, bool)
+        ):
+            return [
+                Issue(
+                    ".",
+                    "Could not interpret pull request ruleset parameters.",
+                    parameters,
+                    "review count, stale dismissal, and thread resolution",
+                    status="indeterminate",
+                )
+            ]
+        review_counts.append(reviews)
+        dismiss_stale.append(stale)
+        conversation_resolution.append(resolution)
+
+    contexts: set[str] = set()
+    strict_checks: list[bool] = []
+    for rule in status_check_rules:
+        parameters = rule["parameters"]
+        checks = parameters.get("required_status_checks")
+        strict = parameters.get("strict_required_status_checks_policy")
+        if (
+            not isinstance(checks, list)
+            or not isinstance(strict, bool)
+            or not all(
+                isinstance(check, dict) and isinstance(check.get("context"), str)
+                for check in checks
+            )
+        ):
+            return [
+                Issue(
+                    ".",
+                    "Could not interpret required status check ruleset parameters.",
+                    parameters,
+                    "status check contexts and strict policy",
+                    status="indeterminate",
+                )
+            ]
+        contexts.update(check["context"] for check in checks)
+        strict_checks.append(strict)
+
+    protection = {
+        "required_pull_request_reviews": (
+            {
+                "required_approving_review_count": max(review_counts),
+                "dismiss_stale_reviews": any(dismiss_stale),
+            }
+            if review_counts
+            else None
+        ),
+        "required_status_checks": (
+            {"contexts": sorted(contexts), "strict": any(strict_checks)}
+            if strict_checks
+            else None
+        ),
+        "required_conversation_resolution": {"enabled": any(conversation_resolution)},
+        "enforce_admins": {"enabled": not bypass_actors and bool(relevant_rules)},
+    }
+    return _branch_protection_issues(protection, config)
+
+
 def _branch_protection(context: CheckContext, config: dict[str, Any]) -> list[Issue]:
     remote = _git_remote_url(context.root)
     match = _GITHUB_REMOTE_PATTERN.search(remote) if remote else None
@@ -686,57 +953,24 @@ def _branch_protection(context: CheckContext, config: dict[str, Any]) -> list[Is
                 status="indeterminate",
             )
         ]
-    endpoint = (
-        f"repos/{match.group('owner_repo')}/branches/{config['branch']}/protection"
-    )
-    try:
-        result = subprocess.run(
-            ["gh", "api", endpoint],
-            cwd=context.root,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as error:
-        return [
-            Issue(
-                ".",
-                f"Platform command unavailable: {error}",
-                None,
-                "branch protection response",
-                status="indeterminate",
-            )
-        ]
+    owner_repo = match.group("owner_repo")
+    endpoint = f"repos/{owner_repo}/branches/{config['branch']}/protection"
+    result, error = _gh_api(context, endpoint)
+    if error is not None:
+        return [error]
+    assert result is not None
     if result.returncode != 0:
         stderr = result.stderr.strip()
-        unsupported = re.search(
-            r"branch not protected|upgrade to github pro|"
-            r"branch protection (?:is )?not available",
-            stderr,
-            re.IGNORECASE,
-        )
-        status = "violation" if unsupported else "indeterminate"
+        if re.search(r"branch not protected", stderr, re.IGNORECASE):
+            return _ruleset_branch_protection(context, owner_repo, config)
         return [
-            Issue(
-                ".",
-                f"Branch protection query failed: {stderr}",
-                stderr,
-                "configured protection",
-                status=status,
+            _platform_query_failure(
+                "Branch protection query failed", stderr, "configured protection"
             )
         ]
-    try:
-        protection = json.loads(result.stdout)
-    except json.JSONDecodeError as error:
-        return [
-            Issue(
-                ".",
-                f"Platform response was not JSON: {error}",
-                result.stdout,
-                "JSON response",
-                status="indeterminate",
-            )
-        ]
+    protection, error = _json_response(result, "branch protection response")
+    if error is not None:
+        return [error]
     if not isinstance(protection, dict):
         return [
             Issue(
@@ -747,6 +981,12 @@ def _branch_protection(context: CheckContext, config: dict[str, Any]) -> list[Is
                 status="indeterminate",
             )
         ]
+    return _branch_protection_issues(protection, config)
+
+
+def _branch_protection_issues(
+    protection: dict[str, Any], config: dict[str, Any]
+) -> list[Issue]:
 
     branch = config["branch"]
     issues: list[Issue] = []

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -1211,12 +1211,8 @@ def _github_workflow_permissions(
     assert job is not None
     assert isinstance(document.data, dict)
     permissions = _effective_permissions(document.data, job)
-    valid = permissions == "read-all" or (
-        isinstance(permissions, dict)
-        and permissions.get("contents") == "read"
-        and not any(value == "write" for value in permissions.values())
-    )
-    if valid:
+    expected = config["permissions"]
+    if permissions == expected:
         return []
     line = document.line("jobs", config["job"], "permissions") or document.line(
         "permissions"
@@ -1224,9 +1220,9 @@ def _github_workflow_permissions(
     return [
         Issue(
             config["path"],
-            "Quality job permissions are not least privilege.",
+            "Quality job permissions do not match the least-privilege policy.",
             permissions,
-            {"contents": "read", "writes": "none"},
+            expected,
             line,
         )
     ]

--- a/src/repo_standard/compliance/cli.py
+++ b/src/repo_standard/compliance/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from repo_standard.compliance.checks import Finding, check_repo, load_policy
 
-_GREEN = "\033[32m"
+_POSITIVE = "\033[38;2;35;209;111m"
 _RESET = "\033[0m"
 
 
@@ -60,7 +60,7 @@ def _supports_color() -> bool:
 def _format_text(findings: list[Finding], *, color: bool) -> str:
     if not findings:
         message = "All checks passed!"
-        return f"{_GREEN}{message}{_RESET}\n" if color else f"{message}\n"
+        return f"{_POSITIVE}{message}{_RESET}\n" if color else f"{message}\n"
     lines = []
     for finding in findings:
         location = finding.path + (

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -603,7 +603,10 @@
       "check": {
         "config": {
           "job": "quality",
-          "path": ".github/workflows/quality.yml"
+          "path": ".github/workflows/quality.yml",
+          "permissions": {
+            "contents": "read"
+          }
         },
         "kind": "github_workflow_permissions"
       },
@@ -614,8 +617,8 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "Quality checks need source read access and no repository write access.",
-      "remediation": "Set effective quality-job permissions to contents read with no writes.",
+      "rationale": "The quality job only needs read access to repository contents; additional token scopes increase blast radius without supporting the gate chain.",
+      "remediation": "Set the quality job's effective permissions to exactly `contents: read`.",
       "source": {
         "document": "docs/quality-gates.md",
         "section": "5. CI Pull Request Gates"

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -16,6 +16,7 @@ COMPILED_POLICY_PATH = Path(__file__).resolve().parent / "compiled.json"
 LEVELS = {"required", "recommended"}
 ENFORCEMENT_MODES = {"structural", "platform"}
 MARKER_KINDS = {"file", "directory"}
+GITHUB_PERMISSION_VALUES = {"none", "read", "write"}
 
 # Each check kind owns its accepted configuration keys. Required keys are the
 # first set; optional keys are the second. Value-level validation follows in
@@ -48,7 +49,7 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
         set(),
     ),
     "repo_metadata": ({"path", "standard_major"}, set()),
-    "github_workflow_permissions": ({"path", "job"}, set()),
+    "github_workflow_permissions": ({"path", "job", "permissions"}, set()),
     "github_workflow_pins": ({"path"}, set()),
 }
 
@@ -247,6 +248,18 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         for token, field in placeholders.items():
             _string(token, f"{location}.placeholders key")
             _string(field, f"{location}.placeholders.{token}")
+    if "permissions" in config:
+        permissions = _mapping(config["permissions"], f"{location}.permissions")
+        if not permissions:
+            _fail(f"{location}.permissions", "expected a non-empty mapping")
+        for scope, value in permissions.items():
+            _string(scope, f"{location}.permissions key")
+            permission = _string(value, f"{location}.permissions.{scope}")
+            if permission not in GITHUB_PERMISSION_VALUES:
+                _fail(
+                    f"{location}.permissions.{scope}",
+                    f"unsupported permission value {permission!r}",
+                )
     for key in (
         "require_line_length",
         "dismiss_stale_approvals",

--- a/src/repo_standard/starter_kits/python-single/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-single/AGENTS.md
@@ -51,10 +51,10 @@ Run from repo root:
 3. `uv run pytest`
 4. `uv build`
 
-The quality workflow must grant effective `contents: read` permission with no
-write permissions, and pin every remote action or reusable workflow to a full
-40-character commit SHA. Keep version comments and GitHub Actions Dependabot
-configuration so those pins remain maintainable.
+The quality job's effective permissions must be exactly `contents: read`, and
+every remote action or reusable workflow must be pinned to a full 40-character
+commit SHA. Keep version comments and GitHub Actions Dependabot configuration
+so those pins remain maintainable.
 
 ## Coding Standards
 

--- a/src/repo_standard/starter_kits/python-workspace/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-workspace/AGENTS.md
@@ -53,10 +53,10 @@ Run from repo root:
 3. `uv run pytest`
 4. `uv build`
 
-The quality workflow must grant effective `contents: read` permission with no
-write permissions, and pin every remote action or reusable workflow to a full
-40-character commit SHA. Keep version comments and GitHub Actions Dependabot
-configuration so those pins remain maintainable.
+The quality job's effective permissions must be exactly `contents: read`, and
+every remote action or reusable workflow must be pinned to a full 40-character
+commit SHA. Keep version comments and GitHub Actions Dependabot configuration
+so those pins remain maintainable.
 
 ## Coding Standards
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -50,10 +50,10 @@ Run from repo root:
 3. `uv run pytest`
 4. `uv build`
 
-The quality workflow must grant effective `contents: read` permission with no
-write permissions, and pin every remote action or reusable workflow to a full
-40-character commit SHA. Keep version comments and GitHub Actions Dependabot
-configuration so those pins remain maintainable.
+The quality job's effective permissions must be exactly `contents: read`, and
+every remote action or reusable workflow must be pinned to a full 40-character
+commit SHA. Keep version comments and GitHub Actions Dependabot configuration
+so those pins remain maintainable.
 
 ## Coding Standards
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -986,6 +986,12 @@ def test_json_output_retains_legacy_fields_and_adds_actionable_fields(
     } <= item.keys()
 
 
+def test_success_output_uses_positive_brand_color() -> None:
+    assert cli._format_text([], color=True) == (
+        "\033[38;2;35;209;111mAll checks passed!\033[0m\n"
+    )
+
+
 def test_strict_mode_only_promotes_recommended_findings(tmp_path: Path) -> None:
     root = _minimal_repo(tmp_path)
     (root / "docs" / "adr").rmdir()

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -10,6 +10,7 @@ import tomllib
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -587,6 +588,88 @@ def _mock_branch_protection_query(
     monkeypatch.setattr(checks.subprocess, "run", fake_run)
 
 
+def _compliant_ruleset_rules(
+    *, source_type: str = "Repository", source: str = "org/repo"
+) -> list[dict[str, Any]]:
+    metadata = {
+        "ruleset_source_type": source_type,
+        "ruleset_source": source,
+        "ruleset_id": 42,
+    }
+    return [
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 1,
+                "dismiss_stale_reviews_on_push": True,
+                "required_review_thread_resolution": True,
+            },
+            **metadata,
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": [{"context": "quality"}],
+            },
+            **metadata,
+        },
+    ]
+
+
+def _mock_ruleset_queries(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    rules: list[dict[str, Any]] | None = None,
+    bypass_actors: list[dict[str, Any]] | None = None,
+    rules_stdout: str | None = None,
+    rules_stderr: str = "",
+    rules_returncode: int = 0,
+    detail_stdout: str | None = None,
+    detail_stderr: str = "",
+    detail_returncode: int = 0,
+) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["git", "remote", "get-url"]:
+            return subprocess.CompletedProcess(
+                command, 0, "https://github.com/org/repo.git\n", ""
+            )
+        assert command[:2] == ["gh", "api"]
+        endpoint = command[-1]
+        if endpoint.endswith("/branches/main/protection"):
+            return subprocess.CompletedProcess(
+                command, 1, "", "gh: Branch not protected (HTTP 404)"
+            )
+        if "/rules/branches/main" in endpoint:
+            stdout = (
+                rules_stdout
+                if rules_stdout is not None
+                else json.dumps([rules if rules is not None else []])
+            )
+            return subprocess.CompletedProcess(
+                command, rules_returncode, stdout, rules_stderr
+            )
+        assert "/rulesets/42" in endpoint
+        stdout = (
+            detail_stdout
+            if detail_stdout is not None
+            else json.dumps(
+                {"bypass_actors": bypass_actors if bypass_actors is not None else []}
+            )
+        )
+        return subprocess.CompletedProcess(
+            command, detail_returncode, stdout, detail_stderr
+        )
+
+    monkeypatch.setattr(checks.subprocess, "run", fake_run)
+    return calls
+
+
 @pytest.mark.parametrize(
     ("mutate", "message"),
     [
@@ -657,6 +740,156 @@ def test_fully_compliant_branch_protection_passes(
         monkeypatch, stdout=json.dumps(_compliant_branch_protection())
     )
     assert "RSK014" not in _rule_ids(check_repo(root, POLICY, include_platform=True))
+
+
+def test_fully_compliant_repository_ruleset_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    calls = _mock_ruleset_queries(monkeypatch, rules=_compliant_ruleset_rules())
+    assert "RSK014" not in _rule_ids(check_repo(root, POLICY, include_platform=True))
+    assert ["gh", "api", "--paginate", "--slurp"] == calls[2][:4]
+    assert calls[3][-1] == "repos/org/repo/rulesets/42"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda rules: rules[0]["parameters"].update(
+                {"required_approving_review_count": 0}
+            ),
+            "main requires too few approving reviews.",
+        ),
+        (
+            lambda rules: rules[0]["parameters"].update(
+                {"dismiss_stale_reviews_on_push": False}
+            ),
+            "main does not dismiss stale approvals.",
+        ),
+        (
+            lambda rules: rules[1]["parameters"].update({"required_status_checks": []}),
+            "main omits required status checks: quality.",
+        ),
+        (
+            lambda rules: rules[1]["parameters"].update(
+                {"strict_required_status_checks_policy": False}
+            ),
+            "main does not require branches to be up to date.",
+        ),
+        (
+            lambda rules: rules[0]["parameters"].update(
+                {"required_review_thread_resolution": False}
+            ),
+            "main does not require conversation resolution.",
+        ),
+    ],
+)
+def test_each_required_ruleset_property_is_enforced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Callable[[list[dict[str, Any]]], None],
+    message: str,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    rules = _compliant_ruleset_rules()
+    mutate(rules)
+    _mock_ruleset_queries(monkeypatch, rules=rules)
+    findings = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert [finding.message for finding in findings] == [message]
+    assert findings[0].status == "violation"
+
+
+def test_ruleset_bypass_actor_reports_admin_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_ruleset_queries(
+        monkeypatch,
+        rules=_compliant_ruleset_rules(),
+        bypass_actors=[
+            {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+        ],
+    )
+    findings = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert [finding.message for finding in findings] == [
+        "main allows administrator bypass."
+    ]
+
+
+def test_organization_ruleset_uses_organization_detail_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    calls = _mock_ruleset_queries(
+        monkeypatch,
+        rules=_compliant_ruleset_rules(source_type="Organization", source="org"),
+    )
+    assert "RSK014" not in _rule_ids(check_repo(root, POLICY, include_platform=True))
+    assert calls[3][-1] == "orgs/org/rulesets/42"
+
+
+def test_missing_ruleset_bypass_evidence_is_indeterminate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_ruleset_queries(
+        monkeypatch,
+        rules=_compliant_ruleset_rules(),
+        detail_stdout=json.dumps({}),
+    )
+    [finding] = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert finding.status == "indeterminate"
+    assert finding.message == "Could not obtain ruleset bypass actors."
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "rules_returncode": 1,
+                "rules_stderr": "gh: failed to connect to api.github.com",
+            },
+            "Ruleset query failed",
+        ),
+        ({"rules_stdout": "{}"}, "Effective rules response was not a paginated list."),
+        (
+            {
+                "detail_returncode": 1,
+                "detail_stderr": "gh: Resource not accessible (HTTP 403)",
+            },
+            "Ruleset detail query failed",
+        ),
+    ],
+)
+def test_unavailable_or_malformed_ruleset_evidence_is_indeterminate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs: dict[str, Any],
+    message: str,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _mock_ruleset_queries(monkeypatch, rules=_compliant_ruleset_rules(), **kwargs)
+    [finding] = [
+        finding
+        for finding in check_repo(root, POLICY, include_platform=True)
+        if finding.rule_id == "RSK014"
+    ]
+    assert finding.status == "indeterminate"
+    assert message in finding.message
 
 
 def test_malformed_branch_protection_json_is_indeterminate(

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -240,6 +240,42 @@ def test_rsk021_policy_is_workflow_scoped() -> None:
     assert CHECK_SCHEMAS["github_workflow_pins"] == ({"path"}, set())
 
 
+def test_rsk020_policy_defines_exact_effective_permissions() -> None:
+    assert POLICY.rule("RSK020").check.config == {
+        "path": ".github/workflows/quality.yml",
+        "job": "quality",
+        "permissions": {"contents": "read"},
+    }
+    assert CHECK_SCHEMAS["github_workflow_permissions"] == (
+        {"path", "job", "permissions"},
+        set(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("permissions", "message"),
+    [
+        ("read-all", "expected a mapping with string keys"),
+        ({}, "expected a non-empty mapping"),
+        ({"contents": "execute"}, "unsupported permission value"),
+    ],
+)
+def test_invalid_rsk020_policy_permissions_are_rejected(
+    tmp_path: Path, permissions: object, message: str
+) -> None:
+    root = _policy_checkout(tmp_path)
+
+    def mutation(data: dict[str, object]) -> None:
+        rules = data["rules"]
+        assert isinstance(rules, list)
+        rule = next(item for item in rules if item["id"] == "RSK020")
+        rule["check"]["config"]["permissions"] = permissions
+
+    _mutate_base(root, mutation)
+    with pytest.raises(PolicyError, match=message):
+        load_source_policy(root)
+
+
 def test_rsk014_policy_represents_every_required_protection_property() -> None:
     assert POLICY.rule("RSK014").check.config == {
         "branch": "main",
@@ -376,7 +412,9 @@ def test_multiline_complete_command_is_accepted(tmp_path: Path) -> None:
     assert "RSK006" not in _rule_ids(check_repo(root, POLICY))
 
 
-def test_job_permissions_override_workflow_permissions(tmp_path: Path) -> None:
+def test_exact_job_permissions_override_broader_workflow_permissions(
+    tmp_path: Path,
+) -> None:
     root = _minimal_repo(tmp_path)
     path = root / ".github" / "workflows" / "quality.yml"
     text = (
@@ -394,17 +432,57 @@ def test_job_permissions_override_workflow_permissions(tmp_path: Path) -> None:
     assert "RSK020" not in _rule_ids(check_repo(root, POLICY))
 
 
-def test_missing_or_write_permissions_report_rsk020(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("mutation", "actual"),
+    [
+        (
+            lambda text: text.replace(
+                "permissions:\n  contents: read\n", "permissions: read-all\n"
+            ),
+            "read-all",
+        ),
+        (
+            lambda text: text.replace(
+                "  contents: read", "  contents: read\n  issues: read"
+            ),
+            {"contents": "read", "issues": "read"},
+        ),
+        (
+            lambda text: text.replace("  contents: read", "  contents: write"),
+            {"contents": "write"},
+        ),
+        (
+            lambda text: text.replace("permissions:\n  contents: read\n", ""),
+            None,
+        ),
+        (
+            lambda text: text.replace(
+                "  quality:\n    runs-on:",
+                "  quality:\n"
+                "    permissions:\n"
+                "      contents: read\n"
+                "      pull-requests: read\n"
+                "    runs-on:",
+            ),
+            {"contents": "read", "pull-requests": "read"},
+        ),
+    ],
+)
+def test_nonminimal_effective_permissions_report_rsk020(
+    tmp_path: Path, mutation: Callable[[str], str], actual: object
+) -> None:
     root = _minimal_repo(tmp_path)
     path = root / ".github" / "workflows" / "quality.yml"
-    path.write_text(
-        path.read_text(encoding="utf-8").replace(
-            "  contents: read", "  contents: write"
-        ),
-        encoding="utf-8",
-    )
+    path.write_text(mutation(path.read_text(encoding="utf-8")), encoding="utf-8")
     finding = next(f for f in check_repo(root, POLICY) if f.rule_id == "RSK020")
-    assert finding.line is not None
+    assert finding.message == (
+        "Quality job permissions do not match the least-privilege policy."
+    )
+    assert finding.actual == actual
+    assert finding.expected == {"contents": "read"}
+    assert finding.remediation == (
+        "Set the quality job's effective permissions to exactly `contents: read`."
+    )
 
 
 def test_mutable_remote_action_reports_rsk021_at_node_line(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- support active repository and organization rulesets as RSK014 branch-protection evidence
- make RSK020 policy-driven and require effective quality-job permissions to be exactly `contents: read`
- render successful `repo-check` output with the positive `#23D16F` color
- align normative docs, generated policy artifacts, templates, starter guidance, and regression coverage

## Root causes

RSK014 queried only GitHub's classic branch-protection endpoint, so equivalent ruleset enforcement appeared unprotected. RSK020 accepted `read-all` and additional read scopes, enforcing read-only access rather than the least-privilege contract named by the rule.

## Validation

- `uv sync --locked`
- `uv run pre-commit run --all-files`
- `uv run pytest -p no:cacheprovider --basetemp .tmp/pytest-rsk020-final` — 148 passed
- `uv build`
- `uv run repo-check .`

The test suite bootstraps and checks both `python-single` and `python-workspace`; their workflow permissions already use the exact minimal mapping.