### PR TITLE
feat!: add the advisory policy level and drop the JSON severity field

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -17,7 +17,8 @@ Options:
 - `--profile auto|python-single|python-workspace` selects an explicit override.
 - `--check-enforcement` also queries classic branch protection or effective
   active rulesets for RSK014.
-- `--strict` promotes recommended findings to failures.
+- `--strict` promotes recommended findings to failures. It does not promote
+  advisory findings.
 
 Exit code `0` means no blocking findings. Exit code `1` means a required rule
 failed, or a recommended rule failed under `--strict`. Exit code `2` is a
@@ -25,8 +26,9 @@ usage or indeterminate command error, including an explicitly requested
 platform check whose evidence could not be obtained.
 
 Required findings fail by default. Recommended findings are always visible but
-fail only under `--strict`; this behavior is unchanged from the pre-v1 `shall`
-and `should` contract.
+fail only under `--strict`. Advisory findings are always visible and never
+affect the exit code, because the underlying decision belongs to the
+repository; `docs/repo-standard.md` defines the three levels.
 
 ## Profile Resolution
 
@@ -53,9 +55,11 @@ checks execute for the best deterministic profile.
 
 Every finding includes the rule ID, title, canonical level, path and line when
 available, message, actual value, expected value, remediation, and status.
-The JSON output also carries a legacy `severity` field: `required` derives
-`shall`, `recommended` derives `should`, and an unavailable platform command
-derives the legacy `platform` value plus `status: "indeterminate"`.
+`level` is the sole name for how binding a finding is, and `status` reports
+`violation` or, for an unavailable platform command, `indeterminate`. The
+legacy `severity` field that restated `level` as `shall` or `should`, and an
+unavailable platform command as `platform`, is removed in v2; read `level` and
+`status` instead.
 
 YAML and TOML parse failures report parser locations. Workflow findings report
 the relevant node line when the YAML parser exposes one.

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -269,7 +269,7 @@ Remediation: Protect main with pull request protection, stale approval dismissal
 
 ### RSK015: Ruff line length uses the recommended baseline
 
-- Level: `recommended`
+- Level: `advisory`
 - Profiles: `python-single`, `python-workspace`
 - Source: [`docs/quality-gates.md` — 13. Formatting Baseline](../docs/quality-gates.md)
 - Enforcement: `structural`

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -422,8 +422,10 @@ looks like. This section fixes the configuration those gates run with.
 ### Ruff configuration
 
 RSK010 enforces the explicit line-length declaration and mandatory Ruff
-families at the **required** level. RSK015 checks the preferred line length and
-RSK016 checks the `PT` family at the **recommended** level.
+families at the **required** level. RSK016 checks the `PT` family at the
+**recommended** level. RSK015 checks the preferred line length at the
+**advisory** level, because the value itself stays a per-repository decision
+below: the finding is reported but never fails, not even under `--strict`.
 
 Every adopting repository shall declare an explicit `line-length` in
 `[tool.ruff]`, and shall select at least the following rule families:

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -19,6 +19,11 @@ recommended policy level whose finding is non-blocking unless strict checking
 is requested; MAY identifies an optional choice. Plain imperatives carry the
 same level made explicit by their surrounding section or policy reference.
 
+A rule may also carry the **advisory** level. It states a preference for a
+decision this standard leaves to the repository: the finding is always
+reported and never blocks, not even under strict checking. Prose that declares
+a choice free and still names a preferred value is advisory, not SHOULD.
+
 `policy/base.yaml` and `policy/profiles/` are the sole source of executable
 values, applicability, and check configuration for machine-enforced rules.
 Normative Markdown explains those rules and human-review-only guidance but is

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -305,7 +305,7 @@ rules:
 
   - id: RSK015
     title: Ruff line length uses the recommended baseline
-    level: recommended
+    level: advisory
     profiles: [python-single, python-workspace]
     source:
       document: docs/quality-gates.md

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -44,7 +44,6 @@ class Finding:
     rule_id: str
     title: str
     level: str
-    severity: str
     path: str
     line: int | None
     message: str
