### PR TITLE
fix: close four checker correctness gaps (P4)

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -181,7 +181,9 @@ remediation. Markdown explains policy but supplies no executable values.
 - GitHub Actions are parsed with safe GitHub-compatible YAML semantics, so
   `on` remains a string. RSK006 inspects only executable
   `jobs.quality.steps[*].run` nodes. Comments, echo, unrelated fields, and
-  shell-wrapper strings do not satisfy commands.
+  shell-wrapper strings do not satisfy commands, and neither does a command
+  reachable only under a condition the policy does not declare for the
+  profile.
 - Pre-commit is parsed structurally. RSK007 matches hook IDs, normalized entry
   and argument tokens, and policy-owned material fields such as filters and
   `pass_filenames`.

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -181,7 +181,12 @@ Remediation: Link repo-standard-kit from README.md and AGENTS.md.
 
 Rationale: Pull requests must execute the same reproducible gates as local work.
 
-Remediation: Add the pull_request trigger, quality job, and complete commands.
+Remediation: Add the pull_request trigger, quality job, and complete commands, and gate a command only with the condition policy declares for the profile.
+
+| Profile | Permitted guard |
+| --- | --- |
+| `python-single` | none |
+| `python-workspace` | `compgen -G "packages/*/pyproject.toml" > /dev/null` |
 
 ### RSK007: Mandatory pre-commit hooks are configured structurally
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -117,6 +117,13 @@ is inspected; comments, echoed strings, unrelated fields, and commands hidden
 inside a shell-wrapper string do not count. Whitespace, comments, multiline
 commands, and equivalent command formatting are normalized before comparison.
 
