### PR TITLE
feat!: govern the compliance workflow and drop the diagrams placeholder (P5)

### DIFF
--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -315,8 +315,8 @@ Each later `repo-add-package --package-name widget_api` run adds:
 - The repository passes the full `docs/quality-gates.md` chain, which needs the
   `uv.lock` the default path produces
 - `[tool.repo-standard]` declares the generated profile and standard major
-- The quality workflow grants only `contents: read` and pins remote actions to
-  full commit SHAs; Dependabot is configured to propose GitHub Actions updates
+- Both workflows grant only `contents: read` and pin remote actions to full
+  commit SHAs; Dependabot is configured to propose GitHub Actions updates
 - Separate `quality` and `compliance` status checks run on pull requests and
   are suitable for branch-protection enforcement
 

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -267,7 +267,6 @@ widget-service/
   pyproject.toml
   uv.lock
   docs/adr/0001-template.md
-  docs/diagrams/README.md
   src/widget_service/__init__.py
   tests/test_smoke.py
 ```
@@ -294,7 +293,6 @@ widget-platform/
   pyproject.toml
   uv.lock
   docs/adr/0001-template.md
-  docs/diagrams/README.md
   packages/.gitkeep
   tests/test_workspace_shell.py
 ```

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -195,6 +195,11 @@ remediation. Markdown explains policy but supplies no executable values.
   policy-owned `contents: read` mapping; extra read scopes and all write scopes
   fail. RSK021 requires full SHA pins for remote actions and reusable workflows
   in every job in the quality workflow; local and Docker actions are exempt.
+- RSK027 requires `.github/workflows/compliance.yml` to exist. RSK028 and
+  RSK029 apply the permission and pin obligations above to that workflow and
+  its `compliance` job. No rule reads its `run` steps: the checker has no one
+  invocation to require, so an existing, least-privileged, fully pinned
+  compliance workflow can still execute nothing.
 - RSK014 requires pull request protection, stale approval dismissal, required
   status checks, strict up-to-date branches, conversation resolution, and
   administrator enforcement when platform checks are requested, but permits a

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,8 +1,0 @@
-# Diagrams
-
-Store workflow and architecture diagrams here when the repository needs durable
-visual documentation.
-
-For this repository that means the bootstrap flow and the relationship between
-the normative documents, the templates, and the starter kits — add them here
-when a diagram would explain the standard faster than prose does.

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -100,6 +100,7 @@ documents are produced by walking it in the order below.
 | Section | Name | Level |
 | --- | --- | --- |
 | `project` | `project` | `required` |
+| `project-scripts` | `project.scripts` | `optional` |
 | `dependency-groups` | `dependency-groups` | `optional` |
 | `build-system` | `build-system` | `optional` |
 | `tool-uv-build-backend` | `tool.uv.build-backend` | `optional` |
@@ -107,6 +108,7 @@ documents are produced by walking it in the order below.
 | `tool-ruff` | `tool.ruff` | `optional` |
 | `tool-ruff-lint` | `tool.ruff.lint` | `optional` |
 | `tool-pytest-ini-options` | `tool.pytest.ini_options` | `optional` |
+| `tool-repo-check-ignore` | `tool.repo-check.ignore` | `optional` |
 | `tool-ty-src` | `tool.ty.src` | `optional` |
 
 ## Rules
@@ -420,6 +422,42 @@ Remediation: State each dial in the Agent Operating Mode section of AGENTS.md, i
 | --- | --- |
 | Verbosity | 2 / 5 |
 | Precision, repeatability, determinism | 4 / 5 |