@@ -1513,12 +1512,10 @@ CHECK_HANDLERS: dict[str, CheckHandler] = {
 
 
 def _finding(rule: Rule, issue: Issue) -> Finding:
-    severity = "platform" if issue.status == "indeterminate" else rule.severity
     return Finding(
         rule.id,
         rule.title,
         rule.level,
-        severity,
         issue.path,
         issue.line,
         issue.message,

--- a/src/repo_standard/compliance/cli.py
+++ b/src/repo_standard/compliance/cli.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from repo_standard.compliance.checks import Finding, check_repo, load_policy
+from repo_standard.policy.models import DEFAULT_LEVELS, STRICT_LEVELS
 
 _POSITIVE = "\033[38;2;35;209;111m"
 _RESET = "\033[0m"
@@ -39,7 +40,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Treat 'should' findings as failures too.",
+        help="Treat recommended findings as failures too. Advisory never fails.",
     )
     return parser
 
@@ -87,7 +88,6 @@ def _format_json(findings: list[Finding]) -> str:
                     "rule_id": finding.rule_id,
                     "title": finding.title,
                     "level": finding.level,
-                    "severity": finding.severity,
                     "path": finding.path,
                     "line": finding.line,
                     "message": finding.message,
@@ -126,7 +126,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if any(finding.status == "indeterminate" for finding in findings):
         return 2
-    levels = {"required", "recommended"} if args.strict else {"required"}
+    # `advisory` belongs to neither set: those findings are always printed
+    # above and never reach the exit code, not even under `--strict`.
+    levels = STRICT_LEVELS if args.strict else DEFAULT_LEVELS
     if any(finding.level in levels for finding in findings):
         return 1
     return 0

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -490,7 +490,7 @@
       },
       "enforcement": "structural",
       "id": "RSK015",