+A conditional block that skips a gate still exits zero, so a required command
+inside one proves nothing by itself. Policy owns the permitted guard: a
+required command counts when it is unguarded, or when its only condition is
+the guard the [policy reference](policy-reference.md#rsk006-quality-workflow-executes-the-mandatory-gate-chain)
+declares for the resolved profile. Any other condition, an `else` or `elif`
+branch, a loop body, and a `case` arm leave the command unproven.
+
 Every pull request shall also run an independent `compliance` job that checks
 the repository against repo-standard-kit. The separate status prevents a
 quality workflow from weakening or removing required gates while still

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -171,7 +171,9 @@ appear. Shapes are declared in `policy/shapes.yaml` and compiled into the
 Every shape is checked as a **subsequence**. A section the shape does not
 declare is legal anywhere and is ignored. A declared section may be absent
 unless it is marked required. What a shape forbids is *reordering*: the
-declared sections a file does carry must appear in the declared order. Markdown
+declared sections a file does carry must appear in the declared order, and each
+of them appears at most once, because a subsequence can only place a section
+where it first occurs. Repeating an undeclared section stays legal. Markdown
 shapes govern level-two headings only, matching RSK002's semantics.
 
 RSK023 (`README.md`), RSK024 (`CHANGELOG.md`), and RSK025 (`pyproject.toml`)

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -127,8 +127,14 @@ rules:
             - uv run pre-commit run --all-files
             - uv run pytest
             - uv build --all-packages
+        guards_by_profile:
+          python-single: []
+          python-workspace:
+            - 'compgen -G "packages/*/pyproject.toml" > /dev/null'
     rationale: Pull requests must execute the same reproducible gates as local work.
-    remediation: Add the pull_request trigger, quality job, and complete commands.
+    remediation: >-
+      Add the pull_request trigger, quality job, and complete commands, and
+      gate a command only with the condition policy declares for the profile.
 
   - id: RSK007
     title: Mandatory pre-commit hooks are configured structurally

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 import tomllib
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -68,6 +68,13 @@ class CheckContext:
     root: Path
     policy: Policy
     profile: str
+    # Platform answers already fetched during this run, keyed by query. Scoped
+    # to the context so one run sees one consistent view and the next run
+    # starts from the platform again.
+    _platform_responses: dict[
+        tuple[str, bool],
+        tuple[subprocess.CompletedProcess[str] | None, Issue | None],
+    ] = field(default_factory=dict, compare=False, repr=False)
 
 
 CheckHandler = Callable[[CheckContext, dict[str, Any]], list[Issue]]
@@ -217,7 +224,10 @@ def _shape_issues(shape: Shape, path: str, actual: list[str]) -> list[Issue]:
 
     Presence is checked for required sections only. Order is checked as a
     subsequence: sections the shape does not list are ignored entirely, and a
-    listed section that is absent simply drops out of the comparison.
+    listed section that is absent simply drops out of the comparison. A
+    declared section that appears more than once is reported in its own right,
+    because the subsequence comparison keeps only the first occurrence and
+    would otherwise accept a repeat sitting anywhere in the document.
     """
     issues: list[Issue] = []
     missing = [heading for heading in shape.required if heading not in actual]
@@ -232,9 +242,24 @@ def _shape_issues(shape: Shape, path: str, actual: list[str]) -> list[Issue]:
         )
     listed = set(shape.headings)
     observed: list[str] = []
+    repeated: list[str] = []
     for heading in actual:
-        if heading in listed and heading not in observed:
-            observed.append(heading)
+        if heading not in listed:
+            continue
+        if heading in observed:
+            if heading not in repeated:
+                repeated.append(heading)
+            continue
+        observed.append(heading)
+    if repeated:
+        issues.append(
+            Issue(
+                path,
+                f"Declared sections appear more than once: {', '.join(repeated)}.",
+                actual,
+                list(shape.headings),
+            )
+        )
     expected = [heading for heading in shape.headings if heading in observed]
     if observed != expected:
         issues.append(
@@ -423,10 +448,66 @@ def _text_pattern_each(context: CheckContext, config: dict[str, Any]) -> list[Is
     return issues
 
 
-def _shell_commands(run: str) -> list[list[str]]:
-    """Return executable command token lists from an Actions `run` scalar."""
+@dataclass(frozen=True)
+class ShellCommand:
+    """One command a `run` scalar executes, with the conditions gating it.
+
+    A guard is `None` when its condition is not a plain `if` test — an `else`
+    or `elif` branch, a loop body, a `case` arm — because policy declares a
+    permitted guard as one literal condition and nothing else can match it.
+    """
+
+    tokens: tuple[str, ...]
+    guards: tuple[tuple[str, ...] | None, ...] = ()
+
+
+_SHELL_OPERATORS = {";", ";;", "&&", "||", "&", "|"}
+_BLOCK_PREFIXES = {"then", "do", "{"}
+_BLOCK_CLOSERS = {"fi", "done", "esac"}
+_CONDITION_OPENERS = {"if", "elif", "while", "until"}
+_BODY_OPENERS = {"for", "case"}
+
+
+def _consume_shell_segment(
+    segment: list[str],
+    guards: list[tuple[str, ...] | None],
+    commands: list[ShellCommand],
+) -> None:
+    while segment and segment[0] in _BLOCK_PREFIXES:
+        segment.pop(0)
+    while segment and (segment[-1] in _BLOCK_CLOSERS or segment[-1] == "}"):
+        if segment.pop() in _BLOCK_CLOSERS and guards:
+            guards.pop()
+    if not segment:
+        return
+    keyword = segment[0]
+    if keyword == "else":
+        if guards:
+            guards[-1] = None
+        return
+    if keyword in _CONDITION_OPENERS:
+        if keyword == "elif" and guards:
+            guards[-1] = None
+        else:
+            guards.append(tuple(segment[1:]) if keyword == "if" else None)
+        return
+    if keyword in _BODY_OPENERS:
+        guards.append(None)
+        return
+    commands.append(ShellCommand(tuple(segment), tuple(guards)))
+
+
+def _shell_commands(run: str) -> list[ShellCommand]:
+    """Return executable commands from an Actions `run` scalar, with guards.
+
+    A conditional block can skip a command while the step still exits zero, so
+    a required command found inside one proves nothing on its own. The guard
+    travels with the command and only policy decides which condition, if any,
+    may gate a gate.
+    """
     normalized = re.sub(r"\\\r?\n", " ", run)
-    commands: list[list[str]] = []
+    commands: list[ShellCommand] = []
+    guards: list[tuple[str, ...] | None] = []
     for line in normalized.splitlines() or [normalized]:
         lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|")
         lexer.whitespace_split = True
@@ -437,13 +518,8 @@ def _shell_commands(run: str) -> list[list[str]]:
         except ValueError:
             continue
         for token in [*tokens, ";"]:
-            if token in {";", "&&", "||", "&", "|"}:
-                while segment and segment[0] in {"then", "do", "{"}:
-                    segment.pop(0)
-                while segment and segment[-1] in {"fi", "done", "}"}:
-                    segment.pop()
-                if segment:
-                    commands.append(segment)
+            if token in _SHELL_OPERATORS:
+                _consume_shell_segment(segment, guards, commands)
                 segment = []
             else:
                 segment.append(token)
@@ -556,15 +632,24 @@ def _github_workflow_commands(
             )
         )
         return issues
-    actual_commands: list[list[str]] = []
+    actual_commands: list[ShellCommand] = []
     for step in steps:
         if isinstance(step, dict) and isinstance(step.get("run"), str):
             actual_commands.extend(_shell_commands(step["run"]))
+    declared_guards = config["guards_by_profile"][context.profile]
+    permitted = {tuple(shlex.split(guard)) for guard in declared_guards}
+    present = {command.tokens for command in actual_commands}
+    executed = {
+        command.tokens
+        for command in actual_commands
+        if all(guard in permitted for guard in command.guards)
+    }
     required = [
-        shlex.split(command)
+        tuple(shlex.split(command))
         for command in config["commands_by_profile"][context.profile]
     ]
-    missing = [tokens for tokens in required if tokens not in actual_commands]
+    line = document.line("jobs", config["job"], "steps")
+    missing = [tokens for tokens in required if tokens not in present]
     if missing:
         issues.append(
             Issue(
@@ -572,9 +657,23 @@ def _github_workflow_commands(
                 "Quality job is missing complete executable commands: "
                 + ", ".join(shlex.join(tokens) for tokens in missing)
                 + ".",
-                [shlex.join(tokens) for tokens in actual_commands],
+                [shlex.join(command.tokens) for command in actual_commands],
                 [shlex.join(tokens) for tokens in required],
-                document.line("jobs", config["job"], "steps"),
+                line,
+            )
+        )
+    guarded = [
+        tokens for tokens in required if tokens in present and tokens not in executed
+    ]
+    if guarded:
+        issues.append(
+            Issue(
+                config["path"],
+                "Quality job runs required commands only under an undeclared "
+                "guard: " + ", ".join(shlex.join(tokens) for tokens in guarded) + ".",
+                [shlex.join(tokens) for tokens in guarded],
+                list(declared_guards),
+                line,
             )
         )
     return issues
@@ -830,6 +929,15 @@ def _git_remote_url(root: Path) -> str | None:
 def _gh_api(
     context: CheckContext, endpoint: str, *, paginate: bool = False
 ) -> tuple[subprocess.CompletedProcess[str] | None, Issue | None]:
+    """Query the platform once per run, reusing an answer already fetched.
+
+    Several rules read the same branch protection. Repeating the round-trip
+    costs time and lets two rules disagree because one query flaked while the
+    other succeeded.
+    """
+    cached = context._platform_responses.get((endpoint, paginate))
+    if cached is not None:
+        return cached
     command = ["gh", "api"]
     if paginate:
         command.extend(("--paginate", "--slurp"))
@@ -843,16 +951,20 @@ def _gh_api(
             timeout=30,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as error:
-        return None, (
+        response: tuple[subprocess.CompletedProcess[str] | None, Issue | None] = (
+            None,
             Issue(
                 ".",
                 f"Platform command unavailable: {error}",
                 None,
                 "GitHub enforcement response",
                 status="indeterminate",
-            )
+            ),
         )
-    return result, None
+    else:
+        response = (result, None)
+    context._platform_responses[(endpoint, paginate)] = response
+    return response
 
 
 def _platform_query_failure(
@@ -1420,7 +1532,7 @@ def _github_workflow_permissions(
 ) -> list[Issue]:
     document, job, errors = _workflow_job(context, config)
     if errors:
-        return []
+        return errors
     assert document is not None
     assert job is not None
     assert isinstance(document.data, dict)

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -179,6 +179,12 @@
               "uv build --all-packages"
             ]
           },
+          "guards_by_profile": {
+            "python-single": [],
+            "python-workspace": [
+              "compgen -G \"packages/*/pyproject.toml\" > /dev/null"
+            ]
+          },
           "job": "quality",
           "path": ".github/workflows/quality.yml",
           "trigger": "pull_request"
@@ -193,7 +199,7 @@
         "python-workspace"
       ],
       "rationale": "Pull requests must execute the same reproducible gates as local work.",
-      "remediation": "Add the pull_request trigger, quality job, and complete commands.",
+      "remediation": "Add the pull_request trigger, quality job, and complete commands, and gate a command only with the condition policy declares for the profile.",
       "source": {
         "document": "docs/quality-gates.md",
         "section": "5. CI Pull Request Gates"

--- a/src/repo_standard/policy/compiler.py
+++ b/src/repo_standard/policy/compiler.py
@@ -107,6 +107,18 @@ def render_reference(policy: Policy) -> str:
                 for dial in rule.check.config["dials"]
             )
             lines.append("")
+        # A permitted guard is not machinery either: it is the only condition a
+        # repository may put between CI and a required command, so the reader
+        # gets it here instead of from a prose copy that can drift.
+        guards = rule.check.config.get("guards_by_profile")
+        if isinstance(guards, dict):
+            lines.extend(["| Profile | Permitted guard |", "| --- | --- |"])
+            lines.extend(
+                f"| `{profile}` | "
+                f"{', '.join(f'`{guard}`' for guard in declared) or 'none'} |"
+                for profile, declared in sorted(guards.items())
+            )
+            lines.append("")
     if policy.retired_rule_ids:
         lines.extend(
             [

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -45,7 +45,7 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
     "agents_operating_dials": ({"path", "section", "dials"}, set()),
     "text_pattern_each": ({"paths", "pattern"}, set()),
     "github_workflow_commands": (
-        {"path", "job", "trigger", "commands_by_profile"},
+        {"path", "job", "trigger", "commands_by_profile", "guards_by_profile"},
         set(),
     ),
     "pre_commit_hooks": ({"path", "hooks"}, set()),
@@ -435,6 +435,14 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         )
         for profile_id, values in commands.items():
             _strings(values, f"{location}.commands_by_profile.{profile_id}")
+    # A profile with no permitted guard states an empty list: policy owning the
+    # guard form means the absence of one is declared, not merely unwritten.
+    if "guards_by_profile" in config:
+        guards = _mapping(config["guards_by_profile"], f"{location}.guards_by_profile")
+        for profile_id, values in guards.items():
+            _strings(
+                values, f"{location}.guards_by_profile.{profile_id}", non_empty=False
+            )
     if "hooks" in config:
         hooks = config["hooks"]
         if not isinstance(hooks, list) or not hooks:
@@ -671,20 +679,17 @@ class Policy:
                     f"{location}.rules.{rule.id}.profiles",
                     f"unknown profiles: {sorted(unknown)}",
                 )
-            commands = rule.check.config.get("commands_by_profile")
-            if isinstance(commands, dict):
-                unknown_commands = set(commands) - known_profiles
-                if unknown_commands:
-                    _fail(
-                        f"{location}.rules.{rule.id}.check.config.commands_by_profile",
-                        f"unknown profiles: {sorted(unknown_commands)}",
-                    )
-                missing_commands = set(rule.profiles) - set(commands)
-                if missing_commands:
-                    _fail(
-                        f"{location}.rules.{rule.id}.check.config.commands_by_profile",
-                        f"missing profiles: {sorted(missing_commands)}",
-                    )
+            for key in ("commands_by_profile", "guards_by_profile"):
+                by_profile = rule.check.config.get(key)
+                if not isinstance(by_profile, dict):
+                    continue
+                where = f"{location}.rules.{rule.id}.check.config.{key}"
+                unknown_declared = set(by_profile) - known_profiles
+                if unknown_declared:
+                    _fail(where, f"unknown profiles: {sorted(unknown_declared)}")
+                missing_declared = set(rule.profiles) - set(by_profile)
+                if missing_declared:
+                    _fail(where, f"missing profiles: {sorted(missing_declared)}")
             allowed_missing = rule.check.config.get("allow_missing_profiles")
             if isinstance(allowed_missing, list):
                 unknown_allowed = set(allowed_missing) - known_profiles

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -272,6 +272,29 @@ def test_rsk003_reuses_the_workflow_quality_commands() -> None:
     )
 
 
+def test_rsk006_declares_the_permitted_guard_for_every_profile() -> None:
+    """Silence about a guard must be a declaration, not an omission."""
+    rule = POLICY.rule("RSK006")
+    guards = rule.check.config["guards_by_profile"]
+    assert set(guards) == set(rule.profiles)
+    assert "guards_by_profile" in CHECK_SCHEMAS["github_workflow_commands"][0]
+    assert guards["python-single"] == []
+
+
+def test_a_guard_declared_for_an_unknown_profile_is_rejected(tmp_path: Path) -> None:
+    root = _policy_checkout(tmp_path)
+
+    def mutation(data: dict[str, object]) -> None:
+        rules = data["rules"]
+        assert isinstance(rules, list)
+        rule = next(item for item in rules if item["id"] == "RSK006")
+        rule["check"]["config"]["guards_by_profile"] = {"unknown": []}
+
+    _mutate_base(root, mutation)
+    with pytest.raises(PolicyError, match="guards_by_profile: unknown profiles"):
+        load_source_policy(root)
+
+
 def test_rsk021_policy_is_workflow_scoped() -> None:
     assert POLICY.rule("RSK021").check.config == {
         "path": ".github/workflows/quality.yml"
@@ -657,6 +680,103 @@ def test_missing_trigger_job_or_steps_reports_rsk006(
     path = root / ".github" / "workflows" / "quality.yml"
     path.write_text(mutation(path.read_text(encoding="utf-8")), encoding="utf-8")
     assert "RSK006" in _rule_ids(check_repo(root, POLICY))
+
+
+def test_a_required_command_under_an_undeclared_guard_reports_rsk006(
+    tmp_path: Path,
+) -> None:
+    """A skipped gate still exits zero, so the guard has to be policy-owned."""
+    root = _minimal_repo(tmp_path)
+    path = root / ".github" / "workflows" / "quality.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "      - run: uv build\n",
+            "      - run: |\n"
+            '          if [ -n "$SKIP" ]; then\n'
+            "            uv build\n"
+            "          fi\n",
+        ),
+        encoding="utf-8",
+    )
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK006"]
+    assert finding.message == (
+        "Quality job runs required commands only under an undeclared guard: uv build."
+    )
+    assert finding.expected == []
+
+
+def _workspace_guard() -> str:
+    [guard] = POLICY.rule("RSK006").check.config["guards_by_profile"][
+        "python-workspace"
+    ]
+    return str(guard)
+
+
+def _guard_the_workspace_build(root: Path, guard: str, body: str) -> None:
+    path = root / ".github" / "workflows" / "quality.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "      - run: uv build --all-packages\n",
+            f"      - run: |\n          if {guard}; then\n{body}          fi\n",
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_the_declared_guard_satisfies_rsk006_and_no_other_does(
+    tmp_path: Path,
+) -> None:
+    guard = _workspace_guard()
+    body = "            uv build --all-packages\n"
+
+    declared = tmp_path / "declared"
+    declared.mkdir()
+    root = _minimal_repo(declared, "python-workspace")
+    _guard_the_workspace_build(root, guard, body)
+    assert "RSK006" not in _rule_ids(check_repo(root, POLICY))
+
+    undeclared = tmp_path / "undeclared"
+    undeclared.mkdir()
+    other = _minimal_repo(undeclared, "python-workspace")
+    _guard_the_workspace_build(other, "compgen -G 'src/*' > /dev/null", body)
+    [finding] = [f for f in check_repo(other, POLICY) if f.rule_id == "RSK006"]
+    assert finding.actual == ["uv build --all-packages"]
+    assert finding.expected == [guard]
+
+
+def test_a_command_in_the_else_branch_does_not_satisfy_rsk006(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path, "python-workspace")
+    body = (
+        "            echo skipped\n"
+        "          else\n"
+        "            uv build --all-packages\n"
+    )
+    _guard_the_workspace_build(root, _workspace_guard(), body)
+    assert "RSK006" in _rule_ids(check_repo(root, POLICY))
+
+
+def test_a_missing_workflow_is_reported_by_every_workflow_rule(
+    tmp_path: Path,
+) -> None:
+    """RSK020 used to swallow the error its two siblings reported."""
+    root = _minimal_repo(tmp_path)
+    (root / ".github" / "workflows" / "quality.yml").unlink()
+    findings = {f.rule_id: f for f in check_repo(root, POLICY)}
+    assert {"RSK006", "RSK020", "RSK021"} <= set(findings)
+    for rule_id in ("RSK006", "RSK020", "RSK021"):
+        assert ".github/workflows/quality.yml is missing." in findings[rule_id].message
+
+
+def test_an_unusable_quality_job_is_reported_by_every_workflow_rule(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / ".github" / "workflows" / "quality.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("  quality:\n", "  other:\n"),
+        encoding="utf-8",
+    )
+    assert "RSK020" in _rule_ids(check_repo(root, POLICY))
 
 
 def test_malformed_workflow_reports_yaml_line(tmp_path: Path) -> None:
@@ -1096,6 +1216,33 @@ def test_fully_compliant_branch_protection_passes(
     assert "RSK022" not in rule_ids
 
 
+def test_both_protection_rules_share_one_platform_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two rules read the same branch; two answers could disagree."""
+    root = _minimal_repo(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[:3] == ["git", "remote", "get-url"]:
+            return subprocess.CompletedProcess(
+                command, 0, "https://github.com/org/repo.git\n", ""
+            )
+        return subprocess.CompletedProcess(
+            command, 0, json.dumps(_compliant_branch_protection()), ""
+        )
+
+    monkeypatch.setattr(checks.subprocess, "run", fake_run)
+    rule_ids = _rule_ids(check_repo(root, POLICY, include_platform=True))
+    assert not {"RSK014", "RSK022"} & rule_ids
+    assert [command for command in calls if command[:2] == ["gh", "api"]] == [
+        ["gh", "api", "repos/org/repo/branches/main/protection"]
+    ]
+
+
 def test_zero_approvals_passes_required_policy_but_reports_recommendation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1533,6 +1680,30 @@ def test_reordered_sections_are_reported_even_when_all_are_present(
     assert finding.actual.index("Repository Layout") < finding.actual.index(
         "Documentation Rules"
     )
+
+
+def test_a_repeated_declared_section_is_reported_wherever_it_sits(
+    tmp_path: Path,
+) -> None:
+    """A subsequence keeps the first occurrence, so the repeat needs its own say."""
+    root = _minimal_repo(tmp_path)
+    path = root / "README.md"
+    text = path.read_text(encoding="utf-8")
+    path.write_text(f"{text}\n## Install\n\nDetail.\n", encoding="utf-8")
+
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK023"]
+    assert finding.message == "Declared sections appear more than once: Install."
+    assert finding.actual.count("Install") == 2
+
+
+def test_an_unlisted_section_may_repeat(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / "README.md"
+    text = path.read_text(encoding="utf-8").replace(
+        "## Usage", "## Notes\n\nDetail.\n\n## Usage"
+    )
+    path.write_text(f"{text}\n## Notes\n\nDetail.\n", encoding="utf-8")
+    assert "RSK023" not in _rule_ids(check_repo(root, POLICY))
 
 
 def test_unlisted_sections_are_legal_anywhere(tmp_path: Path) -> None:


### PR DESCRIPTION
Phase 4 of the v2.0.0 correction plan: four rules that passed when they should
have failed.

## Finding 13 — a required command inside a false guard satisfied RSK006

Decision D1 applies: policy owns the permitted guard form. `RSK006`'s config
gains `guards_by_profile` — `python-workspace` declares the workspace starter's
`compgen` guard, `python-single` declares none, and the schema requires an
entry for every profile the rule applies to, so silence about a guard is a
declaration rather than an omission.

The shell reader now carries each command's guards with it. A required command
counts when it is unguarded or when its only condition is the declared guard;
any other condition, an `else` or `elif` branch, a loop body, and a `case` arm
leave it unproven and produce a finding distinct from the missing-command one.
The starter's workflow YAML is unchanged and still passes.

Guards are not tracked through `&&` / `||`. The defect being fixed is a *silent*
skip: an `if` that does not fire exits zero and the job goes green, whereas a
failed left-hand side of `&&` fails the step. Treating `&&` as a guard would
also newly reject `uv sync --locked && uv run pytest`, which is not the same
class of problem.

## Finding 14 — a missing workflow was silent for RSK020

`_github_workflow_permissions` discarded the errors `_workflow_job` returns;
its two siblings return them. It now returns them too, so a missing or unusable
`quality.yml` is reported by RSK006, RSK020 and RSK021 alike.

## Finding 20 — the platform was queried twice for one answer

`gh api` responses are cached on `CheckContext` for the life of one
`check_repo` call, keyed by endpoint and pagination flag. RSK014 and RSK022 now
share one branch-protection round-trip and cannot disagree because one of them
flaked. Keying by endpoint rather than by `(owner_repo, branch)` also dedupes
the ruleset fallback queries, which are made for the same branch. The cache is
per-context, so a new run always re-queries the platform.

## Finding 22 — a repeated heading out of position was invisible

`_shape_issues` deduped before comparing order, so a declared heading repeated
later and out of canonical order compared equal to the expected subsequence.
The repeat is now reported in its own right — the option chosen over comparing
without deduping, because it names the actual defect instead of reporting a
reordering that did not happen — and the docstring states why. `allow_unlisted`
is untouched: an unlisted heading may still repeat anywhere.

## Normative prose corrected in the same change

- `docs/quality-gates.md` §5 — RSK006's guard semantics.
- `docs/compliance.md` — the RSK006 structural boundary.
- `docs/repo-standard.md` — a shape's declared section appears at most once.
- `docs/policy-reference.md` now publishes the permitted guard per profile, on
  the same reasoning as the dials table: prose must not carry a copy of an
  executable value that can drift.

## Tests

Each finding has a test that fails on the pre-fix code, verified by reverting
the fixes and re-running: the guard tests report nothing, RSK020 is absent from
the missing-workflow findings, two `gh api` calls are recorded, and the repeated
section produces no finding. Controls cover the legal cases — the declared guard
passing, and an unlisted section repeating.

`uv run pre-commit run --all-files`, `uv run pytest` (420 passed) and
`uv run repo-check . --strict` pass; regeneration leaves the tree clean.

Addresses #59.
