### PR TITLE
feat!: require governed file shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,12 +159,16 @@ the changes listed under **Adopters must**.
   reports dial levels that are missing or have drifted from the ones
   `docs/policy-reference.md` publishes. `repo-adopt` writes both sections and
   restores the levels, keeping any prose you add around them.
-- Bring `README.md`, `CHANGELOG.md`, and `pyproject.toml` onto the shapes
-  `docs/repo-standard.md` declares. RSK023, RSK024, and RSK025 are still
-  recommended at this point on the branch and become required before v2.0.0
-  ships, so `repo-check .` reports them as required findings in the released
-  version. `repo-check --strict` names every section that is missing or out of
-  order.
+- Bring `README.md` onto the RSK023 shape: add its required `Overview`,
+  `Install`, `Usage`, `Development`, and `License` headings and keep every
+  declared heading in the canonical order. `repo-adopt` repairs it.
+- Bring `CHANGELOG.md` onto the RSK024 shape: add `## [Unreleased]` and keep
+  it after an optional `## Compatibility Policy` heading. `repo-adopt` repairs
+  it.
+- Bring `pyproject.toml` onto the RSK025 table order declared in
+  `docs/repo-standard.md`. `repo-adopt` reorders the declared tables while
+  retaining unlisted tables. RSK023, RSK024, and RSK025 report each shape
+  violation as a required finding.
 
 ## [1.2.0] - 2026-08-20
 

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -365,7 +365,7 @@ Remediation: Require at least one approving review when repository staffing perm
 
 ### RSK023: README.md follows the declared section shape
 
-- Level: `recommended`
+- Level: `required`
 - Profiles: `python-single`, `python-workspace`
 - Source: [`docs/repo-standard.md` — File Shapes](../docs/repo-standard.md)
 - Enforcement: `structural`
@@ -377,7 +377,7 @@ Remediation: Add the required README sections and order every declared section a
 
 ### RSK024: CHANGELOG.md follows the declared section shape
 
-- Level: `recommended`
+- Level: `required`
 - Profiles: `python-single`, `python-workspace`
 - Source: [`docs/repo-standard.md` — File Shapes](../docs/repo-standard.md)
 - Enforcement: `structural`
@@ -389,7 +389,7 @@ Remediation: Add an Unreleased section, and keep any Compatibility Policy sectio
 
 ### RSK025: pyproject.toml declares tables in the canonical order
 
-- Level: `recommended`
+- Level: `required`
 - Profiles: `python-single`, `python-workspace`
 - Source: [`docs/repo-standard.md` — File Shapes](../docs/repo-standard.md)
 - Enforcement: `structural`

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -172,7 +172,5 @@ shapes govern level-two headings only, matching RSK002's semantics.
 RSK023 (`README.md`), RSK024 (`CHANGELOG.md`), and RSK025 (`pyproject.toml`)
 each refer to their generated shape table. The tables distinguish required from
 optional sections; undeclared sections and tables stay legal in any position.
-
-These three rules are recommended while the generator that produces conforming
-documents is still being built; strict checking keeps them visible in the
-meantime.
+RSK023, RSK024, and RSK025 enforce their respective shapes at the **required**
+level.

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -437,7 +437,7 @@ rules:
 
   - id: RSK023
     title: README.md follows the declared section shape
-    level: recommended
+    level: required
     profiles: [python-single, python-workspace]
     source:
       document: docs/repo-standard.md
@@ -456,7 +456,7 @@ rules:
 
   - id: RSK024
     title: CHANGELOG.md follows the declared section shape
-    level: recommended
+    level: required
     profiles: [python-single, python-workspace]
     source:
       document: docs/repo-standard.md
@@ -475,7 +475,7 @@ rules:
 
   - id: RSK025
     title: pyproject.toml declares tables in the canonical order
-    level: recommended
+    level: required
     profiles: [python-single, python-workspace]
     source:
       document: docs/repo-standard.md

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -677,7 +677,7 @@
       },
       "enforcement": "structural",
       "id": "RSK023",
-      "level": "recommended",
+      "level": "required",
       "profiles": [
         "python-single",
         "python-workspace"
@@ -699,7 +699,7 @@
       },
       "enforcement": "structural",
       "id": "RSK024",
-      "level": "recommended",
+      "level": "required",
       "profiles": [
         "python-single",
         "python-workspace"
@@ -721,7 +721,7 @@
       },
       "enforcement": "structural",
       "id": "RSK025",
-      "level": "recommended",
+      "level": "required",
       "profiles": [
         "python-single",
         "python-workspace"

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1445,10 +1445,10 @@ def test_rsk002_uses_the_shared_agents_shape_record() -> None:
 
 
 @pytest.mark.parametrize("rule_id", ["RSK023", "RSK024", "RSK025"])
-def test_new_shape_rules_ship_recommended_for_the_migration_window(
+def test_shape_rules_are_required_for_v2(
     rule_id: str,
 ) -> None:
-    assert POLICY.rule(rule_id).level == "recommended"
+    assert POLICY.rule(rule_id).level == "required"
 
 
 def test_readme_shape_distinguishes_required_sections() -> None:


### PR DESCRIPTION
Closes #43.

## Summary

- Promote RSK023, RSK024, and RSK025 to required for v2.0.0.
- State the required File Shapes contract normatively and regenerate policy artifacts.
- Finalize adopter remediations for the README, CHANGELOG, and pyproject shapes.

## Validation

- `uv sync --locked`
- `uv run pre-commit run --all-files`
- `uv run pytest` — 352 passed
- `uv build`
- `uv run repo-check . --strict`
- `uv run repo-adopt . --dry-run`
- `repo-init` and `repo-check` for both profiles