### PR TITLE
Phase 2: generate every reference document from the shape (#42)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,8 @@ repos:
         entry: uv run pymarkdown --config .pymarkdown.json scan
         language: system
         types: [markdown]
+        # templates/content/ holds prose fragments, not documents: they have no
+        # title of their own because the generator emits the heading from
+        # policy/shapes.yaml. Linting them as standalone files reports MD041 on
+        # every one. The rendered documents they produce are linted normally.
+        exclude: ^templates/content/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,14 +48,20 @@ Agents must not:
 
 1. Update canonical YAML policy and its explanatory normative docs together
    when changing a machine-enforced rule.
-2. Update templates and starter kits in the same change.
+2. Update templates and starter kits in the same change. Never edit
+   `templates/{README,AGENTS}.md` or a starter kit's Markdown directly: they
+   are generated. Edit the prose fragment under `templates/content/` or, for
+   section order, `policy/shapes.yaml`.
 3. After changing `policy/` or a policy-linked normative section, run
    `uv run python scripts/generate_policy.py` and commit the regenerated
    `src/repo_standard/policy/compiled.json` and `docs/policy-reference.md`;
    `uv run pytest` fails otherwise.
-4. Validate bootstrap behavior with `uv run pytest`, which generates into a
+4. After changing `policy/shapes.yaml` or `templates/content/`, run
+   `uv run python scripts/generate_docs.py` and commit the regenerated
+   templates and starter-kit documents; `uv run pytest` fails otherwise.
+5. Validate bootstrap behavior with `uv run pytest`, which generates into a
    temporary directory rather than a fixed path.
-5. Keep changes small and focused by concern.
+6. Keep changes small and focused by concern.
 
 ## Quality Gates
 
@@ -112,7 +118,8 @@ end in a temporary directory, on every platform.
 - `docs/`: normative standards
 - `profiles/`: language-specific profiles
 - `policy/`: canonical machine-enforced policy and profile detection metadata
-- `templates/`: fill-in-the-blank reference documents for adopting the standard
+- `templates/`: reference documents rendered from the shapes, plus the
+  `content/` prose fragments they are rendered from
   by hand
 
 ## Change Control Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,23 @@ the changes listed under **Adopters must**.
   section states that terms have not been selected yet and cites RSK018.
 - A `File Shapes` section in `docs/repo-standard.md` stating the contract each
   new rule enforces.
+- **The shape now produces the documents, not merely describes them.**
+  `scripts/generate_docs.py` walks a shape's ordered section list and renders
+  `templates/{README,AGENTS}.md` and both starter kits'
+  `{README,AGENTS,CHANGELOG}.md`. Prose lives in
+  `templates/content/<DOC>/<section-id>.<variant>.md` fragments keyed by section
+  id and carrying no ordering of their own; a section the shape does not declare
+  cannot be emitted, and reordering a document means editing
+  `policy/shapes.yaml`. Fragment resolution falls back from the variant to
+  `shared`, so a section identical across profiles is written once. A staleness
+  test fails when a committed document differs from a fresh render, mirroring
+  the existing policy-regeneration gate.
+- `First 10 Minutes` joins the README spine as an optional section between
+  `Install` and `Configuration`. The starter READMEs already shipped it, so the
+  shape could not render what the kit itself publishes without it.
+- A self-adoption gate: `repo-adopt .` against this repository must plan zero
+  changes, and the individual merges must agree with the committed files rather
+  than relying on the no-findings short-circuit.
 
 ### Changed
 
@@ -57,9 +74,12 @@ the changes listed under **Adopters must**.
   check before — a repository whose `AGENTS.md` carried every heading in the
   wrong sequence used to pass. This is the change that makes the release major:
   a previously aligned repository can now fail a required rule.
-- `repo-init --python-version` now renders the declared `__PYTHON_VERSION__`
-  placeholder instead of string-replacing a literal `>=3.12` in the starter
-  manifest, so any requested version takes effect.
+- `repo-init --python-version` now sets `requires-python` structurally through
+  `tomlkit` instead of string-replacing a literal `>=3.12` in the starter
+  manifest, so any requested version takes effect. The starter manifest keeps a
+  real version rather than the `__PYTHON_VERSION__` token, because Ruff resolves
+  configuration by walking up the tree and rejects a placeholder there; the
+  token is rendered into the starter README's `Install` line instead.
 - `repo-init --author` now reaches the generated `pyproject.toml` as an
   `authors` entry; it was previously threaded into the render values and
   silently discarded. An unnamed author leaves the key out rather than
@@ -70,6 +90,19 @@ the changes listed under **Adopters must**.
 - Starter `README.md` files follow the README spine and carry a `License`
   section; starter `CHANGELOG.md` files declare Keep a Changelog and Semantic
   Versioning and carry a `Compatibility Policy` section.
+- **`repo-adopt` repairs documents in shape order.** A missing required section
+  used to be appended to the end of `AGENTS.md`, which was safe only while
+  RSK002 checked presence alone; it now lands where the shape says it belongs,
+  and the same insertion drives `README.md`. `repo-adopt` no longer invents a
+  `Repository Standards` heading no shape declares — the RSK005 reference goes
+  into `Repository Context` and `Development`, which the shapes already require.
+- `repo-adopt` places new `pyproject.toml` tables in the order RSK025 declares
+  rather than appending them, so `[dependency-groups]` no longer lands after
+  `[build-system]` and `[tool.repo-standard]` no longer splits the Ruff tables.
+- `templates/README.md` states that its section order comes from RSK023 and is
+  checked by `repo-check`, replacing the claim that adopters should keep their
+  README aligned with `templates/` — a path no tooling reads. The same
+  correction lands in the starter READMEs.
 
 ### Adopters must
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v2.0.0" r
 - `policy/`: canonical machine-enforced rules, profile detection metadata, and
   the file shapes governed documents must follow
 - `profiles/`: language or repo-type specific standards
-- `templates/`: fill-in-the-blank reference documents for adopting the standard
+- `templates/`: reference documents rendered from the shapes, plus the
+  `content/` prose fragments they are rendered from
   by hand
 - `src/repo_standard/`: packaged bootstrap implementation
 - `src/repo_standard/policy/`: strict policy models and compiled runtime policy

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -65,6 +65,7 @@ documents are produced by walking it in the order below.
 | `at-a-glance` | `At A Glance` | `optional` |
 | `overview` | `Overview` | `required` |
 | `install` | `Install` | `required` |
+| `first-10-minutes` | `First 10 Minutes` | `optional` |
 | `configuration` | `Configuration` | `optional` |
 | `usage` | `Usage` | `required` |
 | `repo-structure` | `Repo Structure` | `optional` |

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -152,9 +152,9 @@ declared sections a file does carry must appear in the declared order. Markdown
 shapes govern level-two headings only, matching RSK002's semantics.
 
 - `README.md` (RSK023, **recommended**): the spine runs At A Glance, Overview,
-  Install, Configuration, Usage, Repo Structure, Development, Deployment,
-  Compatibility And Versioning, Maintainers And Support, License. Overview,
-  Install, Usage, Development, and License are required.
+  Install, First 10 Minutes, Configuration, Usage, Repo Structure, Development,
+  Deployment, Compatibility And Versioning, Maintainers And Support, License.
+  Overview, Install, Usage, Development, and License are required.
 - `CHANGELOG.md` (RSK024, **recommended**): an `[Unreleased]` section is
   required, and a `Compatibility Policy` section, where present, precedes it.
   Released-version sections are not enumerated.

--- a/policy/shapes.yaml
+++ b/policy/shapes.yaml
@@ -54,6 +54,9 @@ shapes:
       - id: install
         heading: Install
         level: required
+      - id: first-10-minutes
+        heading: First 10 Minutes
+        level: optional
       - id: configuration
         heading: Configuration
         level: optional

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,151 @@
+"""Render every reference document from the shapes declared in ``policy/``.
+
+Prose lives in ``templates/content/<DOC>/<section-id>.<variant>.md`` fragments
+that carry no ordering of their own. This script walks the ordered section list
+of the shape a document is bound to, emits the heading, and appends the
+fragment resolved for the target's variant. A section the shape does not
+declare cannot be emitted, and reordering a document means editing
+``policy/shapes.yaml`` -- order is derived here, never asserted twice.
+
+Two fragment ids are reserved and are not shape sections: ``_preamble`` (the
+title and any prose before the first heading) and ``_epilogue`` (link reference
+definitions). Shape section ids are kebab-case, so the leading underscore
+cannot collide with one.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from repo_standard.policy import load_source_policy  # noqa: E402
+from repo_standard.policy.models import Policy  # noqa: E402
+
+CONTENT_ROOT = REPO_ROOT / "templates" / "content"
+STARTER_KITS = SRC / "repo_standard" / "starter_kits"
+
+PREAMBLE = "_preamble"
+EPILOGUE = "_epilogue"
+SHARED = "shared"
+TEMPLATE = "template"
+
+
+class GeneratorError(RuntimeError):
+    """A document could not be rendered from the shape and its fragments."""
+
+
+@dataclass(frozen=True)
+class Target:
+    """One rendered document.
+
+    ``variant`` selects fragments; ``profile`` selects the policy values that
+    fill generator tokens. They are separate because the ``template`` variant
+    is not a profile but still has to state a concrete gate chain.
+    """
+
+    document: str
+    shape: str
+    variant: str
+    profile: str
+    path: Path
+
+
+TARGETS = (
+    Target("README", "readme", TEMPLATE, "python-single", REPO_ROOT / "templates"),
+    Target("AGENTS", "agents", TEMPLATE, "python-single", REPO_ROOT / "templates"),
+    *(
+        Target(document, shape, profile, profile, STARTER_KITS / profile)
+        for profile in ("python-single", "python-workspace")
+        for document, shape in (
+            ("README", "readme"),
+            ("AGENTS", "agents"),
+            ("CHANGELOG", "changelog"),
+        )
+    ),
+)
+
+
+def _fragment(document: str, fragment_id: str, variant: str) -> str | None:
+    """Resolve ``(document, fragment, variant)``, falling back to ``shared``."""
+    for candidate in (variant, SHARED):
+        path = CONTENT_ROOT / document / f"{fragment_id}.{candidate}.md"
+        if path.is_file():
+            return path.read_text(encoding="utf-8").strip("\n")
+    return None
+
+
+def _tokens(policy: Policy, profile: str) -> dict[str, str]:
+    """Generator-owned substitutions, resolved before anything is written.
+
+    These are deliberately not `repo_init.PLACEHOLDERS`: those must survive
+    verbatim into the starter kits so `repo-init` can fill them per repository.
+    These are filled here, so no shipped file ever carries one.
+    """
+    commands = policy.rule("RSK003").check.config["commands_by_profile"][profile]
+    return {
+        "__GATE_CHAIN__": "\n".join(
+            f"{index}. `{command}`" for index, command in enumerate(commands, 1)
+        ),
+        "__STANDARD_MAJOR__": policy.standard_major,
+    }
+
+
+def render(policy: Policy, target: Target) -> str:
+    shape = policy.shape(target.shape)
+    if shape.heading_level is None:
+        raise GeneratorError(f"shape {shape.id!r} is not a Markdown shape")
+    marks = "#" * shape.heading_level
+
+    preamble = _fragment(target.document, PREAMBLE, target.variant)
+    if preamble is None:
+        raise GeneratorError(
+            f"{target.document}/{PREAMBLE}: no fragment for variant "
+            f"{target.variant!r} and no {SHARED} fallback"
+        )
+    parts = [preamble]
+
+    for section in shape.sections:
+        body = _fragment(target.document, section.id, target.variant)
+        if body is None:
+            if section.level == "required":
+                raise GeneratorError(
+                    f"{target.document}/{section.id}: required by shape "
+                    f"{shape.id!r} but no fragment for variant {target.variant!r}"
+                )
+            continue
+        parts.append(f"{marks} {section.heading}\n\n{body}")
+
+    epilogue = _fragment(target.document, EPILOGUE, target.variant)
+    if epilogue is not None:
+        parts.append(epilogue)
+
+    text = "\n\n".join(parts) + "\n"
+    for token, value in _tokens(policy, target.profile).items():
+        text = text.replace(token, value)
+    return text
+
+
+def render_targets(policy: Policy) -> dict[Path, str]:
+    """Render every target, keyed by absolute destination path."""
+    return {
+        target.path / f"{target.document}.md": render(policy, target)
+        for target in TARGETS
+    }
+
+
+def main() -> int:
+    policy = load_source_policy(REPO_ROOT)
+    for path, content in render_targets(policy).items():
+        path.write_text(content, encoding="utf-8")
+        print(f"Wrote {path.relative_to(REPO_ROOT).as_posix()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -821,6 +821,11 @@
           "level": "required"
         },
         {
+          "heading": "First 10 Minutes",
+          "id": "first-10-minutes",
+          "level": "optional"
+        },
+        {
           "heading": "Configuration",
           "id": "configuration",
           "level": "optional"

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -23,6 +23,7 @@ from ruamel.yaml.error import YAMLError
 from tomlkit.exceptions import ParseError
 
 from repo_standard.compliance.checks import Finding, check_repo, load_policy
+from repo_standard.policy import Shape
 from repo_standard.repo_init import (
     PLACEHOLDERS,
     UNLICENSED_NOTICE,
@@ -30,6 +31,26 @@ from repo_standard.repo_init import (
 )
 
 ADOPTED_LICENSE_NOTICE = "See [`LICENSE`](LICENSE) for the terms that apply."
+
+_STANDARDS_LINK = (
+    "[repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit"
+)
+# RSK005 wants an explicit, linked reference in both documents. Rather than
+# inventing a heading no shape declares, the note goes into a section the shape
+# already requires, so adoption never introduces a section shape of its own.
+_STANDARDS_NOTE = {
+    "agents": (
+        "repository-context",
+        "Standards source: [repo-standard-kit] — quality gates derive from it, "
+        "and this repository is reviewed against it periodically for standards "
+        "drift.",
+    ),
+    "readme": (
+        "development",
+        "Repository workflow and quality gates follow [repo-standard-kit]. "
+        "Review this repository against the pinned standard when upgrading.",
+    ),
+}
 
 
 class AdoptionError(RuntimeError):
@@ -243,11 +264,46 @@ def _resolve_profile(root: Path, document: Any, override: str | None) -> str:
     return default
 
 
-def _ensure_table(parent: Any, key: str) -> Any:
+def _sibling_order(shape: Shape, prefix: tuple[str, ...]) -> list[str]:
+    """Child names the shape declares under `prefix`, in declared order."""
+    order: list[str] = []
+    for heading in shape.headings:
+        parts = heading.split(".")
+        if len(parts) <= len(prefix) or tuple(parts[: len(prefix)]) != prefix:
+            continue
+        if parts[len(prefix)] not in order:
+            order.append(parts[len(prefix)])
+    return order
+
+
+def _place(
+    parent: Any, key: str, value: Any, shape: Shape, prefix: tuple[str, ...]
+) -> None:
+    """Add `key` where the shape says it belongs among its siblings.
+
+    tomlkit appends, and a table appended past the ones that should follow it is
+    an RSK025 finding. There is no insert-before in the public API, so the
+    declared tables that come after `key` are lifted out and put back in order;
+    each carries its own contents and trivia, so only their position moves.
+    """
+    order = _sibling_order(shape, prefix)
+    if key not in order:
+        parent[key] = value
+        return
+    following = [name for name in order[order.index(key) + 1 :] if name in parent]
+    moved = [(name, parent.pop(name)) for name in following]
+    parent[key] = value
+    for name, table in moved:
+        parent[name] = table
+
+
+def _ensure_table(
+    parent: Any, key: str, shape: Shape, prefix: tuple[str, ...] = ()
+) -> Any:
     value = parent.get(key)
     if value is None:
-        value = tomlkit.table()
-        parent[key] = value
+        _place(parent, key, tomlkit.table(), shape, prefix)
+        value = parent[key]
     if not isinstance(value, dict):
         raise AdoptionError(f"cannot merge TOML key {key!r}: expected a table")
     return value
@@ -257,11 +313,12 @@ def _merge_pyproject(
     path: Path, document: Any, profile: str
 ) -> tuple[str, bool, list[str]]:
     starter = tomllib.loads(_read_starter(profile, "pyproject.toml"))
+    shape = _shape_for("RSK025")
     conflicts: list[str] = []
     dependency_changed = False
 
-    tool = _ensure_table(document, "tool")
-    metadata = _ensure_table(tool, "repo-standard")
+    tool = _ensure_table(document, "tool", shape)
+    metadata = _ensure_table(tool, "repo-standard", shape, ("tool",))
     unknown = set(metadata) - {"profile", "standard"}
     if unknown:
         conflicts.append(
@@ -271,7 +328,7 @@ def _merge_pyproject(
     metadata["profile"] = profile
     metadata["standard"] = load_policy().standard_major
 
-    groups = _ensure_table(document, "dependency-groups")
+    groups = _ensure_table(document, "dependency-groups", shape)
     dev = groups.get("dev")
     if dev is None:
         dev = tomlkit.array().multiline(True)
@@ -288,10 +345,10 @@ def _merge_pyproject(
             dev.append(requirement)
             dependency_changed = True
 
-    ruff = _ensure_table(tool, "ruff")
+    ruff = _ensure_table(tool, "ruff", shape, ("tool",))
     if "line-length" not in ruff:
         ruff["line-length"] = starter["tool"]["ruff"]["line-length"]
-    lint = _ensure_table(ruff, "lint")
+    lint = _ensure_table(ruff, "lint", shape, ("tool", "ruff"))
     select = lint.get("select")
     if select is None:
         select = tomlkit.array()
@@ -308,7 +365,7 @@ def _merge_pyproject(
             build = tomlkit.table()
             build["requires"] = starter["build-system"]["requires"]
             build["build-backend"] = starter["build-system"]["build-backend"]
-            document["build-system"] = build
+            _place(document, "build-system", build, shape, ())
             dependency_changed = True
         elif not isinstance(build, dict):
             raise AdoptionError("cannot merge build-system: expected a table")
@@ -534,23 +591,75 @@ def _section(text: str, heading: str) -> tuple[int, int, str] | None:
     return (match.start(), match.end(), match.group(0)) if match else None
 
 
-def _merge_agents(path: Path, profile: str, values: dict[str, str]) -> str:
-    template = _render(_read_starter(profile, "AGENTS.md"), values)
-    try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return template
-    except UnicodeDecodeError as error:
-        raise AdoptionError(f"could not parse {path} as UTF-8") from error
-    policy = load_policy()
-    headings = policy.shape(policy.rule("RSK002").check.config["shape"]).required
-    for heading in headings:
-        if _section(text, heading) is not None:
-            continue
-        source = _section(template, heading)
-        assert source is not None
-        text = text.rstrip() + "\n\n" + source[2].rstrip() + "\n"
+_LINK_DEFINITIONS = re.compile(r"(?:^\[[^\]\r\n]+\]:[^\r\n]*\r?\n?)+\Z", re.MULTILINE)
 
+
+def _append_block(text: str, block: str) -> str:
+    """Append `block`, keeping any trailing link-reference definitions last."""
+    body = text.rstrip() + "\n"
+    match = _LINK_DEFINITIONS.search(body)
+    if match is None:
+        return f"{body.rstrip()}\n\n{block.rstrip()}\n"
+    head = body[: match.start()].rstrip()
+    return f"{head}\n\n{block.rstrip()}\n\n{body[match.start() :].strip()}\n"
+
+
+def _append_link_definition(text: str, definition: str) -> str:
+    body = text.rstrip() + "\n"
+    match = _LINK_DEFINITIONS.search(body)
+    if match is None:
+        return f"{body}\n{definition}\n"
+    return f"{body[: match.end()].rstrip()}\n{definition}\n"
+
+
+def _insert_section(text: str, shape: Shape, heading: str, block: str) -> str:
+    """Insert `block` where `shape` says the section belongs.
+
+    Appending was safe while RSK002 checked presence alone. Shapes are
+    order-enforced, so a repaired section has to land before the first declared
+    section that follows it canonically, or the repair trades a missing-section
+    finding for an out-of-order one.
+    """
+    order = list(shape.headings)
+    for following in order[order.index(heading) + 1 :]:
+        location = _section(text, following)
+        if location is None:
+            continue
+        head = text[: location[0]].rstrip()
+        return f"{head}\n\n{block.rstrip()}\n\n{text[location[0] :]}"
+    return _append_block(text, block)
+
+
+def _fill_required_sections(text: str, shape: Shape, reference: str) -> str:
+    """Add every required section `text` lacks, taken from `reference`."""
+    for section in shape.sections:
+        if section.level != "required" or _section(text, section.heading) is not None:
+            continue
+        source = _section(reference, section.heading)
+        if source is None:
+            raise AdoptionError(
+                f"cannot reconcile {shape.path}: the reference document has no "
+                f"{section.heading!r} section"
+            )
+        text = _insert_section(text, shape, section.heading, source[2])
+    return text
+
+
+def _ensure_standards_reference(text: str, shape: Shape) -> str:
+    """Satisfy RSK005 inside a section the shape already declares."""
+    if "repo-standard-kit" in text:
+        return text
+    section_id, note = _STANDARDS_NOTE[shape.id]
+    location = _section(text, shape.section(section_id).heading)
+    if location is None:
+        return _append_block(text, f"{note}\n\n{_STANDARDS_LINK}")
+    block = f"{location[2].rstrip()}\n\n{note}\n\n"
+    return _append_link_definition(
+        text[: location[0]] + block + text[location[1] :], _STANDARDS_LINK
+    )
+
+
+def _reconcile_gate_chain(text: str, profile: str) -> str:
     quality = _section(text, "Quality Gates")
     assert quality is not None
     block = quality[2]
@@ -570,31 +679,43 @@ def _merge_agents(path: Path, profile: str, values: dict[str, str]) -> str:
         if body.strip():
             replacement += "\n" + body.strip("\r\n") + "\n"
     replacement = replacement.rstrip() + "\n\n"
-    text = text[: quality[0]] + replacement + text[quality[1] :]
-    if "repo-standard-kit" not in text:
-        text = text.rstrip() + (
-            "\n\nThis repository adopts [repo-standard-kit] and its documented quality "
-            "baseline.\n\n[repo-standard-kit]: "
-            "https://github.com/FP-DevTools/repo-standard-kit\n"
-        )
-    return text
+    return text[: quality[0]] + replacement + text[quality[1] :]
+
+
+def _existing(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except UnicodeDecodeError as error:
+        raise AdoptionError(f"could not parse {path} as UTF-8") from error
+
+
+def _shape_for(rule_id: str) -> Shape:
+    """Resolve a shape through the rule that enforces it, never by literal id."""
+    policy = load_policy()
+    return policy.shape(policy.rule(rule_id).check.config["shape"])
+
+
+def _merge_agents(path: Path, profile: str, values: dict[str, str]) -> str:
+    reference = _render(_read_starter(profile, "AGENTS.md"), values)
+    text = _existing(path)
+    if text is None:
+        return reference
+    shape = _shape_for("RSK002")
+    text = _fill_required_sections(text, shape, reference)
+    text = _reconcile_gate_chain(text, profile)
+    return _ensure_standards_reference(text, shape)
 
 
 def _merge_readme(path: Path, profile: str, values: dict[str, str]) -> str:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return _render(_read_starter(profile, "README.md"), values)
-    except UnicodeDecodeError as error:
-        raise AdoptionError(f"could not parse {path} as UTF-8") from error
-    if "repo-standard-kit" in text:
-        return text
-    return text.rstrip() + (
-        "\n\n## Repository Standards\n\nRepository workflow and quality gates follow "
-        "[repo-standard-kit]. Review this repository against the pinned standard "
-        "when upgrading.\n\n[repo-standard-kit]: "
-        "https://github.com/FP-DevTools/repo-standard-kit\n"
-    )
+    reference = _render(_read_starter(profile, "README.md"), values)
+    text = _existing(path)
+    if text is None:
+        return reference
+    shape = _shape_for("RSK023")
+    text = _fill_required_sections(text, shape, reference)
+    return _ensure_standards_reference(text, shape)
 
 
 def _planned(path: Path, content: str, root: Path) -> PlannedFile | None:

--- a/src/repo_standard/starter_kits/python-single/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-single/AGENTS.md
@@ -23,23 +23,23 @@
 Humans own:
 
 - product scope and intent
+- security exceptions and secret handling
 - merge and release authority
 - approval of breaking changes
-- security exceptions and secrets
 
 Agents own:
 
-- implementation within documented boundaries
+- implementation within documented repo boundaries
 - tests and regression coverage
-- docs updates for behavior changes
+- docs updates tied to behavior changes
 - running documented quality gates
 
 ## Workflow
 
 - Long-lived branch: `main`
 - Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
-- Merge through reviewed PRs only
-- Keep PRs focused and small
+- Merge via reviewed PRs only
+- Keep PRs small and single-purpose
 - CI must mirror the documented local quality gates
 
 ## Quality Gates
@@ -67,6 +67,8 @@ ruleset applies to every adopting repository.
 - Minimize `Any` and justify it when required
 - Keep I/O boundaries explicit
 - Separate side effects from business logic
+- Separate durable logic from scripts
+- Preserve public interface stability by default
 
 ## Testing Policy
 
@@ -91,8 +93,8 @@ ruleset applies to every adopting repository.
 
 ## Change Control Notes
 
-Document API, schema, or migration-specific rules here when the repository
-introduces them.
+Document any repo-specific API, schema, migration, or operational constraints
+here when the repository introduces them.
 
 [repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
 [quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md

--- a/src/repo_standard/starter_kits/python-single/README.md
+++ b/src/repo_standard/starter_kits/python-single/README.md
@@ -45,11 +45,14 @@ actually for.
 ## Development
 
 Repository workflow, quality gates, and coding standards are defined in
-`AGENTS.md`. The mandatory quality gates and this README's structure derive
-from [repo-standard-kit] — see its [quality-gates spec][quality-gates] and
-[README template][readme-template]. Keep this file's shape aligned with those
-when you update it, and check this repository against it periodically for
-standards drift.
+`AGENTS.md`. The mandatory quality gates derive from [repo-standard-kit] — see
+its [quality-gates spec][quality-gates].
+
+This README's section order is RSK023, whose canonical section list lives in
+the kit's `policy/shapes.yaml` and is published in the
+[policy reference][policy-reference]. Run `repo-check .` after editing this
+file and it names any section that is missing or out of order; `repo-adopt .`
+inserts the required ones.
 
 ## License
 
@@ -57,4 +60,4 @@ __LICENSE_NOTICE__
 
 [repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
 [quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md
-[readme-template]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/templates/README.md
+[policy-reference]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/policy-reference.md

--- a/src/repo_standard/starter_kits/python-workspace/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-workspace/AGENTS.md
@@ -25,22 +25,22 @@
 Humans own:
 
 - workspace scope and package boundaries
+- security exceptions and secret handling
 - merge and release authority
 - approval of breaking cross-package changes
-- security exceptions and secrets
 
 Agents own:
 
 - implementation within package or workspace boundaries
 - tests and regression coverage
-- docs updates for behavior changes
+- docs updates tied to behavior changes
 - running repo-wide quality gates
 
 ## Workflow
 
 - Long-lived branch: `main`
 - Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
-- Merge through reviewed PRs only
+- Merge via reviewed PRs only
 - Keep PRs package-scoped or clearly cross-cutting
 - CI must mirror the documented local quality gates
 

--- a/src/repo_standard/starter_kits/python-workspace/README.md
+++ b/src/repo_standard/starter_kits/python-workspace/README.md
@@ -21,7 +21,7 @@ uv run pre-commit install
 
 ## First 10 Minutes
 
-1. Review `AGENTS.md`.
+1. Review `AGENTS.md` and confirm the repo-specific scope and constraints.
 2. Run `uv sync`.
 3. Run `uv run pre-commit install` after Git is initialized. If you used
    `repo-init` without `--no-install`, this is already done for you.
@@ -49,11 +49,14 @@ actually for once it holds real packages.
 ## Development
 
 Repository workflow, quality gates, and coding standards are defined in
-`AGENTS.md`. The mandatory quality gates and this README's structure derive
-from [repo-standard-kit] — see its [quality-gates spec][quality-gates] and
-[README template][readme-template]. Keep this file's shape aligned with those
-when you update it, and check this repository against it periodically for
-standards drift.
+`AGENTS.md`. The mandatory quality gates derive from [repo-standard-kit] — see
+its [quality-gates spec][quality-gates].
+
+This README's section order is RSK023, whose canonical section list lives in
+the kit's `policy/shapes.yaml` and is published in the
+[policy reference][policy-reference]. Run `repo-check .` after editing this
+file and it names any section that is missing or out of order; `repo-adopt .`
+inserts the required ones.
 
 ## License
 
@@ -61,4 +64,4 @@ __LICENSE_NOTICE__
 
 [repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
 [quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md
-[readme-template]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/templates/README.md
+[policy-reference]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/policy-reference.md

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -63,7 +63,9 @@ ruleset applies to every adopting repository.
 ## Coding Standards
 
 - Type all production function signatures
+- Minimize `Any` and justify it when required
 - Keep I/O boundaries explicit
+- Separate side effects from business logic
 - Separate durable logic from scripts
 - Preserve public interface stability by default
 
@@ -83,14 +85,15 @@ ruleset applies to every adopting repository.
 
 ## Repository Layout
 
-- `src/`: production code
-- `tests/`: tests
+- `src/`: production package code
+- `tests/`: automated tests
 - `docs/`: durable project knowledge
-- `scripts/`: developer or operational helpers
+- `scripts/`: developer helpers, not core business logic
 
 ## Change Control Notes
 
-Document any repo-specific API, schema, migration, or operational constraints.
+Document any repo-specific API, schema, migration, or operational constraints
+here when the repository introduces them.
 
 [repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
 [quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md

--- a/templates/README.md
+++ b/templates/README.md
@@ -38,9 +38,20 @@ uv add <package-name>
 pip install <package-name>
 ```
 
-## Quick Start
+## First 10 Minutes
 
-### Configuration
+<A checklist a new contributor can finish in one sitting. Keep it to commands
+that verify the checkout is healthy, and delete any that do not apply.>
+
+1. Read `AGENTS.md` and confirm this repo's scope and constraints.
+2. Run `uv sync --locked`.
+3. Run `uv run pre-commit install`.
+4. Run `uv run pre-commit run --all-files` to confirm a clean baseline.
+5. Run `uv run pytest`.
+6. Run `<the repo's primary entry point>` against `<sample or local input>`.
+7. Skim `.github/workflows/quality.yml` to see what CI enforces.
+
+## Configuration
 
 <List required configuration: environment variables, config files, secrets,
 credentials for data sources. Copy `.env.example` to `.env` if applicable.>
@@ -50,7 +61,7 @@ credentials for data sources. Copy `.env.example` to `.env` if applicable.>
 | `<VAR_NAME>` | Yes | — | `<what it controls>` |
 | `<VAR_NAME>` | No | `<default>` | `<what it controls>` |
 
-### Common Commands
+## Usage
 
 | Command | Purpose |
 |---|---|
@@ -114,10 +125,12 @@ See `AGENTS.md` for the full repo-level contract (human/agent
 responsibilities, workflow rules, coding standards). This section covers what
 a new contributor needs first.
 
-This README's structure follows the [repo-standard-kit] standard — see its
-[README template][readme-template]. Keep this file's shape aligned with it
-when you update it, and check this repository against it periodically for
-standards drift.
+This README's section order is not a convention to remember: it is RSK023,
+whose canonical section list lives in the kit's `policy/shapes.yaml` and is
+published in the [policy reference][policy-reference]. Run `repo-check .` after
+editing this file and it names any section that is missing or out of order;
+`repo-adopt .` inserts the required ones. This file is a rendering of that
+shape, not the source of it.
 
 ### Set Up Your Dev Environment
 
@@ -168,7 +181,7 @@ justification in the PR and maintainer approval, and must stay time-limited.
 - Workspace repos: each package under `packages/<slug>/` declares its own
   dependencies; the root `pyproject.toml` is tooling-only.
 
-### Deployment
+## Deployment
 
 <Describe how and where this repo ships: package registry, container image,
 deployment target, and what triggers a release (tag push, manual dispatch,
@@ -177,7 +190,7 @@ merge to `main`, etc.). Include rollback steps if non-obvious.>
 - Cut releases from `main` with tags: `git tag vX.Y.Z && git push --tags`.
 - `<CI/CD pipeline name and what it does on tag push>`
 
-### Compatibility And Versioning
+## Compatibility And Versioning
 
 - Supported Python: `<version range>` (see `requires-python` in
   `pyproject.toml`).
@@ -187,16 +200,16 @@ merge to `main`, etc.). Include rollback steps if non-obvious.>
   require explicit human approval.
 - `<Link to CHANGELOG.md or release notes, if maintained.>`
 
-### Maintainers And Support
+## Maintainers And Support
 
 - Maintainers: `<names / team, @github-handles>`
 - Questions: `<Slack channel, mailing list, or discussion board>`
 - Bugs and feature requests: `<issue tracker link>`
 
-### License
+## License
 
 Licensed under `<license-name>`. See [LICENSE](LICENSE).
 
 [repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
 [quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md
-[readme-template]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/templates/README.md
+[policy-reference]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/policy-reference.md

--- a/templates/content/AGENTS/_epilogue.shared.md
+++ b/templates/content/AGENTS/_epilogue.shared.md
@@ -1,0 +1,2 @@
+[repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
+[quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md

--- a/templates/content/AGENTS/_preamble.shared.md
+++ b/templates/content/AGENTS/_preamble.shared.md
@@ -1,0 +1,1 @@
+# AGENTS.md

--- a/templates/content/AGENTS/change-control-notes.python-workspace.md
+++ b/templates/content/AGENTS/change-control-notes.python-workspace.md
@@ -1,0 +1,1 @@
+Document cross-package API or dependency rules here when the workspace evolves.

--- a/templates/content/AGENTS/change-control-notes.shared.md
+++ b/templates/content/AGENTS/change-control-notes.shared.md
@@ -1,0 +1,2 @@
+Document any repo-specific API, schema, migration, or operational constraints
+here when the repository introduces them.

--- a/templates/content/AGENTS/coding-standards.python-workspace.md
+++ b/templates/content/AGENTS/coding-standards.python-workspace.md
@@ -1,0 +1,4 @@
+- Shared tool config lives at the repo root
+- Package metadata lives in each package's `pyproject.toml`
+- Cross-package changes must be explicit and small
+- Treat package boundaries as stable by default

--- a/templates/content/AGENTS/coding-standards.shared.md
+++ b/templates/content/AGENTS/coding-standards.shared.md
@@ -1,0 +1,6 @@
+- Type all production function signatures
+- Minimize `Any` and justify it when required
+- Keep I/O boundaries explicit
+- Separate side effects from business logic
+- Separate durable logic from scripts
+- Preserve public interface stability by default

--- a/templates/content/AGENTS/documentation-rules.python-workspace.md
+++ b/templates/content/AGENTS/documentation-rules.python-workspace.md
@@ -1,0 +1,5 @@
+- Update root `README.md` when workspace usage changes
+- Add ADRs for significant workspace or package-boundary decisions
+- Document package-specific public usage in package-local READMEs
+- Keep the `repo-standard-kit` reference in `README.md` and `AGENTS.md`
+  current, and check this repository against it periodically

--- a/templates/content/AGENTS/documentation-rules.shared.md
+++ b/templates/content/AGENTS/documentation-rules.shared.md
@@ -1,0 +1,5 @@
+- Update `README.md` when setup or usage changes
+- Update `AGENTS.md` when operating rules change
+- Add ADRs for significant architecture decisions
+- Keep the `repo-standard-kit` reference in `README.md` and `AGENTS.md`
+  current, and check this repository against it periodically

--- a/templates/content/AGENTS/human-and-agent-responsibilities.python-workspace.md
+++ b/templates/content/AGENTS/human-and-agent-responsibilities.python-workspace.md
@@ -1,0 +1,13 @@
+Humans own:
+
+- workspace scope and package boundaries
+- security exceptions and secret handling
+- merge and release authority
+- approval of breaking cross-package changes
+
+Agents own:
+
+- implementation within package or workspace boundaries
+- tests and regression coverage
+- docs updates tied to behavior changes
+- running repo-wide quality gates

--- a/templates/content/AGENTS/human-and-agent-responsibilities.shared.md
+++ b/templates/content/AGENTS/human-and-agent-responsibilities.shared.md
@@ -1,0 +1,13 @@
+Humans own:
+
+- product scope and intent
+- security exceptions and secret handling
+- merge and release authority
+- approval of breaking changes
+
+Agents own:
+
+- implementation within documented repo boundaries
+- tests and regression coverage
+- docs updates tied to behavior changes
+- running documented quality gates

--- a/templates/content/AGENTS/quality-gates.python-workspace.md
+++ b/templates/content/AGENTS/quality-gates.python-workspace.md
@@ -1,0 +1,16 @@
+Run from repo root:
+
+__GATE_CHAIN__
+
+The build step is a documented no-op before the workspace contains its first
+package, matching the workspace quality workflow.
+
+The quality job's effective permissions must be exactly `contents: read`, and
+every remote action or reusable workflow must be pinned to a full 40-character
+commit SHA. Keep version comments and GitHub Actions Dependabot configuration
+so those pins remain maintainable.
+
+Branch protection must require the separate `quality` and `compliance` status
+checks. Quality executes the gate chain; compliance independently checks the
+repository against the standard. Keep these canonical names so the same
+ruleset applies to every adopting repository.

--- a/templates/content/AGENTS/quality-gates.shared.md
+++ b/templates/content/AGENTS/quality-gates.shared.md
@@ -1,0 +1,13 @@
+Run from repo root:
+
+__GATE_CHAIN__
+
+The quality job's effective permissions must be exactly `contents: read`, and
+every remote action or reusable workflow must be pinned to a full 40-character
+commit SHA. Keep version comments and GitHub Actions Dependabot configuration
+so those pins remain maintainable.
+
+Branch protection must require the separate `quality` and `compliance` status
+checks. Quality executes the gate chain; compliance independently checks the
+repository against the standard. Keep these canonical names so the same
+ruleset applies to every adopting repository.

--- a/templates/content/AGENTS/repository-context.python-single.md
+++ b/templates/content/AGENTS/repository-context.python-single.md
@@ -1,0 +1,11 @@
+- Repository name: `__REPO_NAME__`
+- Primary language(s): `Python`
+- Runtime/build system: `uv` with `uv_build` in `pyproject.toml`
+- Repository type: `__REPO_TYPE__`
+- Standards source: [repo-standard-kit] — quality gates derive from its
+  [quality-gates spec][quality-gates]; review this repository against it
+  periodically for standards drift
+- Key directories:
+  - `src/`: production package code
+  - `tests/`: automated tests
+  - `docs/`: durable repository knowledge

--- a/templates/content/AGENTS/repository-context.python-workspace.md
+++ b/templates/content/AGENTS/repository-context.python-workspace.md
@@ -1,0 +1,12 @@
+- Repository name: `__REPO_NAME__`
+- Primary language(s): `Python`
+- Runtime/build system: `uv` with shared root tooling and `uv_build` for
+  package projects
+- Repository type: `workspace`
+- Standards source: [repo-standard-kit] — quality gates derive from its
+  [quality-gates spec][quality-gates]; review this repository against it
+  periodically for standards drift
+- Key directories:
+  - `packages/`: independently structured package projects
+  - `docs/`: durable repository knowledge
+  - `scripts/`: workspace-level helpers

--- a/templates/content/AGENTS/repository-context.template.md
+++ b/templates/content/AGENTS/repository-context.template.md
@@ -1,0 +1,10 @@
+- Repository name: `<repo-name>`
+- Primary language(s): `<languages>`
+- Runtime/build system: `<runtime>`
+- Standards source: [repo-standard-kit] — quality gates derive from its
+  [quality-gates spec][quality-gates]; review this repository against it
+  periodically for standards drift
+- Key directories:
+  - `src/`: `<production-code-scope>`
+  - `tests/`: `<test-scope>`
+  - `docs/`: `<documentation-scope>`

--- a/templates/content/AGENTS/repository-layout.python-workspace.md
+++ b/templates/content/AGENTS/repository-layout.python-workspace.md
@@ -1,0 +1,3 @@
+- `packages/`: package projects under `packages/<package-slug>/`
+- `docs/`: durable workspace knowledge
+- `scripts/`: workspace-level helpers

--- a/templates/content/AGENTS/repository-layout.shared.md
+++ b/templates/content/AGENTS/repository-layout.shared.md
@@ -1,0 +1,4 @@
+- `src/`: production package code
+- `tests/`: automated tests
+- `docs/`: durable project knowledge
+- `scripts/`: developer helpers, not core business logic

--- a/templates/content/AGENTS/repository-purpose.python-single.md
+++ b/templates/content/AGENTS/repository-purpose.python-single.md
@@ -1,0 +1,1 @@
+`__REPO_NAME__` exists to `__DESCRIPTION__`.

--- a/templates/content/AGENTS/repository-purpose.python-workspace.md
+++ b/templates/content/AGENTS/repository-purpose.python-workspace.md
@@ -1,0 +1,2 @@
+`__REPO_NAME__` is a Python workspace repository with per-package projects under
+`packages/`.

--- a/templates/content/AGENTS/repository-purpose.template.md
+++ b/templates/content/AGENTS/repository-purpose.template.md
@@ -1,0 +1,1 @@
+Describe what this repository exists to do, for whom, and what is out of scope.

--- a/templates/content/AGENTS/testing-policy.python-workspace.md
+++ b/templates/content/AGENTS/testing-policy.python-workspace.md
@@ -1,0 +1,3 @@
+- Logic changes require unit tests
+- Cross-package boundary changes require integration coverage where relevant
+- Bug fixes require regression tests

--- a/templates/content/AGENTS/testing-policy.shared.md
+++ b/templates/content/AGENTS/testing-policy.shared.md
@@ -1,0 +1,3 @@
+- Logic changes require unit tests
+- Boundary changes require integration tests
+- Bug fixes require regression tests

--- a/templates/content/AGENTS/workflow.python-workspace.md
+++ b/templates/content/AGENTS/workflow.python-workspace.md
@@ -1,0 +1,5 @@
+- Long-lived branch: `main`
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- Merge via reviewed PRs only
+- Keep PRs package-scoped or clearly cross-cutting
+- CI must mirror the documented local quality gates

--- a/templates/content/AGENTS/workflow.shared.md
+++ b/templates/content/AGENTS/workflow.shared.md
@@ -1,0 +1,5 @@
+- Long-lived branch: `main`
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- Merge via reviewed PRs only
+- Keep PRs small and single-purpose
+- CI must mirror the documented local quality gates

--- a/templates/content/CHANGELOG/_preamble.shared.md
+++ b/templates/content/CHANGELOG/_preamble.shared.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/templates/content/CHANGELOG/compatibility-policy.shared.md
+++ b/templates/content/CHANGELOG/compatibility-policy.shared.md
@@ -1,0 +1,6 @@
+Version numbers describe the impact on a consumer of this repository, not the
+size of the internal change.
+
+- **MAJOR**: a consumer must change to stay working.
+- **MINOR**: new capability that leaves working consumers working.
+- **PATCH**: corrections with no effect on a consumer.

--- a/templates/content/CHANGELOG/unreleased.shared.md
+++ b/templates/content/CHANGELOG/unreleased.shared.md
@@ -1,0 +1,4 @@
+### Added
+
+- Initial repository generated from
+  [repo-standard-kit](https://github.com/FP-DevTools/repo-standard-kit).

--- a/templates/content/README/_epilogue.shared.md
+++ b/templates/content/README/_epilogue.shared.md
@@ -1,0 +1,3 @@
+[repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit
+[quality-gates]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/quality-gates.md
+[policy-reference]: https://github.com/FP-DevTools/repo-standard-kit/blob/main/docs/policy-reference.md

--- a/templates/content/README/_preamble.shared.md
+++ b/templates/content/README/_preamble.shared.md
@@ -1,0 +1,3 @@
+# __REPO_NAME__
+
+__DESCRIPTION__

--- a/templates/content/README/_preamble.template.md
+++ b/templates/content/README/_preamble.template.md
@@ -1,0 +1,3 @@
+# <repo-name>
+
+<One-sentence description: what this repo does and who it's for.>

--- a/templates/content/README/at-a-glance.template.md
+++ b/templates/content/README/at-a-glance.template.md
@@ -1,0 +1,7 @@
+| | |
+|---|---|
+| Type | `<python-single \| python-workspace \| other>` |
+| Language | `<Python 3.12+>` |
+| Package manager | `<uv>` |
+| Status | `<active \| maintenance \| deprecated>` |
+| License | `<license-name>` |

--- a/templates/content/README/compatibility-and-versioning.template.md
+++ b/templates/content/README/compatibility-and-versioning.template.md
@@ -1,0 +1,7 @@
+- Supported Python: `<version range>` (see `requires-python` in
+  `pyproject.toml`).
+- Versioned with [Semantic Versioning](https://semver.org/)
+  (`MAJOR.MINOR.PATCH`).
+- Public interfaces are stable by default; breaking changes bump `MAJOR` and
+  require explicit human approval.
+- `<Link to CHANGELOG.md or release notes, if maintained.>`

--- a/templates/content/README/configuration.template.md
+++ b/templates/content/README/configuration.template.md
@@ -1,0 +1,7 @@
+<List required configuration: environment variables, config files, secrets,
+credentials for data sources. Copy `.env.example` to `.env` if applicable.>
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `<VAR_NAME>` | Yes | — | `<what it controls>` |
+| `<VAR_NAME>` | No | `<default>` | `<what it controls>` |

--- a/templates/content/README/deployment.template.md
+++ b/templates/content/README/deployment.template.md
@@ -1,0 +1,6 @@
+<Describe how and where this repo ships: package registry, container image,
+deployment target, and what triggers a release (tag push, manual dispatch,
+merge to `main`, etc.). Include rollback steps if non-obvious.>
+
+- Cut releases from `main` with tags: `git tag vX.Y.Z && git push --tags`.
+- `<CI/CD pipeline name and what it does on tag push>`

--- a/templates/content/README/development.shared.md
+++ b/templates/content/README/development.shared.md
@@ -1,0 +1,9 @@
+Repository workflow, quality gates, and coding standards are defined in
+`AGENTS.md`. The mandatory quality gates derive from [repo-standard-kit] — see
+its [quality-gates spec][quality-gates].
+
+This README's section order is RSK023, whose canonical section list lives in
+the kit's `policy/shapes.yaml` and is published in the
+[policy reference][policy-reference]. Run `repo-check .` after editing this
+file and it names any section that is missing or out of order; `repo-adopt .`
+inserts the required ones.

--- a/templates/content/README/development.template.md
+++ b/templates/content/README/development.template.md
@@ -1,0 +1,68 @@
+This repository declares its machine-enforced standard contract in
+`pyproject.toml`:
+
+```toml
+[tool.repo-standard]
+profile = "<python-single or python-workspace>"
+standard = "__STANDARD_MAJOR__"
+```
+
+See `AGENTS.md` for the full repo-level contract (human/agent
+responsibilities, workflow rules, coding standards). This section covers what
+a new contributor needs first.
+
+This README's section order is not a convention to remember: it is RSK023,
+whose canonical section list lives in the kit's `policy/shapes.yaml` and is
+published in the [policy reference][policy-reference]. Run `repo-check .` after
+editing this file and it names any section that is missing or out of order;
+`repo-adopt .` inserts the required ones. This file is a rendering of that
+shape, not the source of it.
+
+### Set Up Your Dev Environment
+
+1. Clone the repo and run `uv sync --locked`.
+2. Run `uv run pre-commit install`.
+3. Run `uv run pre-commit run --all-files` to confirm a clean baseline.
+4. Copy `.env.example` to `.env` (if present) and fill in local config.
+
+### Guidelines
+
+- Follow the workflow and standards in `AGENTS.md`.
+- Trunk-based development: short-lived branches off `main`, merged via
+  reviewed PRs only. Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`,
+  `chore/`.
+- Keep PRs small and single-purpose.
+- Type all production function signatures; keep I/O boundaries explicit.
+- Tests are part of the change, not follow-up work: logic changes need unit
+  tests, boundary changes need integration tests, bug fixes need regression
+  tests.
+- Update `README.md` when setup or usage changes; update `AGENTS.md` when
+  operating rules change; add an ADR under `docs/adr/` for significant
+  architecture decisions.
+
+### Quality Gates
+
+The mandatory gate chain is listed in `AGENTS.md`, which is the one place this
+repository states it, and runs in CI on every PR to `main`
+(`.github/workflows/quality.yml`). A separate
+`.github/workflows/compliance.yml` job checks that the repository and quality
+workflow still match repo-standard-kit. Run the gate chain locally before
+pushing.
+
+No PR merges into `main` unless both `quality` and `compliance` pass, and
+branch protection enforces that rather than convention — see the
+[quality-gates spec][quality-gates]. Temporary exemptions require explicit
+justification in the PR and maintainer approval, and must stay time-limited.
+
+### Dependency Management
+
+- `uv` is the only supported package manager; `pyproject.toml` and `uv.lock`
+  are the source of truth. Commit `uv.lock`.
+- Add a runtime dependency: `uv add <package>`.
+- Add a dev-only dependency: `uv add --group dev <package>`.
+- Upgrade a dependency: `uv lock --upgrade-package <package>` then
+  `uv sync --locked`.
+- `uv run deptry .` and `uv run pip-audit` are recommended for dependency
+  hygiene and vulnerability scanning (see the [quality-gates spec][quality-gates]).
+- Workspace repos: each package under `packages/<slug>/` declares its own
+  dependencies; the root `pyproject.toml` is tooling-only.

--- a/templates/content/README/first-10-minutes.shared.md
+++ b/templates/content/README/first-10-minutes.shared.md
@@ -1,0 +1,12 @@
+1. Review `AGENTS.md` and confirm the repo-specific scope and constraints.
+2. Run `uv sync`.
+3. Run `uv run pre-commit install` after Git is initialized. If you used
+   `repo-init` without `--no-install`, this is already done for you.
+4. Run `uv run pre-commit run --all-files`.
+5. Run `uv run ruff format --check .`.
+6. Run `uv run ruff check .`.
+7. Run `uv run ty check`.
+8. Run `uv run pytest`.
+9. Run `uv build`.
+10. Review `.github/workflows/quality.yml`.
+11. Commit the generated `uv.lock`, then make the initial commit on `main`.

--- a/templates/content/README/first-10-minutes.template.md
+++ b/templates/content/README/first-10-minutes.template.md
@@ -1,0 +1,10 @@
+<A checklist a new contributor can finish in one sitting. Keep it to commands
+that verify the checkout is healthy, and delete any that do not apply.>
+
+1. Read `AGENTS.md` and confirm this repo's scope and constraints.
+2. Run `uv sync --locked`.
+3. Run `uv run pre-commit install`.
+4. Run `uv run pre-commit run --all-files` to confirm a clean baseline.
+5. Run `uv run pytest`.
+6. Run `<the repo's primary entry point>` against `<sample or local input>`.
+7. Skim `.github/workflows/quality.yml` to see what CI enforces.

--- a/templates/content/README/install.shared.md
+++ b/templates/content/README/install.shared.md
@@ -1,0 +1,9 @@
+Requires Python `__PYTHON_VERSION__` or newer.
+
+```bash
+uv sync
+uv run pre-commit install
+```
+
+`uv run pre-commit install` needs Git to be initialized. If you used
+`repo-init` without `--no-install`, both steps have already run for you.

--- a/templates/content/README/install.template.md
+++ b/templates/content/README/install.template.md
@@ -1,0 +1,15 @@
+Requires `<Python version range>` and [uv](https://docs.astral.sh/uv/).
+
+```bash
+git clone <repo-url>
+cd <repo-name>
+uv sync --locked
+```
+
+<If this repo publishes an installable package, also document that path:>
+
+```bash
+uv add <package-name>
+# or
+pip install <package-name>
+```

--- a/templates/content/README/license.shared.md
+++ b/templates/content/README/license.shared.md
@@ -1,0 +1,1 @@
+__LICENSE_NOTICE__

--- a/templates/content/README/license.template.md
+++ b/templates/content/README/license.template.md
@@ -1,0 +1,1 @@
+Licensed under `<license-name>`. See [LICENSE](LICENSE).

--- a/templates/content/README/maintainers-and-support.template.md
+++ b/templates/content/README/maintainers-and-support.template.md
@@ -1,0 +1,3 @@
+- Maintainers: `<names / team, @github-handles>`
+- Questions: `<Slack channel, mailing list, or discussion board>`
+- Bugs and feature requests: `<issue tracker link>`

--- a/templates/content/README/overview.python-single.md
+++ b/templates/content/README/overview.python-single.md
@@ -1,0 +1,1 @@
+This repository contains the `__PACKAGE_NAME__` Python project.

--- a/templates/content/README/overview.python-workspace.md
+++ b/templates/content/README/overview.python-workspace.md
@@ -1,0 +1,2 @@
+This repository is a Python workspace with independently structured package
+projects under `packages/`.

--- a/templates/content/README/overview.template.md
+++ b/templates/content/README/overview.template.md
@@ -1,0 +1,5 @@
+<2-4 sentences: the problem this repo solves, the primary use case (e.g. data
+pipeline, service, library, analysis), and anything explicitly out of scope.
+For data repos, note the primary data sources/sinks and what the repo does
+NOT own (e.g. "reads from `<source>`, writes curated tables to `<sink>`; does
+not own orchestration/scheduling, see `<owning-repo>`").>

--- a/templates/content/README/repo-structure.python-workspace.md
+++ b/templates/content/README/repo-structure.python-workspace.md
@@ -1,0 +1,3 @@
+- `packages/`: one directory per workspace package.
+- `tests/`: workspace-level tests that span packages.
+- `docs/`: architecture decision records and diagrams.

--- a/templates/content/README/repo-structure.template.md
+++ b/templates/content/README/repo-structure.template.md
@@ -1,0 +1,33 @@
+Pick the block that matches this repo's profile and delete the other.
+
+**Single-package (`python-single`)**
+
+```text
+.
+├── src/<package_name>/   # production code
+├── tests/                # unit and integration tests
+├── docs/adr/             # architecture decisions
+├── docs/diagrams/        # workflow / architecture diagrams
+├── scripts/              # dev or operational helpers (not core logic)
+├── AGENTS.md             # repo operating contract: workflow, gates, standards
+├── README.md
+└── pyproject.toml
+```
+
+**Workspace (`python-workspace`)**
+
+```text
+.
+├── packages/<package-slug>/
+│   ├── src/<package_name>/
+│   └── tests/
+├── docs/adr/
+├── docs/diagrams/
+├── AGENTS.md
+├── README.md
+└── pyproject.toml        # tooling-only root config
+```
+
+<If this is a data repo, note where data-related paths live, e.g.
+`data/` (gitignored, local only) or `notebooks/` (exploratory, not
+production code), and how they relate to `src/`.>

--- a/templates/content/README/usage.python-single.md
+++ b/templates/content/README/usage.python-single.md
@@ -1,0 +1,6 @@
+```python
+import __PACKAGE_NAME__
+```
+
+Replace this with the entry points, commands, or API this repository is
+actually for.

--- a/templates/content/README/usage.python-workspace.md
+++ b/templates/content/README/usage.python-workspace.md
@@ -1,0 +1,3 @@
+Add the first package with `repo-add-package --package-name your_pkg`, then
+import it from `packages/`. Replace this section with what the workspace is
+actually for once it holds real packages.

--- a/templates/content/README/usage.template.md
+++ b/templates/content/README/usage.template.md
@@ -1,0 +1,10 @@
+| Command | Purpose |
+|---|---|
+| `uv run <entrypoint>` | `<run the app / pipeline / CLI>` |
+| `uv run pytest` | Run tests |
+| `uv run ruff format . && uv run ruff check .` | Format and lint |
+| `uv run ty check` | Type check |
+| `uv build` | Build distributable package |
+
+<Add repo-specific commands here, e.g. running a pipeline end-to-end,
+regenerating a dataset, or launching a notebook kernel.>

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1386,6 +1386,7 @@ def test_readme_shape_declares_the_documented_spine() -> None:
         "At A Glance",
         "Overview",
         "Install",
+        "First 10 Minutes",
         "Configuration",
         "Usage",
         "Repo Structure",

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -1,0 +1,165 @@
+"""The shape produces the reference documents; nothing else may.
+
+These tests guard the property that makes `policy/shapes.yaml` a single source
+rather than one of two things kept in agreement: every shipped reference
+document is a fresh render of the shape, and no fragment carries ordering of
+its own.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from conftest import REPO_ROOT
+
+from repo_standard.policy import load_source_policy
+
+_SPEC = importlib.util.spec_from_file_location(
+    "generate_docs", REPO_ROOT / "scripts" / "generate_docs.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+generate_docs = importlib.util.module_from_spec(_SPEC)
+# `dataclasses` resolves annotations through `sys.modules`, so the module has to
+# be registered before it executes, not after.
+sys.modules[_SPEC.name] = generate_docs
+_SPEC.loader.exec_module(generate_docs)
+
+POLICY = load_source_policy(REPO_ROOT)
+RESERVED = (generate_docs.PREAMBLE, generate_docs.EPILOGUE)
+FRAGMENT = re.compile(r"^(?P<id>.+)\.(?P<variant>[^.]+)\.md$")
+
+
+def _fragment_files() -> list[Path]:
+    return sorted(generate_docs.CONTENT_ROOT.rglob("*.md"))
+
+
+def _headings_outside_code(text: str) -> list[tuple[int, str]]:
+    """Return `(level, heading)` pairs, ignoring anything inside a code fence."""
+    headings: list[tuple[int, str]] = []
+    fence: str | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if fence is None:
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                fence = stripped[:3]
+                continue
+        else:
+            if stripped.startswith(fence):
+                fence = None
+            continue
+        match = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if match is not None:
+            headings.append((len(match.group(1)), match.group(2).strip()))
+    return headings
+
+
+@pytest.mark.parametrize(
+    "target", generate_docs.TARGETS, ids=lambda t: f"{t.variant}-{t.document}"
+)
+def test_shipped_documents_are_not_stale(target: Any) -> None:
+    """`scripts/generate_docs.py` must be a no-op against a clean checkout."""
+    path = target.path / f"{target.document}.md"
+    assert path.read_text(encoding="utf-8") == generate_docs.render(POLICY, target), (
+        f"{path.relative_to(REPO_ROOT).as_posix()} is stale; "
+        "run `uv run python scripts/generate_docs.py`"
+    )
+
+
+@pytest.mark.parametrize(
+    "target", generate_docs.TARGETS, ids=lambda t: f"{t.variant}-{t.document}"
+)
+def test_rendered_headings_are_exactly_the_shape_in_order(target: Any) -> None:
+    """Order is derived from the shape, so a render cannot deviate from it."""
+    shape = POLICY.shape(target.shape)
+    rendered = generate_docs.render(POLICY, target)
+    emitted = [
+        heading
+        for level, heading in _headings_outside_code(rendered)
+        if level == shape.heading_level
+    ]
+    declared = [h for h in shape.headings if h in emitted]
+    assert emitted == declared, (
+        f"{target.variant} {target.document} emitted headings the shape does not "
+        f"declare, or declared ones out of order: {emitted}"
+    )
+    missing = [s.heading for s in shape.sections if s.level == "required"]
+    assert [h for h in missing if h not in emitted] == []
+
+
+@pytest.mark.parametrize("path", _fragment_files(), ids=lambda p: p.name)
+def test_fragments_carry_no_ordering_of_their_own(path: Path) -> None:
+    """A fragment that opens its own section would escape the shape's order."""
+    document = path.parent.name
+    fragment_id = path.name.split(".", maxsplit=1)[0]
+    shape = next(
+        POLICY.shape(t.shape) for t in generate_docs.TARGETS if t.document == document
+    )
+    assert shape.heading_level is not None
+    ceiling = shape.heading_level if fragment_id != generate_docs.PREAMBLE else 0
+    offenders = [
+        heading
+        for level, heading in _headings_outside_code(
+            path.read_text(encoding="utf-8")
+        )
+        if level <= ceiling
+    ]
+    assert not offenders, (
+        f"{path.name} declares its own section headings {offenders}; sections come "
+        "from policy/shapes.yaml, fragments carry prose only"
+    )
+
+
+@pytest.mark.parametrize("path", _fragment_files(), ids=lambda p: p.name)
+def test_every_fragment_is_bound_to_a_declared_section(path: Path) -> None:
+    """An orphan fragment is prose nothing will ever emit."""
+    match = FRAGMENT.match(path.name)
+    assert match is not None, f"{path.name} is not <section-id>.<variant>.md"
+    fragment_id = match.group("id")
+    document = path.parent.name
+    targets = [t for t in generate_docs.TARGETS if t.document == document]
+    assert targets, f"{document}/ has no target that renders it"
+    if fragment_id in RESERVED:
+        return
+    section_ids = {s.id for s in POLICY.shape(targets[0].shape).sections}
+    assert fragment_id in section_ids, (
+        f"{path.name} keys off {fragment_id!r}, which no section of shape "
+        f"{targets[0].shape!r} declares"
+    )
+    variants = {generate_docs.SHARED, *(t.variant for t in targets)}
+    assert match.group("variant") in variants, (
+        f"{path.name} has variant {match.group('variant')!r}; {document} renders "
+        f"only {sorted(variants)}"
+    )
+
+
+def test_generator_tokens_never_reach_shipped_output() -> None:
+    """Generator tokens are resolved here, unlike the repo-init placeholders."""
+    tokens = generate_docs._tokens(POLICY, "python-single")
+    for target in generate_docs.TARGETS:
+        rendered = generate_docs.render(POLICY, target)
+        leftover = [token for token in tokens if token in rendered]
+        assert not leftover, f"{target.variant} {target.document} leaked {leftover}"
+
+
+def test_the_gate_chain_is_injected_from_policy_not_written_by_hand() -> None:
+    """The chain had four hand-maintained copies; there must now be none."""
+    fragments = [
+        path
+        for path in _fragment_files()
+        if path.parent.name == "AGENTS" and path.name.startswith("quality-gates.")
+    ]
+    assert fragments, "the AGENTS quality-gates fragments disappeared"
+    for path in fragments:
+        text = path.read_text(encoding="utf-8")
+        assert "__GATE_CHAIN__" in text, f"{path.name} must defer to policy"
+        for profile in ("python-single", "python-workspace"):
+            commands = POLICY.rule("RSK003").check.config["commands_by_profile"][
+                profile
+            ]
+            restated = [command for command in commands if command in text]
+            assert not restated, f"{path.name} restates the chain: {restated}"

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -22,7 +22,8 @@ from repo_standard.policy import load_source_policy
 _SPEC = importlib.util.spec_from_file_location(
     "generate_docs", REPO_ROOT / "scripts" / "generate_docs.py"
 )
-assert _SPEC is not None and _SPEC.loader is not None
+assert _SPEC is not None
+assert _SPEC.loader is not None
 generate_docs = importlib.util.module_from_spec(_SPEC)
 # `dataclasses` resolves annotations through `sys.modules`, so the module has to
 # be registered before it executes, not after.
@@ -103,9 +104,7 @@ def test_fragments_carry_no_ordering_of_their_own(path: Path) -> None:
     ceiling = shape.heading_level if fragment_id != generate_docs.PREAMBLE else 0
     offenders = [
         heading
-        for level, heading in _headings_outside_code(
-            path.read_text(encoding="utf-8")
-        )
+        for level, heading in _headings_outside_code(path.read_text(encoding="utf-8"))
         if level <= ceiling
     ]
     assert not offenders, (

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 import tomlkit
-from conftest import dump_yaml, load_yaml
+from conftest import REPO_ROOT, dump_yaml, load_yaml
 
 from repo_standard.compliance.checks import check_repo, load_policy
 from repo_standard.repo_adopt import (
     AdoptionError,
     CommandError,
     _kit_version,
+    _merge_agents,
+    _merge_pyproject,
+    _merge_readme,
+    _project_values,
     _run,
     apply_plan,
     main,
@@ -228,40 +233,11 @@ def test_non_uv_build_backend_is_preserved_without_conflict(tmp_path: Path) -> N
     assert not [finding for finding in findings if finding.level == "required"]
 
 
-def _make_shape_conforming(root: Path) -> None:
-    """Bring the surfaces adoption does not yet reshape onto their shapes.
-
-    Adoption appends `[dependency-groups]` after `[build-system]` and only
-    appends a standards section to an existing README, so neither reaches the
-    shapes RSK023 and RSK025 declare. Until the generator lands, this test
-    supplies conforming versions itself so the zero-finding precondition is
-    real rather than assumed.
-    """
-    policy = load_policy()
-    readme = "\n\n".join(
-        f"## {heading}\n\nDetail." for heading in policy.shape("readme").required
-    )
-    (root / "README.md").write_text(
-        f"# Existing Project\n\nKeep this project-specific guide, "
-        f"aligned with repo-standard-kit.\n\n{readme}\n",
-        encoding="utf-8",
-    )
-    document = tomlkit.parse((root / "pyproject.toml").read_text(encoding="utf-8"))
-    groups = document.pop("dependency-groups")
-    build = document.pop("build-system")
-    tool = document.pop("tool")
-    document["dependency-groups"] = groups
-    document["build-system"] = build
-    document["tool"] = tool
-    (root / "pyproject.toml").write_text(tomlkit.dumps(document), encoding="utf-8")
-
-
 def test_structurally_compliant_repository_is_a_no_op(tmp_path: Path) -> None:
     root = tmp_path / "existing"
     _write_minimal_repo(root, "python-single")
     apply_plan(plan_adoption(root, "python-single"))
     (root / "LICENSE").write_text("Approved license terms.\n", encoding="utf-8")
-    _make_shape_conforming(root)
 
     pre_commit = root / ".pre-commit-config.yaml"
     hooks = load_yaml(pre_commit.read_text(encoding="utf-8"))
@@ -457,3 +433,120 @@ def test_native_tls_is_forwarded_to_dependency_commands(
 
     assert main([str(root), "--profile", "python-single", "--native-tls"]) == 0
     assert commands == [(["uv", "lock"], True), (["uv", "sync"], True)]
+
+
+def test_this_repository_is_its_own_first_adopter() -> None:
+    """`repo-adopt .` must plan nothing against the kit that publishes it."""
+    plan = plan_adoption(REPO_ROOT, "python-single")
+
+    assert plan.changes == ()
+    assert plan.conflicts == ()
+
+
+def test_self_adoption_is_a_real_no_op_not_a_short_circuit() -> None:
+    """Prove the merges agree with the committed files.
+
+    `plan_adoption` returns early when the repository already has no findings,
+    so the plan being empty would also be satisfied by merges that disagree
+    with what is committed. Run them directly instead.
+    """
+    path = REPO_ROOT / "pyproject.toml"
+    document = tomlkit.parse(path.read_text(encoding="utf-8"))
+    values = _project_values(REPO_ROOT, document)
+
+    for relative, merge in (("AGENTS.md", _merge_agents), ("README.md", _merge_readme)):
+        target = REPO_ROOT / relative
+        assert merge(target, "python-single", values) == target.read_text(
+            encoding="utf-8"
+        ), f"repo-adopt would rewrite {relative}"
+
+    merged, _changed, conflicts = _merge_pyproject(path, document, "python-single")
+    assert conflicts == []
+    assert merged == path.read_text(encoding="utf-8")
+
+
+def _h2(text: str) -> list[str]:
+    return re.findall(r"^##\s+(.+?)\s*$", text, re.MULTILINE)
+
+
+def _is_subsequence(actual: list[str], declared: tuple[str, ...]) -> bool:
+    seen = [item for item in actual if item in declared]
+    return seen == [item for item in declared if item in seen]
+
+
+@pytest.mark.parametrize(
+    ("document", "rule_id", "last_section"),
+    [
+        ("AGENTS.md", "RSK002", "Change Control Notes"),
+        ("README.md", "RSK023", "License"),
+    ],
+)
+def test_repaired_sections_land_in_shape_order(
+    tmp_path: Path, document: str, rule_id: str, last_section: str
+) -> None:
+    """A missing section must not be appended past the ones that follow it.
+
+    Appending was safe while RSK002 only checked presence. Now that shapes are
+    order-enforced, appending would trade a missing-section finding for an
+    out-of-order one.
+    """
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    (root / document).write_text(
+        f"# Existing\n\nKeep this.\n\n## {last_section}\n\nProject-owned prose.\n",
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    policy = load_policy()
+    shape = policy.shape(policy.rule(rule_id).check.config["shape"])
+    headings = _h2((root / document).read_text(encoding="utf-8"))
+    assert headings[-1] == last_section, "the project's own section moved"
+    assert _is_subsequence(headings, shape.headings), (
+        f"{document} sections are out of canonical order: {headings}"
+    )
+    assert "Project-owned prose." in (root / document).read_text(encoding="utf-8")
+
+
+def test_adoption_invents_no_heading_the_shape_does_not_declare(
+    tmp_path: Path,
+) -> None:
+    """The RSK005 reference used to arrive as a `Repository Standards` section."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    policy = load_policy()
+    for document, rule_id in (("AGENTS.md", "RSK002"), ("README.md", "RSK023")):
+        text = (root / document).read_text(encoding="utf-8")
+        declared = policy.shape(policy.rule(rule_id).check.config["shape"]).headings
+        assert "Repository Standards" not in _h2(text)
+        assert set(_h2(text)) <= set(declared), (
+            f"adoption added headings to {document} that no shape declares"
+        )
+        assert "repo-standard-kit" in text
+
+
+def test_new_pyproject_tables_are_placed_in_declared_order(tmp_path: Path) -> None:
+    """`[dependency-groups]` used to be appended after `[build-system]`."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8") + '\n[tool.ty.src]\nroot = "src"\n',
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    policy = load_policy()
+    shape = policy.shape(policy.rule("RSK025").check.config["shape"])
+    tables = re.findall(
+        r"^\[\[?\s*([^\]\s]+)\s*\]\]?$",
+        pyproject.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert _is_subsequence(tables, shape.headings), f"table order is wrong: {tables}"
+    assert tables.index("dependency-groups") < tables.index("build-system")


### PR DESCRIPTION
Phase 2 of #39: make the shape *produce* the reference documents rather than
merely describe them, and make `repo-adopt` shape-driven on both sides.

Staged on `chore/release-v2.0.0`, on top of Phase 1 (#40). Phase 3 (#43)
follows in its own PR.

## The generator

Prose now lives in `templates/content/<DOC>/<section-id>.<variant>.md`
fragments keyed by the shape's section id. No fragment carries a heading at the
shape's level, so none of them carries ordering.
`scripts/generate_docs.py` walks the shape's ordered section list and emits
`## <Heading>` plus the fragment resolved for the target, rendering
`templates/{README,AGENTS}.md` and both starter kits'
`{README,AGENTS,CHANGELOG}.md`.

Resolution is `(document, section, variant)` falling back to `shared`, so a
section identical across profiles is written once — 8 documents render from 51
fragments. Two ids are reserved and are not shape sections: `_preamble` (title
and any prose before the first heading) and `_epilogue` (link definitions).
Shape section ids are kebab-case, so the leading underscore cannot collide.

A section the shape does not declare cannot be emitted, and reordering a
document means editing `policy/shapes.yaml`. That the CHANGELOGs regenerate
byte-identical, and the rest differ only where this PR intends, is the evidence
the decomposition is faithful.

**No new dependency.** The one generator-owned token, `__GATE_CHAIN__`, is
resolved from RSK003's `commands_by_profile` before anything is written, and is
deliberately not an RSK011 placeholder — those must survive verbatim into the
starter kits for `repo-init` to fill per repository. The chain had four
hand-maintained copies; it now has none, and a test enforces that the AGENTS
quality-gates fragments defer to policy rather than restating it.

## `repo-adopt` becomes shape-driven

**Sections are repaired in shape order.** A missing required section used to be
appended to the end of `AGENTS.md`. That was safe only while RSK002 checked
presence alone — Phase 1 gave it order enforcement, so appending would have
traded a missing-section finding for an out-of-order one. Insertion now lands
before the first declared section that follows it canonically, and the same
path drives `README.md`, which previously got no section repair at all.

**The invented heading is gone.** Adoption used to append a
`## Repository Standards` section that no shape declared — the fourth README
shape #39 set out to eliminate. The RSK005 reference now goes into
`Repository Context` and `Development`, sections the shapes already require. A
test asserts adoption adds no heading outside the shape.

**New `pyproject.toml` tables are placed, not appended**, in the order RSK025
declares, so `[dependency-groups]` no longer lands after `[build-system]` and
`[tool.repo-standard]` no longer splits the Ruff tables. tomlkit has no
public insert-before, so the declared tables that should follow are lifted out
and put back in order; each carries its own contents and trivia, so only
position moves.

That last change is what lets `_make_shape_conforming` go. Phase 1 added it so
`test_structurally_compliant_repository_is_a_no_op` kept a real zero-finding
precondition for the two surfaces adoption did not reshape. **The fixture
repository now reaches its shapes through adoption rather than through the
test**, which is the point of the phase.

## Two changes beyond the plan

**`First 10 Minutes` joins the README spine** as an optional section between
`Install` and `Configuration`. Both starter READMEs already shipped that
section, and the generator can only emit what the shape declares — so without
it the shape could not render the documents the kit itself publishes, and the
single-source claim would have been false on arrival. Optional and
subsequence-checked, so it constrains nothing that does not already use the
heading.

**Table ordering in `repo-adopt`** is not in #39's Phase 2 list, but RSK025
becomes required in Phase 3. Without it, every adopted repository would fail a
required rule the moment Phase 3 lands.

## Correcting `templates/README.md:117`

It told adopters to keep their README aligned with `templates/` — a path no
tooling reads. It now states that the section order is RSK023, published in
`docs/policy-reference.md`, reported by `repo-check .`, and repaired by
`repo-adopt .`. The same correction lands in both starter READMEs, which
carried the same claim.

## Gates

- `uv run python scripts/generate_docs.py` then diff — committed templates and
  starter kits are not stale. A parametrized test enforces this per target.
- `uv run repo-adopt . --dry-run` — plans zero changes. A second test runs the
  merges directly against the repository root, because `plan_adoption` returns
  early when there are no findings and an empty plan alone would not prove the
  merges agree with what is committed.
- `uv run pytest` — 338 pass (up from 212).
- `uv run repo-check . --strict` — clean.
- `uv run pre-commit run --all-files`, `uv build` — clean.

## What Phase 3 still needs

RSK023/RSK024/RSK025 are still `recommended` on this branch. #43 promotes them
to `required`, restates the contract in `docs/repo-standard.md` at required
level, and finalises the **Adopters must** entry.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
