### PR TITLE
State how agents work in policy: operating dials and single source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,62 @@ Agents must not:
 - add a first-class language profile without complete documentation and starter
   assets
 
+## Agent Operating Mode
+
+Agent behaviour in this repository is calibrated, not left to model defaults.
+Each dial runs from 1 to 5, where 5 is the maximum:
+
+- **Verbosity:** 2 / 5
+- **Precision, repeatability, determinism:** 4 / 5
+
+Low verbosity means:
+
+- Answer what was asked; do not restate the request or read the plan back
+- Report outcomes, not a narration of the steps taken to reach them
+- Prefer a diff, a command, or a `path:line` reference over prose describing it
+- Open with the result; no preamble, and no recap the transcript already shows
+- Spend words on decisions the reader must make, on risks, and on failures
+
+High precision, repeatability, and determinism mean:
+
+- Verify against the repository before asserting, and cite `path:line`
+- Reuse the pattern already in the file rather than introducing a second one
+- Make the smallest change that satisfies the requirement, and nothing beyond it
+- Run the documented quality gates in order and report their real output
+- Pin versions, ordering, and formatting rather than leaving them to chance
+- State assumptions explicitly where the repository does not settle a choice
+- The same task on the same input should reach the same result on a second run
+
+The levels are policy values, not prose: `repo-check` reports drift from them
+and `repo-adopt` restores them.
+
+## Single Source Of Truth
+
+Anything stated twice drifts, and the copy that drifts is the one nobody is
+reading when it matters. Before writing, look for what already exists and
+derive from it.
+
+- **One home per fact.** A value, a command, a version, a path, a section
+  order, a schema: declared in exactly one place, with every other use reading
+  from that place
+- **Derive, do not copy.** Where two artefacts must agree, generate one from
+  the other or both from a shared source, and put the check that they still
+  agree in the quality gates
+- **Reference, do not restate.** Link to the document that owns a subject
+  instead of summarising it somewhere it will go stale
+- **Extend rather than parallel.** A second helper, constant, fixture, config
+  key, or type that means what an existing one means is duplication even when
+  the wording differs — change the original instead
+- **Make unavoidable duplication fail loudly.** Where a copy cannot be removed,
+  add a test or check that regenerates it and compares, so drift is a failure
+  rather than a surprise
+- **Deleting the stale copy is part of the change** that made it stale, not a
+  follow-up
+
+This applies to code, configuration, documentation, fixtures, and data alike.
+When a change means editing the same fact in more than one file, treat that as
+the defect to fix first.
+
 ## Workflow
 
 1. Update canonical YAML policy and its explanatory normative docs together

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,26 @@ the changes listed under **Adopters must**.
 - A self-adoption gate: `repo-adopt .` against this repository must plan zero
   changes, and the individual merges must agree with the committed files rather
   than relying on the no-findings short-circuit.
+- **Agent Operating Mode.** A new required `AGENTS.md` section, and RSK026
+  (**required**) enforcing what it states. Agent behaviour was previously left
+  to model defaults, so the same task produced materially different work in two
+  repositories adopting the same standard. The standard now calibrates two
+  dials — verbosity at 2/5, and precision, repeatability, and determinism at
+  4/5 — and calibrates them the way it calibrates the gate chain: as values in
+  `policy/base.yaml` that the generator renders into every reference document,
+  `repo-check` reports drift from, and `repo-adopt` restores. The check reads
+  the dial lines and nothing else, so the prose around them stays the
+  repository's own. `docs/policy-reference.md` publishes the levels, so no
+  prose document keeps a copy that can drift.
+- **Single Source Of Truth.** A new required `AGENTS.md` section stating the
+  rule that anything recorded twice drifts: one home per fact, derive rather
+  than copy, reference rather than restate, extend an existing definition
+  rather than adding a parallel one, make unavoidable duplication fail through
+  a check, and delete the stale copy as part of the change that staled it. It
+  applies to code, configuration, documentation, fixtures, and data alike. The
+  section is shared across profiles rather than varied per profile, because a
+  profile variant replaces the shared fragment outright and would have to
+  restate it.
 
 ### Changed
 
@@ -115,6 +135,12 @@ the changes listed under **Adopters must**.
   also requires their order, so a repository that ordered them differently
   moves from passing to a required finding. `repo-check .` names the sections
   it found out of order.
+- Add `## Agent Operating Mode` and `## Single Source Of Truth` to `AGENTS.md`,
+  in that order between `Human And Agent Responsibilities` and `Workflow`.
+  RSK002 reports either missing section as a required finding, and RSK026
+  reports dial levels that are missing or have drifted from the ones
+  `docs/policy-reference.md` publishes. `repo-adopt` writes both sections and
+  restores the levels, keeping any prose you add around them.
 - Bring `README.md`, `CHANGELOG.md`, and `pyproject.toml` onto the shapes
   `docs/repo-standard.md` declares. RSK023, RSK024, and RSK025 are still
   recommended at this point on the branch and become required before v2.0.0

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -44,6 +44,8 @@ documents are produced by walking it in the order below.
 | `repository-purpose` | `Repository Purpose` | `required` |
 | `repository-context` | `Repository Context` | `required` |
 | `human-and-agent-responsibilities` | `Human And Agent Responsibilities` | `required` |
+| `agent-operating-mode` | `Agent Operating Mode` | `required` |
+| `single-source-of-truth` | `Single Source Of Truth` | `required` |
 | `workflow` | `Workflow` | `required` |
 | `quality-gates` | `Quality Gates` | `required` |
 | `coding-standards` | `Coding Standards` | `required` |