-      "level": "recommended",
+      "level": "advisory",
       "profiles": [
         "python-single",
         "python-workspace"

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -16,7 +16,13 @@ COMPILED_POLICY_PATH = Path(__file__).resolve().parent / "compiled.json"
 
 _SAFE_YAML = YAML(typ="safe")
 
-LEVELS = {"required", "recommended"}
+# Policy levels, ordered from most to least binding. `required` fails by
+# default; `recommended` fails only under strict checking; `advisory` is always
+# reported and never fails, because the prose it comes from leaves the choice
+# to the repository.
+LEVELS = {"required", "recommended", "advisory"}
+STRICT_LEVELS = {"required", "recommended"}
+DEFAULT_LEVELS = {"required"}
 ENFORCEMENT_MODES = {"structural", "platform"}
 MARKER_KINDS = {"file", "directory"}
 GITHUB_PERMISSION_VALUES = {"none", "read", "write"}
@@ -466,11 +472,6 @@ class Rule:
     check: Check
     rationale: str
     remediation: str
-
-    @property
-    def severity(self) -> str:
-        """Legacy JSON compatibility field retained through v1."""
-        return "shall" if self.level == "required" else "should"
 
     @classmethod
     def from_data(cls, value: Any, location: str) -> Rule:

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -20,7 +20,8 @@ _SAFE_YAML = YAML(typ="safe")
 # default; `recommended` fails only under strict checking; `advisory` is always
 # reported and never fails, because the prose it comes from leaves the choice
 # to the repository.
-LEVELS = {"required", "recommended", "advisory"}
+LEVEL_ORDER = ("required", "recommended", "advisory")
+LEVELS = set(LEVEL_ORDER)
 STRICT_LEVELS = {"required", "recommended"}
 DEFAULT_LEVELS = {"required"}
 ENFORCEMENT_MODES = {"structural", "platform"}

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -26,6 +26,7 @@ from repo_standard.bootstrap_defaults import DEFAULT_PYTHON_VERSION
 from repo_standard.compliance.checks import Finding, check_repo, load_policy
 from repo_standard.github_references import is_full_commit_sha
 from repo_standard.policy import Shape
+from repo_standard.policy.models import LEVEL_ORDER
 from repo_standard.repo_init import (
     PLACEHOLDERS,
     UNLICENSED_NOTICE,
@@ -919,14 +920,13 @@ def _print_summary(plan: AdoptionPlan, findings: list[Finding] | None) -> None:
     if findings is None:
         print("remaining findings: not evaluated during dry-run")
         return
-    required = [finding for finding in findings if finding.level == "required"]
-    recommended = [finding for finding in findings if finding.level == "recommended"]
-    print(f"remaining required findings: {len(required)}")
-    for finding in required:
-        print(f"  - {finding.rule_id} {finding.path}: {finding.message}")
-    print(f"remaining recommended findings: {len(recommended)}")
-    for finding in recommended:
-        print(f"  - {finding.rule_id} {finding.path}: {finding.message}")
+    # Walking the declared levels keeps this summary complete when policy gains
+    # one; naming them here is how `advisory` findings went unreported.
+    for level in LEVEL_ORDER:
+        matching = [finding for finding in findings if finding.level == level]
+        print(f"remaining {level} findings: {len(matching)}")
+        for finding in matching:
+            print(f"  - {finding.rule_id} {finding.path}: {finding.message}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -31,7 +31,7 @@ from repo_standard.policy import (
     load_source_policy,
 )
 from repo_standard.policy.compiler import render_compiled, render_reference
-from repo_standard.policy.models import CHECK_SCHEMAS
+from repo_standard.policy.models import CHECK_SCHEMAS, LEVELS
 from repo_standard.repo_init import bootstrap_repo
 
 POLICY = load_policy()
@@ -539,7 +539,6 @@ def test_finding_contains_actionable_contract_fields(tmp_path: Path) -> None:
     finding = next(f for f in check_repo(root, POLICY) if f.rule_id == "RSK004")
     assert finding.title
     assert finding.level == "required"
-    assert finding.severity == "shall"
     assert finding.actual == "missing"
     assert finding.expected == "file"
     assert finding.remediation
@@ -561,9 +560,46 @@ def test_non_uv_build_backend_is_a_strict_only_recommendation(
         finding for finding in check_repo(root, POLICY) if finding.rule_id == "RSK008"
     )
     assert finding.level == "recommended"
-    assert finding.severity == "should"
     assert cli.main([str(root)]) == 0
     assert cli.main([str(root), "--strict"]) == 1
+
+
+def test_line_length_is_advisory_while_pytest_rules_stay_recommended() -> None:
+    assert LEVELS == {"required", "recommended", "advisory"}
+    assert POLICY.rule("RSK015").level == "advisory"
+    assert POLICY.rule("RSK016").level == "recommended"
+
+
+def test_advisory_finding_is_reported_but_never_blocks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _minimal_repo(tmp_path)
+    pyproject = root / "pyproject.toml"
+    baseline = POLICY.rule("RSK015").check.config["value"]
+    declared = baseline + 12
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace(
+            f"line-length = {baseline}", f"line-length = {declared}"
+        ),
+        encoding="utf-8",
+    )
+
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK015"]
+    assert finding.level == "advisory"
+    assert finding.actual == declared
+    assert finding.expected == baseline
+
+    # Reported in both modes, and blocking in neither — not even under --strict.
+    assert cli.main([str(root)]) == 0
+    assert "RSK015" in capsys.readouterr().out
+    assert cli.main([str(root), "--strict", "--format", "json"]) == 0
+    [item] = [
+        item
+        for item in json.loads(capsys.readouterr().out)
+        if item["rule_id"] == "RSK015"
+    ]
+    assert item["level"] == "advisory"
+    assert "severity" not in item
 
 
 # --- GitHub workflow structure, commands, permissions, and pins -----------
@@ -1073,7 +1109,6 @@ def test_zero_approvals_passes_required_policy_but_reports_recommendation(
     assert not any(finding.rule_id == "RSK014" for finding in findings)
     [finding] = [finding for finding in findings if finding.rule_id == "RSK022"]
     assert finding.level == "recommended"
-    assert finding.severity == "should"
     assert finding.status == "violation"
     assert finding.message == "main requires too few approving reviews."
 
@@ -1155,7 +1190,6 @@ def test_zero_approval_ruleset_passes_rsk014_but_reports_rsk022(
     assert not any(finding.rule_id == "RSK014" for finding in findings)
     [finding] = [finding for finding in findings if finding.rule_id == "RSK022"]
     assert finding.level == "recommended"
-    assert finding.severity == "should"
     assert finding.message == "main requires too few approving reviews."
 
 
@@ -1319,7 +1353,7 @@ def test_only_known_nonempty_ignore_reasons_suppress(tmp_path: Path) -> None:
     assert "RSK004" not in _rule_ids(check_repo(root, POLICY))
 
 
-def test_json_output_retains_legacy_fields_and_adds_actionable_fields(
+def test_json_output_carries_actionable_fields_and_no_legacy_severity(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     root = _minimal_repo(tmp_path)
@@ -1330,7 +1364,7 @@ def test_json_output_retains_legacy_fields_and_adds_actionable_fields(
         for item in json.loads(capsys.readouterr().out)
         if item["rule_id"] == "RSK004"
     ]
-    assert {"rule_id", "severity", "path", "line", "message"} <= item.keys()
+    assert {"rule_id", "path", "line", "message"} <= item.keys()
     assert {
         "title",
         "level",
@@ -1339,6 +1373,7 @@ def test_json_output_retains_legacy_fields_and_adds_actionable_fields(
         "remediation",
         "status",
     } <= item.keys()
+    assert "severity" not in item
 
 
 def test_success_output_uses_positive_brand_color() -> None:
@@ -1355,7 +1390,7 @@ def test_strict_mode_only_promotes_recommended_findings(tmp_path: Path) -> None:
 
 
 def test_unavailable_requested_platform_check_is_command_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     root = _minimal_repo(tmp_path)
 
@@ -1372,7 +1407,18 @@ def test_unavailable_requested_platform_check_is_command_error(
     findings = check_repo(root, POLICY, include_platform=True)
     finding = next(f for f in findings if f.rule_id == "RSK014")
     assert finding.status == "indeterminate"
-    assert finding.severity == "platform"
+
+    # `status` is the only carrier of the indeterminate signal now that the
+    # legacy `severity: "platform"` value is gone, so JSON must still emit it.
+    assert cli.main([str(root), "--check-enforcement", "--format", "json"]) == 2
+    [item] = [
+        item
+        for item in json.loads(capsys.readouterr().out)
+        if item["rule_id"] == "RSK014"
+    ]
+    assert item["status"] == "indeterminate"
+    assert item["level"] == "required"
+    assert "severity" not in item
 
 
 @pytest.mark.parametrize("profile", STARTER_KIT_PROFILES)

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -11,14 +11,17 @@ import pytest
 import tomlkit
 from conftest import REPO_ROOT, dump_yaml, load_yaml
 
-from repo_standard.compliance.checks import check_repo, load_policy
+from repo_standard.compliance.checks import Finding, check_repo, load_policy
+from repo_standard.policy.models import LEVEL_ORDER
 from repo_standard.repo_adopt import (
     AdoptionError,
+    AdoptionPlan,
     CommandError,
     _kit_version,
     _merge_agents,
     _merge_pyproject,
     _merge_readme,
+    _print_summary,
     _project_values,
     _run,
     apply_plan,
@@ -575,3 +578,39 @@ def test_new_pyproject_tables_are_placed_in_declared_order(tmp_path: Path) -> No
     )
     assert _is_subsequence(tables, shape.headings), f"table order is wrong: {tables}"
     assert tables.index("dependency-groups") < tables.index("build-system")
+
+
+def test_summary_reports_every_declared_level(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A level policy declares but the summary omits is a silently dropped finding."""
+    plan = AdoptionPlan(
+        root=tmp_path,
+        profile="python-single",
+        version="0.0.0",
+        changes=(),
+        unchanged=(),
+        conflicts=(),
+        dependency_metadata_changed=False,
+    )
+    findings = [
+        Finding(
+            rule_id=f"RSK{index:03d}",
+            title="title",
+            level=level,
+            path="pyproject.toml",
+            line=None,
+            message=f"{level} message",
+            actual=None,
+            expected=None,
+            remediation="remediate",
+        )
+        for index, level in enumerate(LEVEL_ORDER, 1)
+    ]
+
+    _print_summary(plan, findings)
+
+    output = capsys.readouterr().out
+    for level in LEVEL_ORDER:
+        assert f"remaining {level} findings: 1" in output
+        assert f"{level} message" in output


### PR DESCRIPTION
## Why this level exists

RSK015 recommends `line-length = 88`. Section 13 of `docs/quality-gates.md`
says the opposite about the value itself: it "is a per-repository decision,
not prescribed by this standard", and a different declared value "does not
need an exemption under section 11". So a rule was failing `--strict` on a
choice the normative prose declares free.

The 88 recommendation is still worth stating and still worth printing. What it
must never do is fail. `SHOULD` cannot express that — `docs/repo-standard.md`
defines it as "non-blocking unless strict checking is requested", which is
exactly what `recommended` already does. Hence a third level.

`Rule.severity` had to go in the same commit. It is a second name for `level`
that maps `required` to `shall` and everything else to `should`; keeping it
would have forced an invented `shall`/`should` value for `advisory`. Its
"retained through v1" promise has expired.

## What changed

**The `advisory` level.** `LEVELS` in `src/repo_standard/policy/models.py`
gains it, alongside the `STRICT_LEVELS` / `DEFAULT_LEVELS` sets the CLI now
consumes; `advisory` is deliberately in neither, so it cannot reach the exit
code under any flag. `src/repo_standard/compliance/cli.py` uses those sets and
its `--strict` help says what the flag does not promote.

**RSK015 moves to `advisory`** in `policy/base.yaml`. RSK016 stays
`recommended`: the `PT` family is a real lint improvement, not a value the
standard hands back to the repository. The new level is meant to stay narrow.

**`severity` is gone** from `Rule` (`policy/models.py`), from `Finding` and
`_finding()` (`compliance/checks.py`), and from the JSON payload
(`compliance/cli.py`). It also encoded `"platform"` for an indeterminate
finding; that signal is unaffected, because `status: "indeterminate"` is
emitted separately and now has explicit JSON-level test coverage.

**Prose.** `docs/repo-standard.md` defines `advisory` in the Normative
Language section. `docs/compliance.md` states what `--strict` does and does not
promote, and its JSON section now documents `level` plus `status` in place of
the removed field. `docs/quality-gates.md` section 13 describes RSK015 at the
advisory level and says why.

`docs/policy-reference.md` and `src/repo_standard/policy/compiled.json` are
regenerated. The reference renderer already emitted `rule.level` verbatim, so
no generator change was needed.

## Verification

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
check toml...............................................................Passed
check json...............................................................Passed
trim trailing whitespace.................................................Passed
fix final newline........................................................Passed
check merge conflict markers.............................................Passed
detect private keys......................................................Passed
detect secrets...........................................................Passed
prevent oversized files..................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
ty check.................................................................Passed
markdown lint............................................................Passed

$ uv run pytest
365 passed in 21.07s

$ uv run repo-check . --strict
All checks passed!
EXIT=0
```

Behaviour of the new level, on a copy of this repository whose `pyproject.toml`
declares `line-length = 100`:

```
$ uv run repo-check .tmp/advisory-demo --strict
ADVISORY    RSK015  pyproject.toml  Ruff line length uses the recommended baseline: Ruff line-length differs from the recommendation.
  actual: 100
  expected: 88
  remediation: Prefer line-length = 88 unless the repository has a reason to differ.

1 finding(s).
EXIT=0
```

```
$ uv run repo-check .tmp/advisory-demo --strict --format json
[
  {
    "rule_id": "RSK015",
    "title": "Ruff line length uses the recommended baseline",
    "level": "advisory",
    "path": "pyproject.toml",
    "line": null,
    "message": "Ruff line-length differs from the recommendation.",
    "actual": 100,
    "expected": 88,
    "remediation": "Prefer line-length = 88 unless the repository has a reason to differ.",
    "status": "violation"
  }
]
EXIT=0
```

Reported under `--strict`, exit code `0`, `level: "advisory"` present, no
`severity` key.

## Tests

The six `severity` assertions in `tests/test_compliance.py` are replaced. The
JSON test now asserts `severity` is absent; the platform test asserts the
indeterminate case survives the removal by checking the JSON `status` field
directly. New coverage: the level enum and RSK015/RSK016 placement, and an
advisory finding that is reported in text and JSON while leaving both the
default and the `--strict` exit code at `0`.

## Note for the CHANGELOG (Phase 7)

Dropping `severity` is breaking for anyone parsing `repo-check --format json`,
so the entry needs an **Adopters must** line.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: the adoption summary

Auditing this branch surfaced a regression it introduced. `repo-adopt`'s
summary filtered findings by the two literal level names, so RSK015 moving to
`advisory` dropped it out of that output entirely — neither required nor
recommended, and nothing else printed it.

`_print_summary` now walks `LEVEL_ORDER`, which `models.py` derives `LEVELS`
from, so a level policy declares cannot go unreported. A regression test builds
one finding per declared level and asserts each appears.

Gates after the follow-up: 13/13 hooks, 366 passed, `repo-check . --strict`
clean.
