### PR TITLE
fix: correct stale and inaccurate statements in the standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,11 +172,9 @@ end in a temporary directory, on every platform.
 - `scripts/`: developer scripts, including `generate_policy.py`
 - `tests/`: automated tests
 - `docs/`: normative standards
-- `profiles/`: language-specific profiles
 - `policy/`: canonical machine-enforced policy and profile detection metadata
 - `templates/`: reference documents rendered from the shapes, plus the
   `content/` prose fragments they are rendered from
-  by hand
 
 ## Change Control Notes
 

--- a/README.md
+++ b/README.md
@@ -179,10 +179,8 @@ uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v2.0.0" r
 - `docs/`: the standard and its companion documents
 - `policy/`: canonical machine-enforced rules, profile detection metadata, and
   the file shapes governed documents must follow
-- `profiles/`: language or repo-type specific standards
 - `templates/`: reference documents rendered from the shapes, plus the
   `content/` prose fragments they are rendered from
-  by hand
 - `src/repo_standard/`: packaged bootstrap implementation
 - `src/repo_standard/policy/`: strict policy models and compiled runtime policy
 - `src/repo_standard/starter_kits/`: copyable repository skeletons

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -170,15 +170,10 @@ After generation:
 1. Review `AGENTS.md`
 2. Run `uv sync`
 3. Run `uv run pre-commit install`
-4. Run `uv run pre-commit run --all-files`
-5. Run `uv run ruff format --check .`
-6. Run `uv run ruff check .`
-7. Run `uv run ty check`
-8. Run `uv run pytest`
-9. Run `uv build`
-10. Make the initial commit on `main`
-11. Push an initial pull request, then configure branch protection on `main`
-    as specified in `docs/quality-gates.md` so the gates become binding
+4. Run the quality-gate chain stated in `docs/quality-gates.md`
+5. Make the initial commit on `main`
+6. Push an initial pull request, then configure branch protection on `main`
+   as specified in `docs/quality-gates.md` so the gates become binding
 
 ### Golden Path: Workspace
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -53,17 +53,16 @@ checks execute for the best deterministic profile.
 
 Every finding includes the rule ID, title, canonical level, path and line when
 available, message, actual value, expected value, remediation, and status.
-The JSON `severity` field remains present through v1 for existing consumers:
-`required` derives `shall`, `recommended` derives `should`, and an unavailable
-platform command derives the legacy `platform` value plus
-`status: "indeterminate"`.
+The JSON output also carries a legacy `severity` field: `required` derives
+`shall`, `recommended` derives `should`, and an unavailable platform command
+derives the legacy `platform` value plus `status: "indeterminate"`.
 
 YAML and TOML parse failures report parser locations. Workflow findings report
 the relevant node line when the YAML parser exposes one.
 
 ## Suppressing A Rule
 
-The v1 exception shape remains deliberately small:
+The v2 exception shape remains deliberately small:
 
 ```toml
 [tool.repo-check.ignore]
@@ -72,7 +71,7 @@ RSK005 = "This repository is the standard's own home."
 
 Only a known rule ID with a non-empty string reason suppresses findings. Empty
 reasons, unknown IDs, malformed TOML, and non-string values suppress nothing.
-Owner, expiry, and reference metadata are deferred beyond v1.
+Owner, expiry, and reference metadata remain deferred.
 
 ## Consumption Surfaces
 
@@ -107,7 +106,7 @@ required compliance job; that defense-in-depth duplication is intentional.
 ```yaml
 repos:
   - repo: https://github.com/FP-DevTools/repo-standard-kit
-    rev: v1.2.0
+    rev: v2.0.0
     hooks:
       - id: repo-check
 ```
@@ -124,7 +123,7 @@ jobs:
   compliance:
     uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@<full-sha>
     with:
-      standard-ref: v1.2.0
+      standard-ref: v2.0.0
 ```
 
 The reusable workflow itself SHALL be pinned to a full commit SHA. That
@@ -132,7 +131,7 @@ immutable `uses:` reference selects the workflow implementation the caller
 trusts. The distinct `standard-ref` input selects the released
 `repo-standard-kit` revision whose packaged checker and compiled policy are
 executed. A commit SHA gives the strongest reproducibility. A human-readable
-release tag such as `v1.2.0` is permitted only when repository governance keeps
+release tag such as `v2.0.0` is permitted only when repository governance keeps
 release tags immutable.
 The workflow passes that input through the environment, validates it against a
 narrow Git-ref character allowlist, and never interpolates caller-controlled
@@ -206,5 +205,5 @@ remediation. Markdown explains policy but supplies no executable values.
 - Whether an exception reason is wise, approved, or still timely.
 - Human-owned release, product, architectural, and security decisions.
 