@@ -396,6 +398,23 @@ Remediation: Add an Unreleased section, and keep any Compatibility Policy sectio
 Rationale: A predictable table order keeps related configuration together and stops generated and hand-edited manifests from diverging.
 
 Remediation: Order the declared pyproject tables as the pyproject shape declares; tables the shape does not list may appear anywhere.
+
+### RSK026: AGENTS.md states the calibrated agent operating dials
+
+- Level: `required`
+- Profiles: `python-single`, `python-workspace`
+- Source: [`docs/repo-standard.md` — Agent Operating Mode](../docs/repo-standard.md)
+- Enforcement: `structural`
+- Check kind: `agents_operating_dials`
+
+Rationale: Agent behaviour left to model defaults varies between runs and between repositories. Stating the calibration where agents already read their operating boundaries is what makes the work consistent across every repository adopting the standard.
+
+Remediation: State each dial in the Agent Operating Mode section of AGENTS.md, in the declared order and at the declared level.
+
+| Dial | Level |
+| --- | --- |
+| Verbosity | 2 / 5 |
+| Precision, repeatability, determinism | 4 / 5 |
 
 ## Retired Rule IDs
 

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -120,13 +120,15 @@ Every target repository must include:
 1. Repository Purpose
 2. Repository Context
 3. Human And Agent Responsibilities
-4. Workflow
-5. Quality Gates
-6. Coding Standards
-7. Testing Policy
-8. Documentation Rules
-9. Repository Layout
-10. Change Control Notes
+4. Agent Operating Mode
+5. Single Source Of Truth
+6. Workflow
+7. Quality Gates
+8. Coding Standards
+9. Testing Policy
+10. Documentation Rules
+11. Repository Layout
+12. Change Control Notes
 
 Committed copies must not contain placeholders or generic filler text.
 
@@ -136,6 +138,35 @@ at the **required** level that the `## Quality Gates` section in `AGENTS.md`
 states the exact ordered command chain defined by policy for the resolved
 profile. Commands elsewhere in the document do not count. These checks do not
 attempt subjective scoring of the section prose.