+
+### RSK027: Compliance workflow exists
+
+- Level: `required`
+- Profiles: `python-single`, `python-workspace`
+- Source: [`docs/quality-gates.md` — 5. CI Pull Request Gates](../docs/quality-gates.md)
+- Enforcement: `structural`
+- Check kind: `path_exists`
+
+Rationale: The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims: no rule requires the job to run a particular command, because the checker is invoked one way against a pinned release and another against the working tree, and both forms sit inside conditional branches that RSK006's guard semantics leave unproven. A compliance workflow that exists, grants only contents: read, and pins every action can still execute nothing.
+
+Remediation: Add .github/workflows/compliance.yml with a compliance job that checks the repository against repo-standard-kit on pull requests.
+
+### RSK028: Compliance workflow uses least-privilege permissions
+
+- Level: `required`
+- Profiles: `python-single`, `python-workspace`
+- Source: [`docs/quality-gates.md` — 5. CI Pull Request Gates](../docs/quality-gates.md)
+- Enforcement: `structural`
+- Check kind: `github_workflow_permissions`
+
+Rationale: The compliance job reads the repository and reports on it. A write scope on the token that runs a checker fetched from outside the repository would let that fetched code change what it is auditing.
+
+Remediation: Set the compliance job's effective permissions to exactly `contents: read`.
+
+### RSK029: Compliance workflow pins remote actions immutably
+
+- Level: `required`
+- Profiles: `python-single`, `python-workspace`
+- Source: [`docs/quality-gates.md` — 5. CI Pull Request Gates](../docs/quality-gates.md)
+- Enforcement: `structural`
+- Check kind: `github_workflow_pins`
+
+Rationale: The compliance workflow already executes code fetched from outside the repository, so a mutable action reference beside it is the widest unpinned surface the standard ships.
+
+Remediation: Pin every remote action and reusable workflow in the compliance workflow to a 40-character SHA.
 
 ## Retired Rule IDs
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -148,6 +148,23 @@ workflow is pinned to a full 40-character commit SHA. Local `./` actions and
 `docker://` references are exempt. Keep a version comment next to each SHA so
 Dependabot updates remain understandable.
 