-Vulnerability scanning remains optional in v1.0. Mandatory scanning, SAST,
-SBOMs, signing, richer exception metadata, and non-Python profiles are deferred.
+Vulnerability scanning remains optional. Mandatory scanning, SAST, SBOMs,
+signing, richer exception metadata, and non-Python profiles are deferred.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -87,7 +87,10 @@ was never written to any prose convention. `md033` (no inline HTML) and
 both false-positive on conventions this standard itself relies on —
 `<angle-bracket>` fill-in-the-blank placeholders in `templates/`, and
 `__DUNDER__`-shaped bootstrap tokens, which are valid Markdown
-strong-emphasis syntax before a starter kit is rendered.
+strong-emphasis syntax before a starter kit is rendered. `md024` (no
+duplicate headings) shall run with `siblings_only` enabled, since documents
+in this repository legitimately repeat headings such as `### Added` under
+different release sections in `CHANGELOG.md`.
 
 ### Recommended tools
 
@@ -236,8 +239,8 @@ uv run pip-audit
 
 Identifies known vulnerabilities in dependencies.
 
-Vulnerability scanning remains optional for v1.0. No machine-enforced rule in
-this release requires `pip-audit` or another vulnerability scanner.
+Vulnerability scanning remains optional. No machine-enforced rule in this
+release requires `pip-audit` or another vulnerability scanner.
 
 ---
 

