### PR TITLE
fix: ship starter .gitignore and document repo-adopt flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ __pycache__/
 .uv-cache/
 dist/
 
-.claude
+.claude/

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -40,10 +40,11 @@ is already compliant and produces no planned changes.
 the checkout:
 
 - Standard-owned assets such as the compliance workflow, GitHub Actions
-  Dependabot entry, Markdown configuration, changelog skeleton, and
-  documentation directories are added when missing. Existing non-empty ADR
+  Dependabot entry, Markdown configuration, changelog skeleton, `.gitignore`,
+  and documentation directories are added when missing. Existing non-empty ADR
   and diagram directories are authoritative and are never seeded with starter
-  files or conflicting decision numbers.
+  files or conflicting decision numbers. An existing `.gitignore` is left
+  untouched; it is never merged with the starter's.
 - `pyproject.toml`, `.pre-commit-config.yaml`, and the quality workflow are
   structurally merged. Existing project dependencies, build settings,
   services, custom hooks, and additional steps remain in place.
@@ -257,6 +258,7 @@ widget-service/
   .github/dependabot.yml
   .github/workflows/compliance.yml
   .github/workflows/quality.yml
+  .gitignore
   .pre-commit-config.yaml
   .pymarkdown.json
   AGENTS.md
@@ -283,6 +285,7 @@ widget-platform/
   .github/dependabot.yml
   .github/workflows/compliance.yml
   .github/workflows/quality.yml
+  .gitignore
   .pre-commit-config.yaml
   .pymarkdown.json
   AGENTS.md

--- a/docs/release-plan-v2.0.0.md
+++ b/docs/release-plan-v2.0.0.md
@@ -118,12 +118,14 @@ Numbers are stable identifiers referenced by the phase table and the sub-issues.
 
 ### Dead weight
 