+RSK027 enforces at the **required** level that
+`.github/workflows/compliance.yml` exists. RSK028 and RSK029 place the same two
+obligations on it that RSK020 and RSK021 place on the quality workflow, at the
+same **required** level: the `compliance` job's effective permissions are
+exactly `contents: read`, and every remote action and reusable workflow the
+compliance workflow references is pinned to a full 40-character commit SHA.
+This workflow fetches and executes the checker from outside the repository, so
+it is the reference set least safe to leave mutable.
+
+No rule requires the compliance job to run any particular command. The checker
+is invoked one way against a pinned release and another against the working
+tree, and both forms sit inside conditional branches that the guard semantics
+above leave unproven, so a compliance workflow that exists, is
+least-privileged, and is fully pinned can still execute nothing. Section 10
+enforcement keeps the status check mandatory; whether the job is worth running
+stays a maintainer's judgement.
+
 ### Environment reproducibility
 
 ```bash

--- a/docs/release-plan-v2.0.0.md
+++ b/docs/release-plan-v2.0.0.md
@@ -12,8 +12,9 @@ must not survive the tag.
 
 An audit of `chore/release-v2.0.0` found 22 issues the gates do not catch. Two
 further findings (23, 24) surfaced during the work, bringing the total to 24.
-`uv run pytest` passes and `repo-check . --strict` is clean; that is part of
-the finding rather than a reassurance.
+Finding 16 was withdrawn under scrutiny, leaving 23 standing. `uv run pytest`
+passes and `repo-check . --strict` is clean; that is part of the finding
+rather than a reassurance.
 
 ## Decisions
 
@@ -37,11 +38,11 @@ is P3 → P5 → P7; P2, P4 and P8 run alongside it.
 | P1 | Factual corrections | 4, 5, 6, 8, 10, 15, 18 | — | Merged (#49) |
 | P2 | Root documents under the generator | 7 | P1 | Merged (#58) |
 | P3 | Policy schema: `advisory`, drop `severity` | 19, dead weight | — | Merged (#57) |
-| P4 | Checker correctness | 13, 14, 20, 22 | — | In progress (#59) |
-| P5 | Coverage: compliance workflow and shapes | 11, 12, 16, 17 | P3 | Not started |
+| P4 | Checker correctness | 13, 14, 20, 22 | — | Merged (#61) |
+| P5 | Coverage: compliance workflow, shapes, dead weight | 11, 12, 17 | P3 | In progress (#62) |
 | P6 | Bootstrap contract and dead weight | 9, 21 | — | Merged (#53) |
 | P7 | Release finalization | 1, 2, 3 | all | Not started |
-| P8 | Starter `.gitignore`, `repo-adopt` flag docs | 23, 24 | — | In progress (#56) |
+| P8 | Starter `.gitignore`, `repo-adopt` flag docs | 23, 24 | — | Merged (#60) |
 
 P1 precedes P2 so the corrected prose is what gets migrated into fragments,
 rather than migrating the defects and fixing them twice. P8 shares no files
@@ -85,10 +86,14 @@ Numbers are stable identifiers referenced by the phase table and the sub-issues.
 ### Enforceability gaps
 
 - **11.** Nothing structurally checks `.github/workflows/compliance.yml`,
-  though `docs/quality-gates.md:118-122` makes it a SHALL.
+  though `docs/quality-gates.md:118-122` makes it a SHALL. Closed by P5 with
+  RSK027.
 - **12.** RSK020 and RSK021 cover `quality.yml` only — the compliance
   workflow's permissions and pins are unchecked, and it is the workflow that
-  fetches remote code.
+  fetches remote code. Closed by P5 with RSK028 and RSK029. No rule requires
+  the job to *run* the checker: there is no single command to require, and
+  both shipped invocations sit inside conditional branches that P4 made
+  permanently unprovable. The gap is recorded in RSK027's rationale.
 - **13.** RSK006 accepts a command inside a false guard. Verified:
   `if false; then uv build --all-packages; fi` satisfies the rule. The
   workspace starter depends on this, so its build gate never runs.
@@ -96,11 +101,20 @@ Numbers are stable identifiers referenced by the phase table and the sub-issues.
   workflow while RSK021 returns the error.
 - **15.** `docs/repo-layout.md:20-21` — claims required-rule coverage that
   `tests/`, `src/<package_name>/`, `docs/diagrams/` and `scripts/` do not have.
-- **16.** RSK011 knows only `__DUNDER__` tokens; `templates/README.md` ships 27
-  angle-bracket placeholders with no check.
+- **16.** **Withdrawn.** The claim was that RSK011 knows only `__DUNDER__`
+  tokens while the templates ship angle-bracket placeholders with no check.
+  Both halves are wrong. `repo_init.py:19` derives `PLACEHOLDERS` *from*
+  RSK011's config, so policy is already the single source and the two cannot
+  drift. The angle-bracket tokens are documentation notation, not unrendered
+  placeholders: a generated `python-workspace` repository contains exactly one,
+  `packages/<package-slug>/` in `AGENTS.md`, prose describing the naming
+  convention, and zero `__DUNDER__` leftovers. A generic angle-bracket rule
+  would also be actively harmful, since an adopter's prose and markup
+  legitimately contain `<...>`.
 - **17.** `policy/shapes.yaml:105-137` — the pyproject shape omits
   `[project.scripts]` and `[tool.repo-check.ignore]`, both used by this
-  repository.
+  repository. Closed by P5: both are declared `optional` at their canonical
+  positions.
 - **18.** `.pymarkdown.json` relaxes `md024`; `docs/quality-gates.md` §4
   documents only md013, md033 and md036.
 
@@ -122,10 +136,13 @@ Numbers are stable identifiers referenced by the phase table and the sub-issues.
 - The JSON `severity` field, carrying an expired "through v1" promise. Removed
   by P3 (#57).
 - `profiles/**` in `source-include`. Removed by P1 (#49).
-- `docs/diagrams/README.md` — a placeholder shipped into every generated
-  repository that no rule references. **Still present and owned by no phase.**
-  Deleting it is a starter-kit change; leaving it needs a rule that gives it a
-  reason to exist. P7 must not tag with this unresolved.
+- `docs/diagrams/README.md`, a placeholder no rule references. Removed by P5
+  from this repository and both starter kits. Git cannot track an empty
+  directory, so the kit stops scaffolding `docs/diagrams/` at all;
+  `docs/repo-layout.md` keeps it as a convention to follow when the first
+  diagram is written.
+
+Every entry above is resolved; nothing on this list is outstanding.
 
 ### Findings added during the work
 

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -13,20 +13,21 @@ Use this layout by default for Python repositories:
 - `src/<package_name>/`
 - `tests/`
 - `docs/adr/`
-- `docs/diagrams/`
 - `scripts/`
 - `examples/` when useful
+- `docs/diagrams/` when the repository keeps diagrams
 
 Of the entries above, `AGENTS.md` and `README.md` are governed by required
 existence rules (RSK001, RSK004). No rule checks that `pyproject.toml` or
 `.pre-commit-config.yaml` exist, but required rules read their contents —
 RSK007, RSK010, and RSK019 — and report the file missing when it is absent.
 `tests/`, `src/<package_name>/`, `docs/diagrams/`, `scripts/`, and
-`examples/` are convention only: no rule checks for them. The following
-layout aids are
-intentionally **recommended**: RSK012 checks `docs/adr/`, RSK017 checks
-`CHANGELOG.md`, and RSK018 checks `LICENSE`. Their absence is reported but is
-non-blocking unless strict checking is requested.
+`examples/` are convention only: no rule checks for them. The starter kits do
+not scaffold `docs/diagrams/` either, so it is a name to use when the first
+diagram arrives rather than an empty directory every repository carries. The
+following layout aids are intentionally **recommended**: RSK012 checks
+`docs/adr/`, RSK017 checks `CHANGELOG.md`, and RSK018 checks `LICENSE`. Their
+absence is reported but is non-blocking unless strict checking is requested.
 
 ## Directory Responsibilities
 
@@ -34,7 +35,8 @@ non-blocking unless strict checking is requested.
 - `tests/`: test code only
 - `docs/`: durable project knowledge
 - `docs/adr/`: architecture decisions
-- `docs/diagrams/`: workflow or architecture diagrams
+- `docs/diagrams/`: workflow or architecture diagrams, created when the first
+  one is written
 - `scripts/`: developer or operational helpers, not core business logic
 - `examples/`: user-facing or integration examples when they add value
 

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -526,3 +526,71 @@ rules:
     remediation: >-
       State each dial in the Agent Operating Mode section of AGENTS.md, in the
       declared order and at the declared level.
+
+  - id: RSK027
+    title: Compliance workflow exists
+    level: required
+    profiles: [python-single, python-workspace]
+    source:
+      document: docs/quality-gates.md
+      section: 5. CI Pull Request Gates
+    enforcement: structural
+    check:
+      kind: path_exists
+      config:
+        path: .github/workflows/compliance.yml
+        path_type: file
+    rationale: >-
+      The compliance job is what stops the rest of the standard from drifting,
+      so its absence has to be a finding of its own. Existence is all this rule
+      claims: no rule requires the job to run a particular command, because the
+      checker is invoked one way against a pinned release and another against
+      the working tree, and both forms sit inside conditional branches that
+      RSK006's guard semantics leave unproven. A compliance workflow that
+      exists, grants only contents: read, and pins every action can still
+      execute nothing.
+    remediation: >-
+      Add .github/workflows/compliance.yml with a compliance job that checks the
+      repository against repo-standard-kit on pull requests.
+
+  - id: RSK028
+    title: Compliance workflow uses least-privilege permissions
+    level: required
+    profiles: [python-single, python-workspace]
+    source:
+      document: docs/quality-gates.md
+      section: 5. CI Pull Request Gates
+    enforcement: structural
+    check:
+      kind: github_workflow_permissions
+      config:
+        path: .github/workflows/compliance.yml
+        job: compliance
+        permissions:
+          contents: read
+    rationale: >-
+      The compliance job reads the repository and reports on it. A write scope
+      on the token that runs a checker fetched from outside the repository
+      would let that fetched code change what it is auditing.
+    remediation: >-
+      Set the compliance job's effective permissions to exactly `contents: read`.
+
+  - id: RSK029
+    title: Compliance workflow pins remote actions immutably
+    level: required
+    profiles: [python-single, python-workspace]
+    source:
+      document: docs/quality-gates.md
+      section: 5. CI Pull Request Gates
+    enforcement: structural
+    check:
+      kind: github_workflow_pins
+      config:
+        path: .github/workflows/compliance.yml
+    rationale: >-
+      The compliance workflow already executes code fetched from outside the
+      repository, so a mutable action reference beside it is the widest
+      unpinned surface the standard ships.
+    remediation: >-
+      Pin every remote action and reusable workflow in the compliance workflow
+      to a 40-character SHA.

--- a/policy/shapes.yaml
+++ b/policy/shapes.yaml
@@ -111,6 +111,9 @@ shapes:
       - id: project
         heading: project
         level: required
+      - id: project-scripts
+        heading: project.scripts
+        level: optional
       - id: dependency-groups
         heading: dependency-groups
         level: optional
@@ -131,6 +134,9 @@ shapes:
         level: optional
       - id: tool-pytest-ini-options
         heading: tool.pytest.ini_options
+        level: optional
+      - id: tool-repo-check-ignore
+        heading: tool.repo-check.ignore
         level: optional
       - id: tool-ty-src
         heading: tool.ty.src

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -1546,7 +1546,8 @@ def _github_workflow_permissions(
     return [
         Issue(
             config["path"],
-            "Quality job permissions do not match the least-privilege policy.",
+            f"The {config['job']} job's permissions do not match the "
+            "least-privilege policy.",
             permissions,
             expected,
             line,

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -774,6 +774,77 @@
         "section": "Agent Operating Mode"
       },
       "title": "AGENTS.md states the calibrated agent operating dials"
+    },
+    {
+      "check": {
+        "config": {
+          "path": ".github/workflows/compliance.yml",
+          "path_type": "file"
+        },
+        "kind": "path_exists"
+      },
+      "enforcement": "structural",
+      "id": "RSK027",
+      "level": "required",
+      "profiles": [
+        "python-single",
+        "python-workspace"
+      ],
+      "rationale": "The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims: no rule requires the job to run a particular command, because the checker is invoked one way against a pinned release and another against the working tree, and both forms sit inside conditional branches that RSK006's guard semantics leave unproven. A compliance workflow that exists, grants only contents: read, and pins every action can still execute nothing.",
+      "remediation": "Add .github/workflows/compliance.yml with a compliance job that checks the repository against repo-standard-kit on pull requests.",
+      "source": {
+        "document": "docs/quality-gates.md",
+        "section": "5. CI Pull Request Gates"
+      },
+      "title": "Compliance workflow exists"
+    },
+    {
+      "check": {
+        "config": {
+          "job": "compliance",
+          "path": ".github/workflows/compliance.yml",
+          "permissions": {
+            "contents": "read"
+          }
+        },
+        "kind": "github_workflow_permissions"
+      },
+      "enforcement": "structural",
+      "id": "RSK028",
+      "level": "required",
+      "profiles": [
+        "python-single",
+        "python-workspace"
+      ],
+      "rationale": "The compliance job reads the repository and reports on it. A write scope on the token that runs a checker fetched from outside the repository would let that fetched code change what it is auditing.",
+      "remediation": "Set the compliance job's effective permissions to exactly `contents: read`.",
+      "source": {
+        "document": "docs/quality-gates.md",
+        "section": "5. CI Pull Request Gates"
+      },
+      "title": "Compliance workflow uses least-privilege permissions"
+    },
+    {
+      "check": {
+        "config": {
+          "path": ".github/workflows/compliance.yml"
+        },
+        "kind": "github_workflow_pins"
+      },
+      "enforcement": "structural",
+      "id": "RSK029",
+      "level": "required",
+      "profiles": [
+        "python-single",
+        "python-workspace"
+      ],
+      "rationale": "The compliance workflow already executes code fetched from outside the repository, so a mutable action reference beside it is the widest unpinned surface the standard ships.",
+      "remediation": "Pin every remote action and reusable workflow in the compliance workflow to a 40-character SHA.",
+      "source": {
+        "document": "docs/quality-gates.md",
+        "section": "5. CI Pull Request Gates"
+      },
+      "title": "Compliance workflow pins remote actions immutably"
     }
   ],
   "schema_version": 1,
@@ -952,6 +1023,11 @@
           "level": "required"
         },
         {
+          "heading": "project.scripts",
+          "id": "project-scripts",
+          "level": "optional"
+        },
+        {
           "heading": "dependency-groups",
           "id": "dependency-groups",
           "level": "optional"
@@ -984,6 +1060,11 @@
         {
           "heading": "tool.pytest.ini_options",
           "id": "tool-pytest-ini-options",
+          "level": "optional"
+        },
+        {
+          "heading": "tool.repo-check.ignore",
+          "id": "tool-repo-check-ignore",
           "level": "optional"
         },
         {

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -98,7 +98,6 @@ _MANAGED_SURFACES = (
     "CHANGELOG.md",
     ".gitignore",
     "docs/adr",
-    "docs/diagrams",
 )
 _REMOTE_ACTION = re.compile(r"^[^./\s]+/[^@\s]+@(?P<ref>[^\s]+)$")
 _COMMAND_LIST_BLOCK = re.compile(
@@ -547,22 +546,24 @@ def _merge_workflow(
         elif job_name == "compliance" and update_run:
             match["run"] = expected_run
 
+    # Both governed workflows are under a pin rule, and only actions the kit
+    # ships can be repinned from the starter. An action the repository added
+    # needs a SHA nobody but its maintainer can choose, so it is reported.
     conflicts: list[str] = []
-    if job_name == "quality":
-        for step in steps:
-            uses = step.get("uses") if isinstance(step, dict) else None
-            if (
-                not isinstance(uses, str)
-                or uses.startswith("./")
-                or uses.startswith("docker://")
-            ):
-                continue
-            match = _REMOTE_ACTION.match(uses)
-            if match is not None and not is_full_commit_sha(match.group("ref")):
-                conflicts.append(
-                    f"{path.relative_to(path.parents[2]).as_posix()}: remote action "
-                    f"{uses!r} needs a maintainer-selected full commit SHA"
-                )
+    for step in steps:
+        uses = step.get("uses") if isinstance(step, dict) else None
+        if (
+            not isinstance(uses, str)
+            or uses.startswith("./")
+            or uses.startswith("docker://")
+        ):
+            continue
+        match = _REMOTE_ACTION.match(uses)
+        if match is not None and not is_full_commit_sha(match.group("ref")):
+            conflicts.append(
+                f"{path.relative_to(path.parents[2]).as_posix()}: remote action "
+                f"{uses!r} needs a maintainer-selected full commit SHA"
+            )
     return _dump_yaml(current), conflicts
 
 
@@ -842,17 +843,14 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
     else:
         generated[".gitignore"] = _read_starter(selected, ".gitignore")
 
-    for directory, starter_file in (
-        ("docs/adr", "docs/adr/0001-template.md"),
-        ("docs/diagrams", "docs/diagrams/README.md"),
-    ):
-        path = root / directory
-        if path.is_dir() and any(path.iterdir()):
-            unchanged.append(directory)
-        else:
-            generated[starter_file] = _render(
-                _read_starter(selected, starter_file), values
-            )
+    # A repository that already keeps decision records keeps its own; the
+    # template is only seeded where there is nothing to overwrite.
+    adr = root / "docs/adr"
+    if adr.is_dir() and any(adr.iterdir()):
+        unchanged.append("docs/adr")
+    else:
+        template = "docs/adr/0001-template.md"
+        generated[template] = _render(_read_starter(selected, template), values)
 
     for relative, content in generated.items():
         change = _planned(root / relative, content, root)

--- a/src/repo_standard/starter_kits/python-single/docs/diagrams/README.md
+++ b/src/repo_standard/starter_kits/python-single/docs/diagrams/README.md
@@ -1,4 +1,0 @@
-# Diagrams
-
-Store workflow and architecture diagrams here when the repository needs durable
-visual documentation.

--- a/src/repo_standard/starter_kits/python-workspace/docs/diagrams/README.md
+++ b/src/repo_standard/starter_kits/python-workspace/docs/diagrams/README.md
@@ -1,4 +1,0 @@
-# Diagrams
-
-Store workflow and architecture diagrams here when the workspace needs durable
-visual documentation.

--- a/templates/README.md
+++ b/templates/README.md
@@ -85,7 +85,6 @@ Pick the block that matches this repo's profile and delete the other.
 ├── src/<package_name>/   # production code
 ├── tests/                # unit and integration tests
 ├── docs/adr/             # architecture decisions
-├── docs/diagrams/        # workflow / architecture diagrams
 ├── scripts/              # dev or operational helpers (not core logic)
 ├── AGENTS.md             # repo operating contract: workflow, gates, standards
 ├── README.md
@@ -100,7 +99,6 @@ Pick the block that matches this repo's profile and delete the other.
 │   ├── src/<package_name>/
 │   └── tests/
 ├── docs/adr/
-├── docs/diagrams/
 ├── AGENTS.md
 ├── README.md
 └── pyproject.toml        # tooling-only root config

--- a/templates/content/README/repo-structure.template.md
+++ b/templates/content/README/repo-structure.template.md
@@ -7,7 +7,6 @@ Pick the block that matches this repo's profile and delete the other.
 ├── src/<package_name>/   # production code
 ├── tests/                # unit and integration tests
 ├── docs/adr/             # architecture decisions
-├── docs/diagrams/        # workflow / architecture diagrams
 ├── scripts/              # dev or operational helpers (not core logic)
 ├── AGENTS.md             # repo operating contract: workflow, gates, standards
 ├── README.md
@@ -22,7 +21,6 @@ Pick the block that matches this repo's profile and delete the other.
 │   ├── src/<package_name>/
 │   └── tests/
 ├── docs/adr/
-├── docs/diagrams/
 ├── AGENTS.md
 ├── README.md
 └── pyproject.toml        # tooling-only root config

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -64,6 +64,25 @@ def _workflow_text(profile: str = "python-single") -> str:
     )
 
 
+def _compliance_workflow_text() -> str:
+    config = POLICY.rule("RSK028").check.config
+    permissions = "\n".join(
+        f"  {scope}: {value}" for scope, value in config["permissions"].items()
+    )
+    return (
+        "name: Compliance\n"
+        "on:\n"
+        "  pull_request:\n"
+        "permissions:\n"
+        f"{permissions}\n"
+        "jobs:\n"
+        f"  {config['job']}:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: repo-check .\n"
+    )
+
+
 def _shape(rule_id: str) -> Shape:
     return POLICY.shape(POLICY.rule(rule_id).check.config["shape"])
 
@@ -106,6 +125,9 @@ def _minimal_repo(tmp_path: Path, profile: str = "python-single") -> Path:
     workflow = root / ".github" / "workflows"
     workflow.mkdir(parents=True)
     (workflow / "quality.yml").write_text(_workflow_text(profile), encoding="utf-8")
+    (root / POLICY.rule("RSK027").check.config["path"]).write_text(
+        _compliance_workflow_text(), encoding="utf-8"
+    )
     hooks = [dict(hook) for hook in POLICY.rule("RSK007").check.config["hooks"]]
     for hook in hooks:
         hook["language"] = "system"
@@ -863,7 +885,7 @@ def test_nonminimal_effective_permissions_report_rsk020(
     path.write_text(mutation(path.read_text(encoding="utf-8")), encoding="utf-8")
     finding = next(f for f in check_repo(root, POLICY) if f.rule_id == "RSK020")
     assert finding.message == (
-        "Quality job permissions do not match the least-privilege policy."
+        "The quality job's permissions do not match the least-privilege policy."
     )
     assert finding.actual == actual
     assert finding.expected == {"contents": "read"}
@@ -918,6 +940,76 @@ def test_rsk021_scans_every_job_in_the_quality_workflow(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert "RSK021" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_compliance_workflow_rules_are_scoped_to_the_compliance_workflow() -> None:
+    path = ".github/workflows/compliance.yml"
+    assert POLICY.rule("RSK027").check.config == {"path": path, "path_type": "file"}
+    assert POLICY.rule("RSK028").check.config == {
+        "path": path,
+        "job": "compliance",
+        "permissions": {"contents": "read"},
+    }
+    assert POLICY.rule("RSK029").check.config == {"path": path}
+    assert all(
+        POLICY.rule(rule_id).level == "required"
+        for rule_id in ("RSK027", "RSK028", "RSK029")
+    )
+
+
+def test_a_missing_compliance_workflow_is_reported_by_every_rule_that_reads_it(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    (root / ".github" / "workflows" / "compliance.yml").unlink()
+    assert {"RSK027", "RSK028", "RSK029"} <= _rule_ids(check_repo(root, POLICY))
+
+
+def test_nonminimal_compliance_permissions_report_rsk028(tmp_path: Path) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / ".github" / "workflows" / "compliance.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "  contents: read", "  contents: write"
+        ),
+        encoding="utf-8",
+    )
+    finding = next(f for f in check_repo(root, POLICY) if f.rule_id == "RSK028")
+    assert finding.message == (
+        "The compliance job's permissions do not match the least-privilege policy."
+    )
+    assert finding.actual == {"contents": "write"}
+
+
+def test_mutable_remote_action_in_the_compliance_workflow_reports_rsk029(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / ".github" / "workflows" / "compliance.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "    steps:\n", "    steps:\n      - uses: actions/checkout@v5\n"
+        ),
+        encoding="utf-8",
+    )
+    finding = next(f for f in check_repo(root, POLICY) if f.rule_id == "RSK029")
+    assert finding.actual == "actions/checkout@v5"
+
+
+@pytest.mark.parametrize("profile", STARTER_KIT_PROFILES)
+def test_shipped_compliance_workflows_satisfy_their_rules(profile: str) -> None:
+    """A required rule no shipped workflow can satisfy would be a release bug."""
+    kit = REPO_ROOT / "src" / "repo_standard" / "starter_kits" / profile
+    for root in (REPO_ROOT, kit):
+        issues = [
+            issue
+            for rule_id in ("RSK027", "RSK028", "RSK029")
+            for issue in CHECK_HANDLERS[POLICY.rule(rule_id).check.kind](
+                checks.CheckContext(root=root, policy=POLICY, profile=profile),
+                POLICY.rule(rule_id).check.config,
+            )
+        ]
+        assert issues == []
 
 
 # --- pre-commit structure -------------------------------------------------

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -189,21 +189,14 @@ def test_existing_documentation_directories_are_not_seeded(tmp_path: Path) -> No
     root = tmp_path / "existing"
     _write_minimal_repo(root, "python-single")
     adr = root / "docs" / "adr"
-    diagrams = root / "docs" / "diagrams"
     adr.mkdir(parents=True)
-    diagrams.mkdir(parents=True)
     (adr / "0001-existing-decision.md").write_text("# Existing ADR\n", encoding="utf-8")
-    (diagrams / "architecture.puml").write_text(
-        "@startuml\n@enduml\n", encoding="utf-8"
-    )
 
     plan = plan_adoption(root, "python-single")
 
     changed = {change.path.as_posix() for change in plan.changes}
     assert "docs/adr/0001-template.md" not in changed
-    assert "docs/diagrams/README.md" not in changed
     assert "docs/adr" in plan.unchanged
-    assert "docs/diagrams" in plan.unchanged
 
 
 def test_quality_gates_prose_before_list_stays_in_place(tmp_path: Path) -> None:
@@ -375,6 +368,29 @@ def test_unpinned_custom_quality_action_is_an_explicit_conflict(
         "on: pull_request\n"
         "jobs:\n"
         "  quality:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: vendor/custom-action@v2\n",
+        encoding="utf-8",
+    )
+
+    plan = plan_adoption(root, "python-single")
+
+    assert any("vendor/custom-action@v2" in conflict for conflict in plan.conflicts)
+
+
+def test_unpinned_custom_compliance_action_is_an_explicit_conflict(
+    tmp_path: Path,
+) -> None:
+    """RSK029 puts the compliance workflow under the same pin rule as quality."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    workflow = root / ".github" / "workflows" / "compliance.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "on: pull_request\n"
+        "jobs:\n"
+        "  compliance:\n"
         "    runs-on: ubuntu-latest\n"
         "    steps:\n"
         "      - uses: vendor/custom-action@v2\n",


### PR DESCRIPTION
Phase 5 of the v2.0.0 correction plan: findings 11, 12 and 17, the approved
`docs/diagrams/README.md` deletion, and the tracker corrections.

## Three new required rules over `.github/workflows/compliance.yml`

`docs/quality-gates.md` makes an independent `compliance` job a SHALL, and
nothing checked it. RSK020 and RSK021 hard-coded `quality.yml`, so the workflow
that fetches and executes remote code was the unchecked one.

| Rule | Level | Check kind | What it requires |
| --- | --- | --- | --- |
| RSK027 | required | `path_exists` | `.github/workflows/compliance.yml` exists |
| RSK028 | required | `github_workflow_permissions` | the `compliance` job's effective permissions are exactly `contents: read` |
| RSK029 | required | `github_workflow_pins` | every remote reference in the workflow carries a 40-character SHA |

All three reuse existing check kinds. No handler was added; only rule config.

**No rule requires the job to run `repo-check`.** There is no single command to
require — the starter runs `uvx --from git+... repo-check .`, this repository
runs `uv run --locked --no-dev repo-check .` — and both sit inside conditional
branches, this repository's in an `else` branch that P4 made permanently
unprovable by design. A commands rule would fail this repository against its own
standard. RSK027's rationale records the gap instead of pretending to close it.

**Verified against every shipped workflow, unmodified:**

```text
repo-standard-kit itself         RSK027/RSK028/RSK029  PASS
starter_kits/python-single       RSK027/RSK028/RSK029  PASS
starter_kits/python-workspace    RSK027/RSK028/RSK029  PASS
```

`tests/test_compliance.py::test_shipped_compliance_workflows_satisfy_their_rules`
keeps that true.

## Finding 17 — pyproject shape

`[project.scripts]` and `[tool.repo-check.ignore]` were legal but unordered
under `allow_unlisted`, which is what a shape exists to prevent. Both are now
declared `optional` at their canonical positions, and this repository's own
`pyproject.toml` still satisfies RSK025.

## Approved deletion — `docs/diagrams/README.md`

A `.gitkeep` wearing a title. Removing it removes `docs/diagrams/` from both
starter kits entirely, which is the intended outcome; no `.gitkeep` substitute.
`docs/repo-layout.md` keeps the directory as a convention to follow when the
first diagram is written, rather than one the kit scaffolds empty.

Also touched: `repo_adopt.py` (`_MANAGED_SURFACES` and the seeding block),
`tests/test_repo_adopt.py`, `docs/bootstrap-workflow.md` (both expected-output
trees) and `templates/content/README/repo-structure.template.md` (re-rendered).

## Reviewer attention

- **`repo-adopt` conflict reporting now covers `compliance.yml`.** The pin
  conflict loop was scoped to `job_name == "quality"`. With RSK029 in force, an
  unpinned action a repository added to `compliance.yml` would otherwise leave a
  required rule failing after adoption with no message. Verified before the
  change: adoption produced zero conflicts and left RSK029 failing. No new
  *repair* was added — `repo-adopt` cannot pick a SHA for a maintainer.
- **The RSK020 finding message changed.** It read `Quality job permissions do
  not match the least-privilege policy.` from a handler that is job-generic;
  emitting that text for RSK028's compliance job would have been wrong. It now
  names the job it read.

## Verification

```text
uv run pre-commit run --all-files              clean
uv run pytest                                  430 passed
uv run repo-check . --strict                   All checks passed!
generate_policy && generate_docs && git diff   no drift
```

Freshly generated repositories, `--license mit`, default lock/sync path:

```text
repo-check <python-single>    --strict   All checks passed!  (exit 0)
repo-check <python-workspace> --strict   All checks passed!  (exit 0)
```

Neither carries `docs/diagrams/` nor any diagrams placeholder.

`CHANGELOG.md` is untouched — P7 owns it.

Addresses #62.