--- a/docs/release-plan-v2.0.0.md
+++ b/docs/release-plan-v2.0.0.md
@@ -1,0 +1,122 @@
+# Release Plan: v2.0.0 Corrections
+
+This is a working tracker, not part of the standard. It records the audit
+findings for `chore/release-v2.0.0`, the decisions taken about them, and the
+phase each correction belongs to.
+
+**P7 deletes this file.** It exists to keep seven phases coordinated while the
+release branch is open, and `pyproject.toml` ships `docs/**` to adopters, so it
+must not survive the tag.
+
+## Context
+
+An audit of `chore/release-v2.0.0` found 22 issues the gates do not catch.
+`uv run pytest` passes and `repo-check . --strict` is clean; that is part of
+the finding rather than a reassurance.
+
+## Decisions
+
+| | Decision | Consequence |
+| --- | --- | --- |
+| D1 | Policy owns the permitted guard form for RSK006 | The workspace starter's `compgen` guard becomes canonical; other conditionals are rejected |
+| D2 | New rules may land in v2.0.0 | The release is unmade, so a new required rule costs nothing now and a major later |
+| D3 | Root `README.md` and `AGENTS.md` become generated | Closes the drift class that produced findings 5 and 6 |
+| D4 | New `advisory` policy level; RSK015 moves to it | `line-length = 88` stays visible and stops failing `--strict` |
+| D5 | `repo-init` gains `repo-adopt`'s `--no-lock` / `--no-install` split | Bootstrapped repositories stop failing required RSK009 |
+| D6 | Drop `load_rules` and the JSON `severity` field | Must land with D4, or `advisory` needs an invented `shall`/`should` value |
+
+## Phases
+
+Each phase is a sub-issue and one PR into `chore/release-v2.0.0`. Critical path
+is P3 → P5 → P7; P1, P2, P4 and P6 run alongside it.
+
+| Phase | Scope | Findings | Depends on | Status |
+| --- | --- | --- | --- | --- |
+| P1 | Factual corrections | 4, 5, 6, 8, 10, 15, 18 | — | In progress |
+| P2 | Root documents under the generator | 7 | P1 | Not started |
+| P3 | Policy schema: `advisory`, drop `severity` | 19, dead weight | — | Not started |
+| P4 | Checker correctness | 13, 14, 20, 22 | — | Not started |
+| P5 | Coverage: compliance workflow and shapes | 11, 12, 16, 17 | P3 | Not started |
+| P6 | Bootstrap contract and dead weight | 9, 21 | — | In progress |
+| P7 | Release finalization | 1, 2, 3 | all | Not started |
+
+P1 precedes P2 so the corrected prose is what gets migrated into fragments,
+rather than migrating the defects and fixing them twice.
+
+## Findings Index
+
+Numbers are stable identifiers referenced by the phase table and the sub-issues.
+
+### Release blockers
+
+- **1.** `CHANGELOG.md:58-60` — the 2.0.0 entry says RSK023–025 are
+  "recommended as of this commit and are promoted to required later on this
+  branch". They are `required` in `policy/base.yaml`. The note contradicts the
+  release.
+- **2.** `CHANGELOG.md` tail — no `[2.0.0]:` link definition; `[Unreleased]`
+  still compares `v1.2.0...HEAD`.
+- **3.** `CHANGELOG.md:27-43` — four `Fixed` entries that landed on this
+  release branch sit under `[Unreleased]`, above a dated `[2.0.0]` heading.
+- **4.** `docs/compliance.md:56,66,75,110,127,209` and
+  `docs/quality-gates.md:239` — v1 described as the current release; examples
+  pin `v1.2.0`.
+
+### Inaccuracies
+
+- **5.** `README.md:182`, `AGENTS.md:175`, `pyproject.toml:43` — `profiles/`
+  was removed in 0.3.0 and is still referenced; `source-include` packages it.
+- **6.** `README.md:184-185`, `AGENTS.md:178-179` — sentence ends in a dangling
+  "by hand" clause.
+- **7.** `scripts/generate_docs.py:70-82` — root `README.md` and `AGENTS.md`
+  are the only governed documents the generator skips, and both defects above
+  live in them.
+- **8.** `starter_kits/*/.github/workflows/quality.yml:17,20` — v5 pins beside
+  a `compliance.yml` pinning v7.0.1 and v10.0.1.
+- **9.** `repo_init.py:293-301,364` — `--no-install` skips `uv sync`, so no
+  `uv.lock`, so required RSK009 fails on a fresh repository.
+- **10.** `docs/bootstrap-workflow.md:170-179` — an eight-step gate chain that
+  `docs/quality-gates.md:157-161` rules out and `AGENTS.md:206` says is stated
+  once.
+
+### Enforceability gaps
+
+- **11.** Nothing structurally checks `.github/workflows/compliance.yml`,
+  though `docs/quality-gates.md:118-122` makes it a SHALL.
+- **12.** RSK020 and RSK021 cover `quality.yml` only — the compliance
+  workflow's permissions and pins are unchecked, and it is the workflow that
+  fetches remote code.
+- **13.** RSK006 accepts a command inside a false guard. Verified:
+  `if false; then uv build --all-packages; fi` satisfies the rule. The
+  workspace starter depends on this, so its build gate never runs.
+- **14.** `checks.py:1427-1428` — RSK020 returns no findings on a missing
+  workflow while RSK021 returns the error.
+- **15.** `docs/repo-layout.md:20-21` — claims required-rule coverage that
+  `tests/`, `src/<package_name>/`, `docs/diagrams/` and `scripts/` do not have.
+- **16.** RSK011 knows only `__DUNDER__` tokens; `templates/README.md` ships 27
+  angle-bracket placeholders with no check.
+- **17.** `policy/shapes.yaml:105-137` — the pyproject shape omits
+  `[project.scripts]` and `[tool.repo-check.ignore]`, both used by this
+  repository.
+- **18.** `.pymarkdown.json` relaxes `md024`; `docs/quality-gates.md` §4
+  documents only md013, md033 and md036.
+
+### Rules worth reconsidering
+
+- **19.** RSK015 recommends `line-length = 88` while
+  `docs/quality-gates.md:440-445` says the value is not prescribed. Resolved by
+  D4.
+- **20.** `checks.py:1512` — RSK022 reuses the full branch-protection handler,
+  so `--check-enforcement` queries the platform twice.
+- **21.** RSK005 cannot be satisfied by the standard's own home and is
+  suppressed in `pyproject.toml:69`.
+- **22.** `checks.py:238-243` — shape order checking dedupes repeated headings,
+  so a declared heading repeated out of position is invisible.
+
+### Dead weight
+
+- `checks.py:82-83` — `load_rules`, a compatibility alias for the v0.4 name.
+- `models.py:470-473` and `cli.py:90` — the JSON `severity` field, carrying an
+  expired "through v1" promise.
+- `pyproject.toml:43` — `profiles/**` in `source-include`.
+- `docs/diagrams/README.md` — a placeholder shipped into every generated
+  repository that no rule references.

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -17,11 +17,16 @@ Use this layout by default for Python repositories:
 - `scripts/`
 - `examples/` when useful
 