-- `checks.py:82-83` — `load_rules`, a compatibility alias for the v0.4 name.
-- `models.py:470-473` and `cli.py:90` — the JSON `severity` field, carrying an
-  expired "through v1" promise.
-- `pyproject.toml:43` — `profiles/**` in `source-include`.
+- `load_rules`, a compatibility alias for the v0.4 name. Removed by P6 (#53).
+- The JSON `severity` field, carrying an expired "through v1" promise. Removed
+  by P3 (#57).
+- `profiles/**` in `source-include`. Removed by P1 (#49).
 - `docs/diagrams/README.md` — a placeholder shipped into every generated
-  repository that no rule references.
+  repository that no rule references. **Still present and owned by no phase.**
+  Deleting it is a starter-kit change; leaving it needs a rule that gives it a
+  reason to exist. P7 must not tag with this unresolved.
 
 ### Findings added during the work
 

--- a/docs/release-plan-v2.0.0.md
+++ b/docs/release-plan-v2.0.0.md
@@ -4,13 +4,14 @@ This is a working tracker, not part of the standard. It records the audit
 findings for `chore/release-v2.0.0`, the decisions taken about them, and the
 phase each correction belongs to.
 
-**P7 deletes this file.** It exists to keep seven phases coordinated while the
+**P7 deletes this file.** It exists to keep eight phases coordinated while the
 release branch is open, and `pyproject.toml` ships `docs/**` to adopters, so it
 must not survive the tag.
 
 ## Context
 
-An audit of `chore/release-v2.0.0` found 22 issues the gates do not catch.
+An audit of `chore/release-v2.0.0` found 22 issues the gates do not catch. Two
+further findings (23, 24) surfaced during the work, bringing the total to 24.
 `uv run pytest` passes and `repo-check . --strict` is clean; that is part of
 the finding rather than a reassurance.
 
@@ -24,24 +25,27 @@ the finding rather than a reassurance.
 | D4 | New `advisory` policy level; RSK015 moves to it | `line-length = 88` stays visible and stops failing `--strict` |
 | D5 | `repo-init` gains `repo-adopt`'s `--no-lock` / `--no-install` split | Bootstrapped repositories stop failing required RSK009 |
 | D6 | Drop `load_rules` and the JSON `severity` field | Must land with D4, or `advisory` needs an invented `shall`/`should` value |
+| D7 | No rule checks `.gitignore`; shipping it in the starter is enough | Fixes finding 23 without adding a check that would be noise in every adopter's output |
 
 ## Phases
 
 Each phase is a sub-issue and one PR into `chore/release-v2.0.0`. Critical path
-is P3 → P5 → P7; P1, P2, P4 and P6 run alongside it.
+is P3 → P5 → P7; P2, P4 and P8 run alongside it.
 
 | Phase | Scope | Findings | Depends on | Status |
 | --- | --- | --- | --- | --- |
-| P1 | Factual corrections | 4, 5, 6, 8, 10, 15, 18 | — | In progress |
-| P2 | Root documents under the generator | 7 | P1 | Not started |
-| P3 | Policy schema: `advisory`, drop `severity` | 19, dead weight | — | Not started |
-| P4 | Checker correctness | 13, 14, 20, 22 | — | Not started |
+| P1 | Factual corrections | 4, 5, 6, 8, 10, 15, 18 | — | Merged (#49) |
+| P2 | Root documents under the generator | 7 | P1 | Merged (#58) |
+| P3 | Policy schema: `advisory`, drop `severity` | 19, dead weight | — | Merged (#57) |
+| P4 | Checker correctness | 13, 14, 20, 22 | — | In progress (#59) |
 | P5 | Coverage: compliance workflow and shapes | 11, 12, 16, 17 | P3 | Not started |
-| P6 | Bootstrap contract and dead weight | 9, 21 | — | In progress |
+| P6 | Bootstrap contract and dead weight | 9, 21 | — | Merged (#53) |
 | P7 | Release finalization | 1, 2, 3 | all | Not started |
+| P8 | Starter `.gitignore`, `repo-adopt` flag docs | 23, 24 | — | In progress (#56) |
 
 P1 precedes P2 so the corrected prose is what gets migrated into fragments,
-rather than migrating the defects and fixing them twice.
+rather than migrating the defects and fixing them twice. P8 shares no files
+with any other phase and blocks nothing.
 
 ## Findings Index
 
@@ -120,3 +124,16 @@ Numbers are stable identifiers referenced by the phase table and the sub-issues.
 - `pyproject.toml:43` — `profiles/**` in `source-include`.
 - `docs/diagrams/README.md` — a placeholder shipped into every generated
   repository that no rule references.
+
+### Findings added during the work
+
+- **23.** Neither starter kit ships a `.gitignore`, and `repo-init` never
+  writes one, so a bootstrapped repository starts with `.venv/`,
+  `__pycache__/`, `.pytest_cache/`, `.ruff_cache/` and `dist/` all
+  committable. Sharpened by P6: `repo-init` now runs `uv lock` and `uv sync`
+  on the default path, so a generated repository has a `.venv/` before the
+  maintainer's first commit. Resolved by D7 and scoped to P8.
+- **24.** `repo_adopt.build_parser` declared `--dry-run`, `--no-lock` and
+  `--no-install` with no help text, so `repo-adopt --help` listed three flags
+  with no explanation. Its failure handling was already correct — only the
+  help text was missing. Scoped to P8.

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -96,6 +96,7 @@ _MANAGED_SURFACES = (
     "AGENTS.md",
     "README.md",
     "CHANGELOG.md",
+    ".gitignore",
     "docs/adr",
     "docs/diagrams",
 )
@@ -131,9 +132,22 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("target", nargs="?", default=".")
     parser.add_argument("--profile", choices=policy.profile_ids)
-    parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--no-lock", action="store_true")
-    parser.add_argument("--no-install", action="store_true")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan and print the reconciliation without writing, staging, or "
+        "running any command.",
+    )
+    parser.add_argument(
+        "--no-lock",
+        action="store_true",
+        help="Skip uv lock, leaving lockfile refresh to the maintainer.",
+    )
+    parser.add_argument(
+        "--no-install",
+        action="store_true",
+        help="Skip environment synchronization after reconciliation.",
+    )
     parser.add_argument(
         "--native-tls",
         action="store_true",
@@ -761,7 +775,12 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
     document = _parse_toml(root / "pyproject.toml")
     selected = _resolve_profile(root, document, profile)
     policy = load_policy()
-    if not check_repo(root, policy, profile=selected):
+    # No rule checks .gitignore (a repo-specific file is a poor fit for a
+    # structural rule), so a repository can be fully compliant and still lack
+    # one. The short circuit below only fires when `check_repo` already found
+    # something to fix, so it is gated on the file's presence too.
+    gitignore_present = (root / ".gitignore").is_file()
+    if not check_repo(root, policy, profile=selected) and gitignore_present:
         unchanged = tuple(
             relative for relative in _MANAGED_SURFACES if (root / relative).exists()
         )
@@ -815,6 +834,12 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
         generated["CHANGELOG.md"] = _render(
             _read_starter(selected, "CHANGELOG.md"), values
         )
+
+    gitignore = root / ".gitignore"
+    if gitignore.exists():
+        unchanged.append(".gitignore")
+    else:
+        generated[".gitignore"] = _read_starter(selected, ".gitignore")
 
     for directory, starter_file in (
         ("docs/adr", "docs/adr/0001-template.md"),

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -775,10 +775,11 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
     document = _parse_toml(root / "pyproject.toml")
     selected = _resolve_profile(root, document, profile)
     policy = load_policy()
-    # No rule checks .gitignore (a repo-specific file is a poor fit for a
-    # structural rule), so a repository can be fully compliant and still lack
-    # one. The short circuit below only fires when `check_repo` already found
-    # something to fix, so it is gated on the file's presence too.
+    # The short circuit below returns an empty plan when `check_repo` finds
+    # nothing. No rule checks .gitignore -- a file this repo-specific is a poor
+    # fit for a structural rule -- so a repository can be clean by every rule
+    # and still have none, which is why presence is asked here rather than
+    # inferred from the findings.
     gitignore_present = (root / ".gitignore").is_file()
     if not check_repo(root, policy, profile=selected) and gitignore_present:
         unchanged = tuple(

--- a/src/repo_standard/starter_kits/python-single/.gitignore
+++ b/src/repo_standard/starter_kits/python-single/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.tmp/
+.uv-cache/
+dist/

--- a/src/repo_standard/starter_kits/python-workspace/.gitignore
+++ b/src/repo_standard/starter_kits/python-workspace/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.tmp/
+.uv-cache/
+dist/

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -137,6 +137,29 @@ def test_adoption_reaches_zero_required_findings_and_is_idempotent(
     assert repeated.changes == ()
 
 
+def test_missing_gitignore_is_added_never_merged(tmp_path: Path) -> None:
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    gitignore = (root / ".gitignore").read_text(encoding="utf-8")
+    assert ".venv/" in gitignore
+    assert "__pycache__/" in gitignore
+
+
+def test_existing_gitignore_is_left_untouched(tmp_path: Path) -> None:
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    (root / ".gitignore").write_text("node_modules/\n", encoding="utf-8")
+
+    plan = plan_adoption(root, "python-single")
+    apply_plan(plan)
+
+    assert ".gitignore" not in {change.path.as_posix() for change in plan.changes}
+    assert (root / ".gitignore").read_text(encoding="utf-8") == "node_modules/\n"
+
+
 def test_dry_run_is_read_only_and_does_not_require_git(tmp_path: Path) -> None:
     root = tmp_path / "existing"
     _write_minimal_repo(root, "python-single")
@@ -234,6 +257,24 @@ def test_non_uv_build_backend_is_preserved_without_conflict(tmp_path: Path) -> N
     )
     assert backend_finding.level == "recommended"
     assert not [finding for finding in findings if finding.level == "required"]
+
+
+def test_fully_compliant_repository_still_gets_a_missing_gitignore(
+    tmp_path: Path,
+) -> None:
+    """No rule checks `.gitignore`, so zero findings must not short-circuit it."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    apply_plan(plan_adoption(root, "python-single"))
+    (root / "LICENSE").write_text("Approved license terms.\n", encoding="utf-8")
+    assert check_repo(root, load_policy(), profile="python-single") == []
+    (root / ".gitignore").unlink()
+
+    plan = plan_adoption(root, "python-single")
+
+    assert {change.path.as_posix() for change in plan.changes} == {".gitignore"}
+    apply_plan(plan)
+    assert (root / ".gitignore").is_file()
 
 
 def test_structurally_compliant_repository_is_a_no_op(tmp_path: Path) -> None:

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -112,6 +112,9 @@ def test_bootstrap_repo_renders_python_single_starter(tmp_path: Path) -> None:
     assert not (output_dir / ".ruff_cache").exists()
     assert (output_dir / "src" / "demo_service" / "__init__.py").exists()
     assert not (output_dir / "src" / "package_name").exists()
+    gitignore_text = (output_dir / ".gitignore").read_text(encoding="utf-8")
+    for entry in (".venv/", "__pycache__/", ".pytest_cache/", ".ruff_cache/", "dist/"):
+        assert entry in gitignore_text
 
 
 def test_bootstrap_repo_infers_package_name_for_python_single(tmp_path: Path) -> None:
@@ -179,6 +182,9 @@ def test_bootstrap_repo_renders_python_workspace_starter(tmp_path: Path) -> None
     assert not (output_dir / ".ruff_cache").exists()
     assert (output_dir / "packages" / ".gitkeep").exists()
     assert not (output_dir / "src").exists()
+    gitignore_text = (output_dir / ".gitignore").read_text(encoding="utf-8")
+    for entry in (".venv/", "__pycache__/", ".pytest_cache/", ".ruff_cache/", "dist/"):
+        assert entry in gitignore_text
 
     # M1: pytest must not exit 5 (empty collection) before any package exists.
     assert (output_dir / "tests" / "test_workspace_shell.py").exists()


### PR DESCRIPTION
## Why

Two gaps found during the v2.0.0 audit, both narrow bootstrap-tooling fixes
that share no files with any other phase and block nothing.

**Finding 23.** Neither starter kit shipped a `.gitignore`, and `repo-init`
never wrote one, so a bootstrapped repository started with `.venv/`,
`__pycache__/`, `.pytest_cache/`, `.ruff_cache/` and `dist/` all committable.
P6 sharpened this: `repo-init` now runs `uv lock` and `uv sync` on the default
path, so a generated repository already has a `.venv/` before the
maintainer's first commit.

**Finding 24.** `repo_adopt.build_parser` declared `--dry-run`, `--no-lock`
and `--no-install` with no help text, so `repo-adopt --help` listed three
flags with no explanation. Its failure handling was already correct — only
the help text was missing.

## What changed

- Added `.gitignore` (`.venv/`, `__pycache__/`, `*.pyc`, `.pytest_cache/`,
  `.ruff_cache/`, `.tmp/`, `.uv-cache/`, `dist/`) to both
  `src/repo_standard/starter_kits/*/`, mirroring this repository's own. It is
  copied into every generated repository the same way every other starter
  file is.
- `repo_adopt.plan_adoption` adds `.gitignore` when it is entirely missing and
  never touches one that already exists — the same "added when missing, never
  merged" treatment as `CHANGELOG.md`. Because D7 keeps `.gitignore` outside
  policy, a repository can have zero `repo-check` findings and still lack the
  file, so the existing zero-findings short circuit is now also gated on the
  file's presence; a covering test exercises exactly that case.
- Help text for `--dry-run`, `--no-lock` and `--no-install` in
  `repo_adopt.build_parser`, matching `repo-init`'s existing text.
- `docs/bootstrap-workflow.md`: `.gitignore` added to the "added when missing"
  ownership list (with a note that an existing one is never merged) and to
  both `python-single` / `python-workspace` expected-output trees.
- `docs/release-plan-v2.0.0.md`: added the P8 row, findings 23/24, decision
  D7, and refreshed phase statuses to match the repository (P1/P2/P3/P6
  merged, P4 in progress, P7 not started).
- Tests: the generated `.gitignore` exists and covers the expected paths in
  both `repo-init` profiles; `repo-adopt` adds it when missing, leaves an
  existing one untouched, and still adds it even when every policy-checked
  surface is already compliant.

## Explicitly not in scope (per #56)

No rule checks `.gitignore` — shipping it in the starter is the fix, and its
contents are too repo-specific for a structural check to say anything
meaningful. No rule was added, removed, or re-levelled.
`repo-adopt`'s failure handling is unchanged.

## Verification

```text
$ uv run pre-commit run --all-files
... 13/13 hooks Passed

$ uv run pytest
413 passed

$ uv run repo-check . --strict
All checks passed!

$ uv run python scripts/generate_docs.py && uv run python scripts/generate_policy.py && git diff --exit-code
(no drift beyond this PR's own commit)
```

Freshly generated repository:

```text
$ uv run repo-init --profile python-single --repo-name widget-service \
    --output-dir /tmp/p8-demo/widget-service --no-lock --no-install
Bootstrapped widget-service into .../p8-demo/widget-service

$ cat /tmp/p8-demo/widget-service/.gitignore
.venv/
__pycache__/
*.pyc
.pytest_cache/
.ruff_cache/
.tmp/
.uv-cache/
dist/
```

The same file, with the same content, is produced for `python-workspace`, and
is present inside the built wheel (`uv build --wheel`), so `uvx`-installed
`repo-init` ships it too.

```text
$ uv run repo-adopt --help
  --dry-run             Plan and print the reconciliation without writing,
                        staging, or running any command.
  --no-lock             Skip uv lock, leaving lockfile refresh to the
                        maintainer.
  --no-install          Skip environment synchronization after reconciliation.
```

---

Addresses #56.