+
+## Agent Operating Mode
+
+Agent behaviour left to model defaults varies between runs and between
+repositories, which is the opposite of what a standard is for. The standard
+therefore calibrates two dials — *verbosity*, and *precision, repeatability,
+and determinism* — and calibrates them the way it calibrates the gate chain: as
+policy values a check reports drift from, not as prose an adopter silently
+rewrites.
+
+*Low verbosity* means answering what was asked, reporting outcomes rather than
+narrating steps, preferring a diff or a `path:line` reference to prose
+describing it, and spending words on decisions, risks, and failures.
+
+*High precision, repeatability, and determinism* mean verifying against the
+repository before asserting, reusing the pattern already in the file, making
+the smallest change that satisfies the requirement, running the documented
+gates in order and reporting their real output, pinning what can be pinned,
+stating assumptions where the repository does not settle a choice, and reaching
+the same result when the same task runs again.
+
+RSK026 enforces at the **required** level that the `## Agent Operating Mode`
+section of `AGENTS.md` states every dial, in the declared order, at the level
+`policy/base.yaml` declares. The level of each dial is published in
+[`docs/policy-reference.md`](policy-reference.md#rsk026-agentsmd-states-the-calibrated-agent-operating-dials)
+and stated nowhere by hand: the generator renders it into every reference
+document from the rule, `repo-check` reports a document that has drifted, and
+`repo-adopt` restores it. The surrounding prose is the repository's own — the
+check reads the dial lines and nothing else.
 
 ## File Shapes
 

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -491,3 +491,32 @@ rules:
     remediation: >-
       Order the declared pyproject tables as the pyproject shape declares;
       tables the shape does not list may appear anywhere.
+
+  - id: RSK026
+    title: AGENTS.md states the calibrated agent operating dials
+    level: required
+    profiles: [python-single, python-workspace]
+    source:
+      document: docs/repo-standard.md
+      section: Agent Operating Mode
+    enforcement: structural
+    check:
+      kind: agents_operating_dials
+      config:
+        path: AGENTS.md
+        section: Agent Operating Mode
+        dials:
+          - label: Verbosity
+            level: 2
+            scale: 5
+          - label: Precision, repeatability, determinism
+            level: 4
+            scale: 5
+    rationale: >-
+      Agent behaviour left to model defaults varies between runs and between
+      repositories. Stating the calibration where agents already read their
+      operating boundaries is what makes the work consistent across every
+      repository adopting the standard.
+    remediation: >-
+      State each dial in the Agent Operating Mode section of AGENTS.md, in the
+      declared order and at the declared level.

--- a/policy/shapes.yaml
+++ b/policy/shapes.yaml
@@ -16,6 +16,12 @@ shapes:
       - id: human-and-agent-responsibilities
         heading: Human And Agent Responsibilities
         level: required
+      - id: agent-operating-mode
+        heading: Agent Operating Mode
+        level: required
+      - id: single-source-of-truth
+        heading: Single Source Of Truth
+        level: required
       - id: workflow
         heading: Workflow
         level: required

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -88,9 +88,14 @@ def _tokens(policy: Policy, profile: str) -> dict[str, str]:
     These are filled here, so no shipped file ever carries one.
     """
     commands = policy.rule("RSK003").check.config["commands_by_profile"][profile]
+    dials = policy.rule("RSK026").check.config["dials"]
     return {
         "__GATE_CHAIN__": "\n".join(
             f"{index}. `{command}`" for index, command in enumerate(commands, 1)
+        ),
+        "__AGENT_DIALS__": "\n".join(
+            f"- **{dial['label']}:** {dial['level']} / {dial['scale']}"
+            for dial in dials
         ),
         "__STANDARD_MAJOR__": policy.standard_major,
     }

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -324,24 +324,30 @@ def _text_contains_all(context: CheckContext, config: dict[str, Any]) -> list[Is
     ]
 
 
+def _section_body(text: str, heading: str) -> str | None:
+    """Return the body of the level-two section named `heading`, if present."""
+    match = re.search(
+        rf"^##\s+{re.escape(heading)}\s*$\n?(?P<body>.*?)(?=^##\s+|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match is not None else None
+
+
 def _agents_quality_commands(
     context: CheckContext, config: dict[str, Any]
 ) -> list[Issue]:
     text = _read(context.root / config["path"])
     if text is None:
         return []
-    section_match = re.search(
-        r"^##\s+Quality Gates\s*$\n?(?P<body>.*?)(?=^##\s+|\Z)",
-        text,
-        re.MULTILINE | re.DOTALL,
-    )
+    body = _section_body(text, "Quality Gates")
     actual: list[str] = []
-    if section_match is not None:
+    if body is not None:
         actual = [
             re.sub(r"\s+", " ", command).strip()
             for command in re.findall(
                 r"^\s*(?:\d+[.)]|[-*+])\s+`([^`\r\n]+)`\s*$",
-                section_match.group("body"),
+                body,
                 re.MULTILINE,
             )
         ]
@@ -353,6 +359,52 @@ def _agents_quality_commands(
             config["path"],
             "Quality Gates must list the exact ordered commands for profile "
             f"{context.profile!r}.",
+            actual,
+            expected,
+        )
+    ]
+
+
+_DIAL_LINE = re.compile(
+    r"^[ \t]*[-*+][ \t]+\*\*(?P<label>[^*\r\n]+?)[ \t]*:?\*\*[ \t]*"
+    r"(?P<level>\d+)[ \t]*/[ \t]*(?P<scale>\d+)[ \t]*$",
+    re.MULTILINE,
+)
+
+
+def _dial(label: str, level: object, scale: object) -> str:
+    return f"{label}: {level} / {scale}"
+
+
+def _agents_operating_dials(
+    context: CheckContext, config: dict[str, Any]
+) -> list[Issue]:
+    """RSK026: the operating dials are policy values, not prose an editor owns.
+
+    Deliberately parallel to `_agents_quality_commands`: the section must state
+    every dial, in the declared order, at the declared level. Prose around them
+    is the repository's business.
+    """
+    text = _read(context.root / config["path"])
+    if text is None:
+        return []
+    body = _section_body(text, config["section"])
+    actual: list[str] = []
+    if body is not None:
+        actual = [
+            _dial(
+                match.group("label").strip(), match.group("level"), match.group("scale")
+            )
+            for match in _DIAL_LINE.finditer(body)
+        ]
+    expected = [_dial(d["label"], d["level"], d["scale"]) for d in config["dials"]]
+    if actual == expected:
+        return []
+    return [
+        Issue(
+            config["path"],
+            f"{config['section']} must state every dial, in order, at the level "
+            "policy declares.",
             actual,
             expected,
         )
@@ -1450,6 +1502,7 @@ CHECK_HANDLERS: dict[str, CheckHandler] = {
     "toml_table_order": _toml_table_order,
     "text_contains_all": _text_contains_all,
     "agents_quality_commands": _agents_quality_commands,
+    "agents_operating_dials": _agents_operating_dials,
     "text_pattern_each": _text_pattern_each,
     "github_workflow_commands": _github_workflow_commands,
     "pre_commit_hooks": _pre_commit_hooks,

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -733,6 +733,41 @@
         "section": "File Shapes"
       },
       "title": "pyproject.toml declares tables in the canonical order"
+    },
+    {
+      "check": {
+        "config": {
+          "dials": [
+            {
+              "label": "Verbosity",
+              "level": 2,
+              "scale": 5
+            },
+            {
+              "label": "Precision, repeatability, determinism",
+              "level": 4,
+              "scale": 5
+            }
+          ],
+          "path": "AGENTS.md",
+          "section": "Agent Operating Mode"
+        },
+        "kind": "agents_operating_dials"
+      },
+      "enforcement": "structural",
+      "id": "RSK026",
+      "level": "required",
+      "profiles": [
+        "python-single",
+        "python-workspace"
+      ],
+      "rationale": "Agent behaviour left to model defaults varies between runs and between repositories. Stating the calibration where agents already read their operating boundaries is what makes the work consistent across every repository adopting the standard.",
+      "remediation": "State each dial in the Agent Operating Mode section of AGENTS.md, in the declared order and at the declared level.",
+      "source": {
+        "document": "docs/repo-standard.md",
+        "section": "Agent Operating Mode"
+      },
+      "title": "AGENTS.md states the calibrated agent operating dials"
     }
   ],
   "schema_version": 1,
@@ -758,6 +793,16 @@
         {
           "heading": "Human And Agent Responsibilities",
           "id": "human-and-agent-responsibilities",
+          "level": "required"
+        },
+        {
+          "heading": "Agent Operating Mode",
+          "id": "agent-operating-mode",
+          "level": "required"
+        },
+        {
+          "heading": "Single Source Of Truth",
+          "id": "single-source-of-truth",
           "level": "required"
         },
         {

--- a/src/repo_standard/policy/compiler.py
+++ b/src/repo_standard/policy/compiler.py
@@ -97,6 +97,16 @@ def render_reference(policy: Policy) -> str:
                 "",
             ]
         )
+        # Most check config is machinery. Dials are calibrated values a reader
+        # of the standard needs, so publishing them here keeps prose documents
+        # from having to keep a copy that can drift.
+        if "dials" in rule.check.config:
+            lines.extend(["| Dial | Level |", "| --- | --- |"])
+            lines.extend(
+                f"| {dial['label']} | {dial['level']} / {dial['scale']} |"
+                for dial in rule.check.config["dials"]
+            )
+            lines.append("")
     if policy.retired_rule_ids:
         lines.extend(
             [

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -35,6 +35,7 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
     "toml_table_order": ({"shape"}, set()),
     "text_contains_all": ({"path", "values"}, set()),
     "agents_quality_commands": ({"path", "commands_by_profile"}, set()),
+    "agents_operating_dials": ({"path", "section", "dials"}, set()),
     "text_pattern_each": ({"paths", "pattern"}, set()),
     "github_workflow_commands": (
         {"path", "job", "trigger", "commands_by_profile"},
@@ -340,6 +341,24 @@ def _validate_hook(value: Any, location: str) -> None:
             _boolean(data[key], f"{location}.{key}")
 
 
+def _validate_dials(value: Any, location: str) -> None:
+    """A dial is one calibrated behaviour, stated as a level out of a scale."""
+    if not isinstance(value, list) or not value:
+        _fail(location, "expected a non-empty list")
+    labels: list[str] = []
+    for index, item in enumerate(value):
+        where = f"{location}[{index}]"
+        data = _mapping(item, where)
+        _keys(data, where, required={"label", "level", "scale"})
+        labels.append(_string(data["label"], f"{where}.label"))
+        level = _integer(data["level"], f"{where}.level")
+        scale = _integer(data["scale"], f"{where}.scale")
+        if not 1 <= level <= scale:
+            _fail(f"{where}.level", f"expected 1..{scale}, got {level}")
+    if len(labels) != len(set(labels)):
+        _fail(location, "contains duplicate labels")
+
+
 def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> None:
     required, optional = CHECK_SCHEMAS[kind]
     _keys(config, location, required=required, optional=optional)
@@ -353,6 +372,7 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         "trigger",
         "standard_major",
         "shape",
+        "section",
     ):
         if key in config:
             _string(config[key], f"{location}.{key}")
@@ -414,6 +434,8 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
             _fail(f"{location}.hooks", "expected a non-empty list")
         for index, hook in enumerate(hooks):
             _validate_hook(hook, f"{location}.hooks[{index}]")
+    if "dials" in config:
+        _validate_dials(config["dials"], f"{location}.dials")
 
 
 @dataclass(frozen=True)

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -102,6 +102,10 @@ _COMMAND_LIST_BLOCK = re.compile(
     r"(?:^[ \t]*(?:\d+[.)]|[-*+])[ \t]+`[^`\r\n]+`[ \t]*\r?\n?)+",
     re.MULTILINE,
 )
+_DIAL_LIST_BLOCK = re.compile(
+    r"(?:^[ \t]*[-*+][ \t]+\*\*[^*\r\n]+\*\*[ \t]*\d+[ \t]*/[ \t]*\d+[ \t]*\r?\n?)+",
+    re.MULTILINE,
+)
 _ROUND_TRIP_YAML = YAML()
 _ROUND_TRIP_YAML.preserve_quotes = True
 _ROUND_TRIP_YAML.width = 88
@@ -659,27 +663,46 @@ def _ensure_standards_reference(text: str, shape: Shape) -> str:
     )
 
 
-def _reconcile_gate_chain(text: str, profile: str) -> str:
-    quality = _section(text, "Quality Gates")
-    assert quality is not None
-    block = quality[2]
-    heading_line, _, body = block.partition("\n")
-    commands = load_policy().rule("RSK003").check.config["commands_by_profile"][profile]
-    command_block = "\n".join(
-        f"{index}. `{command}`" for index, command in enumerate(commands, 1)
-    )
-    list_match = _COMMAND_LIST_BLOCK.search(body)
-    if list_match is not None:
-        body = (
-            body[: list_match.start()] + command_block + "\n" + body[list_match.end() :]
-        )
+def _reconcile_block(
+    text: str, heading: str, block: str, pattern: re.Pattern[str]
+) -> str:
+    """Restate a policy-owned block inside a section the document already has.
+
+    An existing block is replaced where it stands, so surrounding prose keeps
+    its position; a section that states nothing gets the block first, ahead of
+    whatever prose it does carry.
+    """
+    location = _section(text, heading)
+    assert location is not None
+    heading_line, _, body = location[2].partition("\n")
+    match = pattern.search(body)
+    if match is not None:
+        body = body[: match.start()] + block + "\n" + body[match.end() :]
         replacement = f"{heading_line}\n{body}"
     else:
-        replacement = f"{heading_line}\n\n{command_block}\n"
+        replacement = f"{heading_line}\n\n{block}\n"
         if body.strip():
             replacement += "\n" + body.strip("\r\n") + "\n"
     replacement = replacement.rstrip() + "\n\n"
-    return text[: quality[0]] + replacement + text[quality[1] :]
+    return text[: location[0]] + replacement + text[location[1] :]
+
+
+def _reconcile_gate_chain(text: str, profile: str) -> str:
+    commands = load_policy().rule("RSK003").check.config["commands_by_profile"][profile]
+    block = "\n".join(
+        f"{index}. `{command}`" for index, command in enumerate(commands, 1)
+    )
+    return _reconcile_block(text, "Quality Gates", block, _COMMAND_LIST_BLOCK)
+
+
+def _reconcile_operating_dials(text: str) -> str:
+    """RSK026: the dial levels come from policy, never from the existing text."""
+    config = load_policy().rule("RSK026").check.config
+    block = "\n".join(
+        f"- **{dial['label']}:** {dial['level']} / {dial['scale']}"
+        for dial in config["dials"]
+    )
+    return _reconcile_block(text, config["section"], block, _DIAL_LIST_BLOCK)
 
 
 def _existing(path: Path) -> str | None:
@@ -705,6 +728,7 @@ def _merge_agents(path: Path, profile: str, values: dict[str, str]) -> str:
     shape = _shape_for("RSK002")
     text = _fill_required_sections(text, shape, reference)
     text = _reconcile_gate_chain(text, profile)
+    text = _reconcile_operating_dials(text)
     return _ensure_standards_reference(text, shape)
 
 

--- a/src/repo_standard/starter_kits/python-single/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-single/AGENTS.md
@@ -34,6 +34,62 @@ Agents own:
 - docs updates tied to behavior changes
 - running documented quality gates
 
+## Agent Operating Mode
+
+Agent behaviour in this repository is calibrated, not left to model defaults.
+Each dial runs from 1 to 5, where 5 is the maximum:
+
+- **Verbosity:** 2 / 5
+- **Precision, repeatability, determinism:** 4 / 5
+
+Low verbosity means:
+
+- Answer what was asked; do not restate the request or read the plan back
+- Report outcomes, not a narration of the steps taken to reach them
+- Prefer a diff, a command, or a `path:line` reference over prose describing it
+- Open with the result; no preamble, and no recap the transcript already shows
+- Spend words on decisions the reader must make, on risks, and on failures
+
+High precision, repeatability, and determinism mean:
+
+- Verify against the repository before asserting, and cite `path:line`
+- Reuse the pattern already in the file rather than introducing a second one
+- Make the smallest change that satisfies the requirement, and nothing beyond it
+- Run the documented quality gates in order and report their real output
+- Pin versions, ordering, and formatting rather than leaving them to chance
+- State assumptions explicitly where the repository does not settle a choice
+- The same task on the same input should reach the same result on a second run
+
+The levels are policy values, not prose: `repo-check` reports drift from them
+and `repo-adopt` restores them.
+
+## Single Source Of Truth
+
+Anything stated twice drifts, and the copy that drifts is the one nobody is
+reading when it matters. Before writing, look for what already exists and
+derive from it.
+
+- **One home per fact.** A value, a command, a version, a path, a section
+  order, a schema: declared in exactly one place, with every other use reading
+  from that place
+- **Derive, do not copy.** Where two artefacts must agree, generate one from
+  the other or both from a shared source, and put the check that they still
+  agree in the quality gates
+- **Reference, do not restate.** Link to the document that owns a subject
+  instead of summarising it somewhere it will go stale
+- **Extend rather than parallel.** A second helper, constant, fixture, config
+  key, or type that means what an existing one means is duplication even when
+  the wording differs — change the original instead
+- **Make unavoidable duplication fail loudly.** Where a copy cannot be removed,
+  add a test or check that regenerates it and compares, so drift is a failure
+  rather than a surprise
+- **Deleting the stale copy is part of the change** that made it stale, not a
+  follow-up
+
+This applies to code, configuration, documentation, fixtures, and data alike.
+When a change means editing the same fact in more than one file, treat that as
+the defect to fix first.
+
 ## Workflow
 
 - Long-lived branch: `main`

--- a/src/repo_standard/starter_kits/python-workspace/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-workspace/AGENTS.md
@@ -36,6 +36,62 @@ Agents own:
 - docs updates tied to behavior changes
 - running repo-wide quality gates
 
+## Agent Operating Mode
+
+Agent behaviour in this repository is calibrated, not left to model defaults.
+Each dial runs from 1 to 5, where 5 is the maximum:
+
+- **Verbosity:** 2 / 5
+- **Precision, repeatability, determinism:** 4 / 5
+
+Low verbosity means:
+
+- Answer what was asked; do not restate the request or read the plan back
+- Report outcomes, not a narration of the steps taken to reach them
+- Prefer a diff, a command, or a `path:line` reference over prose describing it
+- Open with the result; no preamble, and no recap the transcript already shows
+- Spend words on decisions the reader must make, on risks, and on failures
+
+High precision, repeatability, and determinism mean:
+
+- Verify against the repository before asserting, and cite `path:line`
+- Reuse the pattern already in the file rather than introducing a second one
+- Make the smallest change that satisfies the requirement, and nothing beyond it
+- Run the documented quality gates in order and report their real output
+- Pin versions, ordering, and formatting rather than leaving them to chance
+- State assumptions explicitly where the repository does not settle a choice
+- The same task on the same input should reach the same result on a second run
+
+The levels are policy values, not prose: `repo-check` reports drift from them
+and `repo-adopt` restores them.
+
+## Single Source Of Truth
+
+Anything stated twice drifts, and the copy that drifts is the one nobody is
+reading when it matters. Before writing, look for what already exists and
+derive from it.
+
+- **One home per fact.** A value, a command, a version, a path, a section
+  order, a schema: declared in exactly one place, with every other use reading
+  from that place
+- **Derive, do not copy.** Where two artefacts must agree, generate one from
+  the other or both from a shared source, and put the check that they still
+  agree in the quality gates
+- **Reference, do not restate.** Link to the document that owns a subject
+  instead of summarising it somewhere it will go stale
+- **Extend rather than parallel.** A second helper, constant, fixture, config
+  key, or type that means what an existing one means is duplication even when
+  the wording differs — change the original instead
+- **Make unavoidable duplication fail loudly.** Where a copy cannot be removed,
+  add a test or check that regenerates it and compares, so drift is a failure
+  rather than a surprise
+- **Deleting the stale copy is part of the change** that made it stale, not a
+  follow-up
+
+This applies to code, configuration, documentation, fixtures, and data alike.
+When a change means editing the same fact in more than one file, treat that as
+the defect to fix first.
+
 ## Workflow
 
 - Long-lived branch: `main`

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -33,6 +33,62 @@ Agents own:
 - docs updates tied to behavior changes
 - running documented quality gates
 
+## Agent Operating Mode
+
+Agent behaviour in this repository is calibrated, not left to model defaults.
+Each dial runs from 1 to 5, where 5 is the maximum:
+
+- **Verbosity:** 2 / 5
+- **Precision, repeatability, determinism:** 4 / 5
+
+Low verbosity means:
+
+- Answer what was asked; do not restate the request or read the plan back
+- Report outcomes, not a narration of the steps taken to reach them
+- Prefer a diff, a command, or a `path:line` reference over prose describing it
+- Open with the result; no preamble, and no recap the transcript already shows
+- Spend words on decisions the reader must make, on risks, and on failures
+
+High precision, repeatability, and determinism mean:
+
+- Verify against the repository before asserting, and cite `path:line`
+- Reuse the pattern already in the file rather than introducing a second one
+- Make the smallest change that satisfies the requirement, and nothing beyond it
+- Run the documented quality gates in order and report their real output
+- Pin versions, ordering, and formatting rather than leaving them to chance
+- State assumptions explicitly where the repository does not settle a choice
+- The same task on the same input should reach the same result on a second run
+
+The levels are policy values, not prose: `repo-check` reports drift from them
+and `repo-adopt` restores them.
+
+## Single Source Of Truth
+
+Anything stated twice drifts, and the copy that drifts is the one nobody is
+reading when it matters. Before writing, look for what already exists and
+derive from it.
+
+- **One home per fact.** A value, a command, a version, a path, a section
+  order, a schema: declared in exactly one place, with every other use reading
+  from that place
+- **Derive, do not copy.** Where two artefacts must agree, generate one from
+  the other or both from a shared source, and put the check that they still
+  agree in the quality gates
+- **Reference, do not restate.** Link to the document that owns a subject
+  instead of summarising it somewhere it will go stale
+- **Extend rather than parallel.** A second helper, constant, fixture, config
+  key, or type that means what an existing one means is duplication even when
+  the wording differs — change the original instead
+- **Make unavoidable duplication fail loudly.** Where a copy cannot be removed,
+  add a test or check that regenerates it and compares, so drift is a failure
+  rather than a surprise
+- **Deleting the stale copy is part of the change** that made it stale, not a
+  follow-up
+
+This applies to code, configuration, documentation, fixtures, and data alike.
+When a change means editing the same fact in more than one file, treat that as
+the defect to fix first.
+
 ## Workflow
 
 - Long-lived branch: `main`

--- a/templates/content/AGENTS/agent-operating-mode.shared.md
+++ b/templates/content/AGENTS/agent-operating-mode.shared.md
@@ -1,0 +1,25 @@
+Agent behaviour in this repository is calibrated, not left to model defaults.
+Each dial runs from 1 to 5, where 5 is the maximum:
+
+__AGENT_DIALS__
+
+Low verbosity means:
+
+- Answer what was asked; do not restate the request or read the plan back
+- Report outcomes, not a narration of the steps taken to reach them
+- Prefer a diff, a command, or a `path:line` reference over prose describing it
+- Open with the result; no preamble, and no recap the transcript already shows
+- Spend words on decisions the reader must make, on risks, and on failures
+
+High precision, repeatability, and determinism mean:
+
+- Verify against the repository before asserting, and cite `path:line`
+- Reuse the pattern already in the file rather than introducing a second one
+- Make the smallest change that satisfies the requirement, and nothing beyond it
+- Run the documented quality gates in order and report their real output
+- Pin versions, ordering, and formatting rather than leaving them to chance
+- State assumptions explicitly where the repository does not settle a choice
+- The same task on the same input should reach the same result on a second run
+
+The levels are policy values, not prose: `repo-check` reports drift from them
+and `repo-adopt` restores them.

--- a/templates/content/AGENTS/single-source-of-truth.shared.md
+++ b/templates/content/AGENTS/single-source-of-truth.shared.md
@@ -1,0 +1,24 @@
+Anything stated twice drifts, and the copy that drifts is the one nobody is
+reading when it matters. Before writing, look for what already exists and
+derive from it.
+
+- **One home per fact.** A value, a command, a version, a path, a section
+  order, a schema: declared in exactly one place, with every other use reading
+  from that place
+- **Derive, do not copy.** Where two artefacts must agree, generate one from
+  the other or both from a shared source, and put the check that they still
+  agree in the quality gates
+- **Reference, do not restate.** Link to the document that owns a subject
+  instead of summarising it somewhere it will go stale
+- **Extend rather than parallel.** A second helper, constant, fixture, config
+  key, or type that means what an existing one means is duplication even when
+  the wording differs — change the original instead
+- **Make unavoidable duplication fail loudly.** Where a copy cannot be removed,
+  add a test or check that regenerates it and compares, so drift is a failure
+  rather than a surprise
+- **Deleting the stale copy is part of the change** that made it stale, not a
+  follow-up
+
+This applies to code, configuration, documentation, fixtures, and data alike.
+When a change means editing the same fact in more than one file, treat that as
+the defect to fix first.

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -85,9 +86,14 @@ def _minimal_repo(tmp_path: Path, profile: str = "python-single") -> Path:
             POLICY.rule("RSK003").check.config["commands_by_profile"][profile], 1
         )
     )
+    dials_config = POLICY.rule("RSK026").check.config
+    dial_block = "\n".join(
+        f"- **{dial['label']}:** {dial['level']} / {dial['scale']}"
+        for dial in dials_config["dials"]
+    )
+    bodies = {"Quality Gates": gate_chain, dials_config["section"]: dial_block}
     agents_sections = "\n\n".join(
-        f"## {heading}\n\n{gate_chain if heading == 'Quality Gates' else 'Detail.'}"
-        for heading in headings
+        f"## {heading}\n\n{bodies.get(heading, 'Detail.')}" for heading in headings
     )
     (root / "AGENTS.md").write_text(
         f"# AGENTS.md\n\n{agents_sections}\n\nSee repo-standard-kit.\n",
@@ -431,6 +437,99 @@ def test_rsk003_ignores_unrelated_quality_gate_prose(tmp_path: Path) -> None:
     )
     path.write_text(text, encoding="utf-8")
     assert "RSK003" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_rsk026_rejects_a_dial_stated_at_the_wrong_level(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / "AGENTS.md"
+    text = path.read_text(encoding="utf-8").replace(
+        "**Verbosity:** 2 / 5", "**Verbosity:** 4 / 5"
+    )
+    path.write_text(text, encoding="utf-8")
+    assert "RSK026" in _rule_ids(check_repo(root, POLICY))
+
+
+def test_rsk026_rejects_dials_stated_out_of_order(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / "AGENTS.md"
+    text = path.read_text(encoding="utf-8")
+    first, second = (
+        f"- **{dial['label']}:** {dial['level']} / {dial['scale']}"
+        for dial in POLICY.rule("RSK026").check.config["dials"]
+    )
+    text = text.replace(f"{first}\n{second}", f"{second}\n{first}")
+    path.write_text(text, encoding="utf-8")
+    assert "RSK026" in _rule_ids(check_repo(root, POLICY))
+
+
+def test_rsk026_rejects_a_section_that_states_no_dial(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / "AGENTS.md"
+    text = re.sub(
+        r"^- \*\*[^*]+\*\* \d+ / \d+$",
+        "Be brief and be precise.",
+        path.read_text(encoding="utf-8"),
+        flags=re.MULTILINE,
+    )
+    path.write_text(text, encoding="utf-8")
+    assert "RSK026" in _rule_ids(check_repo(root, POLICY))
+
+
+def test_rsk026_ignores_dials_stated_outside_the_section(tmp_path: Path) -> None:
+    """The section is the contract; a matching line elsewhere is just prose."""
+    root = _minimal_repo(tmp_path)
+    path = root / "AGENTS.md"
+    text = path.read_text(encoding="utf-8").replace("- **Verbosity:** 2 / 5\n", "", 1)
+    path.write_text(f"{text}\n- **Verbosity:** 2 / 5\n", encoding="utf-8")
+    assert "RSK026" in _rule_ids(check_repo(root, POLICY))
+
+
+def test_rsk026_ignores_unrelated_operating_mode_prose(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / "AGENTS.md"
+    section = POLICY.rule("RSK026").check.config["section"]
+    text = path.read_text(encoding="utf-8").replace(
+        f"## {section}\n\n",
+        f"## {section}\n\nEach dial runs from 1 to 5.\n\n",
+    )
+    path.write_text(text, encoding="utf-8")
+    assert "RSK026" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_no_hand_maintained_document_restates_the_dial_levels() -> None:
+    """`docs/` points at the published levels; only the generator writes them.
+
+    `CHANGELOG.md` is exempt by nature: a release entry records what a release
+    did and must not change when policy later does.
+    """
+    generated = {REPO_ROOT / "docs" / "policy-reference.md"}
+    dials = POLICY.rule("RSK026").check.config["dials"]
+    for path in sorted((REPO_ROOT / "docs").rglob("*.md")):
+        if path in generated:
+            continue
+        text = path.read_text(encoding="utf-8")
+        restated = [
+            dial["label"]
+            for dial in dials
+            if f"{dial['level']} / {dial['scale']}" in text
+        ]
+        assert not restated, (
+            f"{path.name} restates the levels for {restated}; link to "
+            "docs/policy-reference.md instead"
+        )
+
+
+def test_rsk026_holds_the_levels_the_standard_calibrates() -> None:
+    """The levels are a deliberate choice, not whatever policy happens to say."""
+    rule = POLICY.rule("RSK026")
+    assert rule.level == "required"
+    assert [
+        (dial["label"], dial["level"], dial["scale"])
+        for dial in rule.check.config["dials"]
+    ] == [
+        ("Verbosity", 2, 5),
+        ("Precision, repeatability, determinism", 4, 5),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1362,6 +1461,8 @@ def test_rsk002_is_re_expressed_on_the_shared_shape_record() -> None:
         "Repository Purpose",
         "Repository Context",
         "Human And Agent Responsibilities",
+        "Agent Operating Mode",
+        "Single Source Of Truth",
         "Workflow",
         "Quality Gates",
         "Coding Standards",

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -145,6 +145,27 @@ def test_generator_tokens_never_reach_shipped_output() -> None:
         assert not leftover, f"{target.variant} {target.document} leaked {leftover}"
 
 
+def test_the_operating_dials_are_injected_from_policy_not_written_by_hand() -> None:
+    """RSK026's levels have one source, for the same reason the chain does."""
+    fragments = [
+        path
+        for path in _fragment_files()
+        if path.parent.name == "AGENTS"
+        and path.name.startswith("agent-operating-mode.")
+    ]
+    assert fragments, "the AGENTS agent-operating-mode fragments disappeared"
+    dials = POLICY.rule("RSK026").check.config["dials"]
+    for path in fragments:
+        text = path.read_text(encoding="utf-8")
+        assert "__AGENT_DIALS__" in text, f"{path.name} must defer to policy"
+        restated = [
+            dial["label"]
+            for dial in dials
+            if f"{dial['level']} / {dial['scale']}" in text
+        ]
+        assert not restated, f"{path.name} restates the levels: {restated}"
+
+
 def test_the_gate_chain_is_injected_from_policy_not_written_by_hand() -> None:
     """The chain had four hand-maintained copies; there must now be none."""
     fragments = [

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -529,6 +529,31 @@ def test_adoption_invents_no_heading_the_shape_does_not_declare(
         assert "repo-standard-kit" in text
 
 
+def test_adoption_restores_a_drifted_operating_dial(tmp_path: Path) -> None:
+    """RSK026 levels are policy's, so adoption overwrites a local edit."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    path = root / "AGENTS.md"
+    config = load_policy().rule("RSK026").check.config
+    section = config["section"]
+    path.write_text(
+        f"# Existing\n\n## {section}\n\nHouse style below.\n\n"
+        "- **Verbosity:** 5 / 5\n- **Precision, repeatability, determinism:** 1 / 5\n"
+        "\nThe rest is ours.\n",
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    text = path.read_text(encoding="utf-8")
+    for dial in config["dials"]:
+        assert f"- **{dial['label']}:** {dial['level']} / {dial['scale']}" in text
+    assert "**Verbosity:** 5 / 5" not in text
+    assert "House style below." in text, "surrounding prose must survive"
+    assert "The rest is ours." in text
+    assert not [f for f in check_repo(root, load_policy()) if f.rule_id == "RSK026"]
+
+
 def test_new_pyproject_tables_are_placed_in_declared_order(tmp_path: Path) -> None:
     """`[dependency-groups]` used to be appended after `[build-system]`."""
     root = tmp_path / "existing"


### PR DESCRIPTION
`AGENTS.md` says what agents own (`Human And Agent Responsibilities`) and which
gates they must run (`Quality Gates`), but nothing said *how* they should work.
Two repositories adopting the same standard therefore got materially different
output from the same agent and the same task.

Two required sections join the `agents` shape, between
`Human And Agent Responsibilities` and `Workflow`. Staged on
`chore/release-v2.0.0`.

## Agent Operating Mode

Two calibrated dials, held in `policy/base.yaml:495` and published in
`docs/policy-reference.md`:

| Dial | Level |
| --- | --- |
| Verbosity | 2 / 5 |
| Precision, repeatability, determinism | 4 / 5 |

*Low verbosity*: answer what was asked, report outcomes rather than narrate
steps, prefer a diff or a `path:line` reference over prose describing it, spend
words only on decisions, risks, and failures.

*High precision, repeatability, determinism*: verify against the repository
before asserting, reuse the pattern already in the file, make the smallest
change that satisfies the requirement, run the documented gates in order and
report their real output, pin what can be pinned, state assumptions where the
repository does not settle a choice, and reach the same result on a second run.

**RSK026** (required) checks that the section states every dial, in the
declared order, at the declared level — modelled directly on RSK003, which does
the same for the gate chain. It reads the dial lines and nothing else, so the
prose around them stays the repository's own. The generator renders the block
through a new `__AGENT_DIALS__` token, and `repo-adopt` replaces a drifted
block where it stands rather than appending a second one.

## Single Source Of Truth

Anything recorded twice drifts, and the copy that drifts is the one nobody is
reading when it matters. One home per fact; derive rather than copy; reference
rather than restate; extend an existing definition rather than adding a
parallel one; make unavoidable duplication fail through a check; delete the
stale copy as part of the change that staled it. Code, configuration,
documentation, fixtures, and data alike.

This is the principle the kit already applies to its own governed documents —
shapes produce them, the gate chain comes from RSK003 — stated as a rule agents
follow in every adopting repository.

**No `python-workspace` variant.** A profile variant *replaces* the shared
fragment rather than extending it, so a workspace variant would have to restate
all six rules to add one. That is the defect the section forbids, so the
fragment is shared-only.

## The rule applied to the change that introduces it

`docs/repo-standard.md` initially carried a hand-written table of the dial
levels — a second copy of a policy value. The compiler now publishes calibrated
values into `docs/policy-reference.md`, the prose links there, and
`test_no_hand_maintained_document_restates_the_dial_levels` fails if any
non-generated file under `docs/` grows a copy.

`CHANGELOG.md` is deliberately exempt: a release entry records what a release
did and must not track later policy changes.

## Two shared code paths, not two copies

- `_reconcile_gate_chain` and `_reconcile_operating_dials` both call
  `_reconcile_block`, which replaces a policy-owned block in place so
  surrounding prose keeps its position.
- `_agents_quality_commands` and `_agents_operating_dials` both call
  `_section_body`, replacing a regex that RSK003 had inlined.

## Not enforced mechanically

Unlike the dials, "do not duplicate" is not checkable in general. RSK002
guarantees the `Single Source Of Truth` section exists and `repo-adopt` keeps
its text current, but nothing verifies a repository follows it. The tractable
version is per-fact staleness gates like the one guarding generated documents;
worth a separate issue rather than a rule.

## Known gap

The dial *levels* have one definition, but the *explanation* of what they mean
is hand-maintained in two places: `docs/repo-standard.md` and
`templates/content/AGENTS/agent-operating-mode.shared.md`. Nothing checks that
they agree. By the rule this PR adds, that is a defect. Closing it means either
the standard stops explaining its own dials, or the generator starts producing
part of `docs/repo-standard.md` — a larger change than this PR. Left for a
follow-up.

## Gates

- `uv run pytest` — 351 pass (up from 340).
- `uv run repo-check . --strict` — clean.
- `uv run repo-adopt . --dry-run` — plans nothing; this repository's own
  `AGENTS.md` carries both sections.
- `uv run pre-commit run --all-files`, `uv build` — clean.

## Adopters must

Add both sections to `AGENTS.md` in shape order. RSK002 reports either missing
section as a required finding, RSK026 reports missing or drifted levels, and
`repo-adopt` writes both and restores the levels while keeping prose you add
around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