-The core operating files above are governed by required rules in the main
-standard. The following layout aids are intentionally **recommended**:
-RSK012 checks `docs/adr/`, RSK017 checks `CHANGELOG.md`, and RSK018 checks
-`LICENSE`. Their absence is reported but is non-blocking unless strict checking
-is requested.
+Of the entries above, `AGENTS.md` and `README.md` are governed by required
+existence rules (RSK001, RSK004). No rule checks that `pyproject.toml` or
+`.pre-commit-config.yaml` exist, but required rules read their contents —
+RSK007, RSK010, and RSK019 — and report the file missing when it is absent.
+`tests/`, `src/<package_name>/`, `docs/diagrams/`, `scripts/`, and
+`examples/` are convention only: no rule checks for them. The following
+layout aids are
+intentionally **recommended**: RSK012 checks `docs/adr/`, RSK017 checks
+`CHANGELOG.md`, and RSK018 checks `LICENSE`. Their absence is reported but is
+non-blocking unless strict checking is requested.
 
 ## Directory Responsibilities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ module-name = "repo_standard"
 source-include = [
   "docs/**",
   "policy/**",
-  "profiles/**",
   "templates/**",
 ]
 source-exclude = [

--- a/src/repo_standard/starter_kits/python-single/.github/workflows/quality.yml
+++ b/src/repo_standard/starter_kits/python-single/.github/workflows/quality.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Install dependencies
         run: uv sync --locked

--- a/src/repo_standard/starter_kits/python-workspace/.github/workflows/quality.yml
+++ b/src/repo_standard/starter_kits/python-workspace/.github/workflows/quality.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Install dependencies
         run: uv sync --locked


### PR DESCRIPTION
Phase 1 of the v2.0.0 correction plan: statements in the repository that are
factually wrong, stale, or contradict another document. No policy change, no
schema change, no adopter impact.

Every defect here passed `uv run pytest` and `repo-check . --strict` before
this PR and passes them after. That is the point — none of it is machine
detectable, which is why later phases close the enforcement gaps.

## What changed

**1. Phantom `profiles/` directory.** Removed in 0.3.0 but still referenced in
`README.md`, `AGENTS.md`, and `pyproject.toml`, where `source-include` packaged
a tree that does not exist.

**2. Truncated sentence.** The `templates/` bullet in `README.md` and
`AGENTS.md` ended in a dangling "by hand" clause left over from an earlier
edit. Both now read as one sentence, identically.

**3. Stale v1 references.** `docs/compliance.md` and `docs/quality-gates.md`
described v1 as the current release and pinned `v1.2.0` in the pre-commit and
reusable-workflow examples. Examples now pin `v2.0.0`, matching the `rev` the
starter kits already ship. The two "optional in v1.0" statements about
vulnerability scanning are re-expressed without pinning to a superseded
version, and the deferred-metadata note no longer says "beyond v1".

The `severity` paragraph is reworded to describe the field as it is rather
than promising it for v2 — P3 removes the field entirely.

**4. Mismatched action pins.** Both starters' `quality.yml` pinned
`actions/checkout` and `setup-uv` at v5 while the `compliance.yml` beside them
pinned v7.0.1 and v10.0.1, so a generated repository carried two different pins
of the same action. The `quality.yml` pins now match their neighbour verbatim.
No new SHAs were introduced; consistency with the existing pin is the fix.

**5. Duplicated gate chain.** `docs/bootstrap-workflow.md` restated the chain
as eight steps including separate `ruff format`, `ruff check` and `ty check`
runs — which `docs/quality-gates.md:157-161` explicitly rules out, because
`pre-commit run --all-files` already covers them, and which `AGENTS.md` says is
stated once. That step now points at `docs/quality-gates.md` instead of
restating any commands. The bootstrap-specific steps are unchanged.

**6. Overstated coverage.** `docs/repo-layout.md` claimed the core operating
files are governed by required rules. It now states accurately which entries
have existence rules (`AGENTS.md`, `README.md`), which are read by required
rules that report them missing (`pyproject.toml`, `.pre-commit-config.yaml` —
RSK007, RSK010, RSK019), and which are convention only (`tests/`,
`src/<package_name>/`, `docs/diagrams/`, `scripts/`, `examples/`).

**7. Undocumented lint relaxation.** `.pymarkdown.json` relaxes `md024`;
section 4 documented only md013, md033 and md036. The `siblings_only` setting
and its rationale are now recorded alongside them.

## Also included

`docs/release-plan-v2.0.0.md` — the tracker for all seven phases: the decision
log, the phase dependency table, and the 22-finding index the sub-issues
reference by number. It is a working document, not part of the standard. P7
deletes it before the tag, since `pyproject.toml` ships `docs/**` to adopters.

## Verification

```
uv run pre-commit run --all-files    all 13 hooks Passed
uv run pytest                        352 passed in 21.45s
uv run repo-check . --strict         All checks passed!
```

## Out of scope, noticed

`docs/compliance.md` documents a pre-commit `rev` and a `standard-ref` that
have to be bumped by hand at every release, with no check that they match the
version being cut. Worth a rule or a generator token; not this phase.

Part of the v2.0.0 correction plan (#50); `docs/release-plan-v2.0.0.md` in this
PR has the full phase breakdown.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
