### PR TITLE
feat!: require the compliance job to invoke the checker

### DIFF
--- a/.github/workflows/compliance-reusable.yml
+++ b/.github/workflows/compliance-reusable.yml
@@ -1,0 +1,57 @@
+name: Compliance (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      standard-ref:
+        description: >-
+          Released repo-standard-kit ref whose packaged checker and compiled
+          policy should execute.
+        type: string
+        required: true
+      strict:
+        description: "Treat 'should' findings as failures too."
+        type: boolean
+        default: false
+      check-enforcement:
+        description: >-
+          Also check branch protection (§10). Needs gh and auth in the
+          caller's job.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  compliance:
+    name: compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Run repo-check
+        shell: bash
+        env:
+          REPO_STANDARD_REF: ${{ inputs.standard-ref }}
+          STRICT: ${{ inputs.strict }}
+          CHECK_ENFORCEMENT: ${{ inputs.check-enforcement }}
+        run: |
+          args=(--format text)
+          if [ "$STRICT" = "true" ]; then
+            args+=(--strict)
+          fi
+          if [ "$CHECK_ENFORCEMENT" = "true" ]; then
+            args+=(--check-enforcement)
+          fi
+          if [[ ! "$REPO_STANDARD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid repo-standard-kit ref" >&2
+            exit 2
+          fi
+          uvx \
+            --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@$REPO_STANDARD_REF" \
+            repo-check . "${args[@]}"

--- a/.github/workflows/compliance-reusable.yml
+++ b/.github/workflows/compliance-reusable.yml
@@ -34,24 +34,17 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
+      # Every input is resolved into the environment, never into Bash source,
+      # so no caller-supplied value is ever parsed as shell. The two flag
+      # variables are therefore deliberately unquoted below: each holds either
+      # one option or nothing, and word splitting is what drops the nothing.
       - name: Run repo-check
         shell: bash
         env:
           REPO_STANDARD_REF: ${{ inputs.standard-ref }}
-          STRICT: ${{ inputs.strict }}
-          CHECK_ENFORCEMENT: ${{ inputs.check-enforcement }}
+          STRICT: ${{ inputs.strict && '--strict' || '' }}
+          CHECK_ENFORCEMENT: ${{ inputs.check-enforcement && '--check-enforcement' || '' }}
         run: |
-          args=(--format text)
-          if [ "$STRICT" = "true" ]; then
-            args+=(--strict)
-          fi
-          if [ "$CHECK_ENFORCEMENT" = "true" ]; then
-            args+=(--check-enforcement)
-          fi
-          if [[ ! "$REPO_STANDARD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-            echo "Invalid repo-standard-kit ref" >&2
-            exit 2
-          fi
           uvx \
             --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@$REPO_STANDARD_REF" \
-            repo-check . "${args[@]}"
+            repo-check . $STRICT $CHECK_ENFORCEMENT

--- a/.github/workflows/compliance-reusable.yml
+++ b/.github/workflows/compliance-reusable.yml
@@ -9,16 +9,6 @@ on:
           policy should execute.
         type: string
         required: true
-      strict:
-        description: "Treat 'should' findings as failures too."
-        type: boolean
-        default: false
-      check-enforcement:
-        description: >-
-          Also check branch protection (§10). Needs gh and auth in the
-          caller's job.
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -34,17 +24,13 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      # Every input is resolved into the environment, never into Bash source,
-      # so no caller-supplied value is ever parsed as shell. The two flag
-      # variables are therefore deliberately unquoted below: each holds either
-      # one option or nothing, and word splitting is what drops the nothing.
+      # The ref is resolved into the environment, never into Bash source, so a
+      # caller's value is always one quoted argument and never shell to parse.
       - name: Run repo-check
         shell: bash
         env:
           REPO_STANDARD_REF: ${{ inputs.standard-ref }}
-          STRICT: ${{ inputs.strict && '--strict' || '' }}
-          CHECK_ENFORCEMENT: ${{ inputs.check-enforcement && '--check-enforcement' || '' }}
         run: |
           uvx \
             --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@$REPO_STANDARD_REF" \
-            repo-check . $STRICT $CHECK_ENFORCEMENT
+            repo-check .

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -2,24 +2,6 @@ name: Compliance
 
 on:
   pull_request:
-  workflow_call:
-    inputs:
-      standard-ref:
-        description: >-
-          Released repo-standard-kit ref whose packaged checker and compiled
-          policy should execute.
-        type: string
-        required: true
-      strict:
-        description: "Treat 'should' findings as failures too."
-        type: boolean
-        default: false
-      check-enforcement:
-        description: >-
-          Also check branch protection (§10). Needs gh and auth in the
-          caller's job.
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -36,27 +18,4 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Run repo-check
-        shell: bash
-        env:
-          REPO_STANDARD_REF: ${{ inputs.standard-ref }}
-          STRICT: ${{ inputs.strict }}
-          CHECK_ENFORCEMENT: ${{ inputs.check-enforcement }}
-        run: |
-          args=(--format text)
-          if [ "$STRICT" = "true" ]; then
-            args+=(--strict)
-          fi
-          if [ "$CHECK_ENFORCEMENT" = "true" ]; then
-            args+=(--check-enforcement)
-          fi
-          if [ -n "$REPO_STANDARD_REF" ]; then
-            if [[ ! "$REPO_STANDARD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-              echo "Invalid repo-standard-kit ref" >&2
-              exit 2
-            fi
-            uvx \
-              --from "git+https://github.com/FP-DevTools/repo-standard-kit.git@$REPO_STANDARD_REF" \
-              repo-check . "${args[@]}"
-          else
-            uv run --locked --no-dev repo-check . "${args[@]}"
-          fi
+        run: uv run --locked --no-dev repo-check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,11 @@ the changes listed under **Adopters must**.
   repository is now this repository's own `pull_request` gate and nothing else:
   one file per trigger, so neither workflow branches on the event name or on
   whether a ref input was supplied.
+- **The reusable workflow drops its `strict` and `check-enforcement` inputs**
+  and now runs one fixed command, leaving `standard-ref` as its sole input.
+  Both flags are reasons to own the command, which the prescribed form above
+  exists to make easy; keeping them as inputs was the whole of what remained
+  conditional in the step.
 - **RSK015 moves from `recommended` to `advisory`.** Section 13 of
   `docs/quality-gates.md` declares `line-length = 88` a per-repository decision
   that needs no exemption, so a rule firing at `recommended` was failing
@@ -280,11 +285,14 @@ to see what is left; the list below is what that repairs and what it cannot.
   `…/.github/workflows/compliance.yml@<sha>` to
   `…/.github/workflows/compliance-reusable.yml@<sha>`. The old path is now a
   `pull_request` workflow of this repository's own and is no longer callable;
-  a caller left on it fails to resolve the workflow. Its inputs are unchanged.
-  Consider moving to the prescribed uvx-direct form instead: the reusable form
-  is supported, but a called workflow's job may report its status check under a
-  concatenated name rather than as `compliance`, which **RSK014** requires
-  verbatim. `docs/compliance.md` records what is and is not known about that.
+  a caller left on it fails to resolve the workflow. `standard-ref` is now its
+  sole input: the `strict` and `check-enforcement` booleans are gone, and a
+  `with:` block still passing either fails the call. Move such a caller to the
+  uvx-direct form, where the flag goes in the command it owns. Consider that
+  form regardless: the reusable form is supported, but a called workflow's job
+  may report its status check under a concatenated name rather than as
+  `compliance`, which **RSK014** requires verbatim. `docs/compliance.md`
+  records what is and is not known about that.
 - Re-check every conditional in `.github/workflows/quality.yml`. RSK006 no
   longer accepts a required command that is reachable only under a condition
   policy does not declare, so a gate-chain command behind your own `if`, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,18 @@ the changes listed under **Adopters must**.
   `.github/workflows/compliance.yml` to exist, RSK028 (**required**) requires
   its `compliance` job's effective permissions to be exactly `contents: read`,
   and RSK029 (**required**) requires every remote action and reusable workflow
-  in it to carry a 40-character commit SHA. No rule requires the job to run a
-  particular command: both shipped invocations sit inside conditional branches
-  that RSK006's guard semantics leave unproven, so RSK027's rationale records
-  the gap rather than closing it with a rule this repository could not satisfy.
+  in it to carry a 40-character commit SHA.
+- **RSK030 (required): the compliance job has to invoke the checker.** An
+  existing, least-privileged, fully pinned compliance workflow could still
+  execute nothing. The rule requires one executed command in
+  `jobs.compliance.steps[*].run` to carry `repo-check` in its argument list.
+  Policy owns the token, and the match is containment rather than an exact
+  command, because an adopter runs a released checker with `uvx` while this
+  repository runs its own working tree with `uv run` — both correct. The claim
+  is correspondingly modest and its rationale says so: a contrived command
+  naming the token passes. Reusing RSK006's guard machinery, an invocation
+  reachable only under a condition policy does not declare does not count, and
+  neither profile declares one.
 - **The `advisory` policy level**, below `recommended`: always reported, never
   blocking, not even under `--strict`. It exists for a rule that names a
   preferred value for a decision the normative prose leaves to the repository.
@@ -110,6 +118,18 @@ the changes listed under **Adopters must**.
   the wrong sequence used to pass, and now reports a required finding. Its
   required set also grows from ten sections to twelve, with `Agent Operating
   Mode` and `Single Source Of Truth` added above.
+- **The prescribed compliance workflow is now the uvx-direct form**, the one
+  both starter kits already ship: the adopter's own `compliance` job running
+  `uvx --from "git+…@<ref>" repo-check .`. `docs/compliance.md` prescribed the
+  reusable-workflow form instead, so the required section and the generated
+  repository disagreed. Owning the command means an option the checker accepts
+  is an edit to that line rather than a request for a workflow input.
+- **The reusable workflow moves to
+  `.github/workflows/compliance-reusable.yml`** and remains supported as an
+  alternative, documented with its trade-off. `compliance.yml` in this
+  repository is now this repository's own `pull_request` gate and nothing else:
+  one file per trigger, so neither workflow branches on the event name or on
+  whether a ref input was supplied.
 - **RSK015 moves from `recommended` to `advisory`.** Section 13 of
   `docs/quality-gates.md` declares `line-length = 88` a per-repository decision
   that needs no exemption, so a rule firing at `recommended` was failing
@@ -208,7 +228,7 @@ the changes listed under **Adopters must**.
 
 ### Adopters must
 
-Seven new required rules and four behaviour changes land here. Run
+Eight new required rules and four behaviour changes land here. Run
 `repo-adopt .` to have most of it done for you, then `repo-check . --strict`
 to see what is left; the list below is what that repairs and what it cannot.
 
@@ -246,6 +266,21 @@ to see what is left; the list below is what that repairs and what it cannot.
   on your behalf, so an unpinned action you added there is reported, not
   repaired. `docs/quality-gates.md` §5 already required this job; only the
   structural checks are new.
+- Make sure that job actually runs the checker. **RSK030** requires one
+  executed command in `jobs.compliance.steps[*].run` to contain `repo-check`,
+  so a job that only checks out the repository, or one whose invocation sits
+  behind your own `if`, reports a required finding. The prescribed form is the
+  one in `docs/compliance.md` §Required CI workflow, which the starter kits
+  ship; `repo-adopt` appends the starter's invocation step when it finds none.
+- Move any caller of this repository's reusable workflow from
+  `…/.github/workflows/compliance.yml@<sha>` to
+  `…/.github/workflows/compliance-reusable.yml@<sha>`. The old path is now a
+  `pull_request` workflow of this repository's own and is no longer callable;
+  a caller left on it fails to resolve the workflow. Its inputs are unchanged.
+  Consider moving to the prescribed uvx-direct form instead: the reusable form
+  is supported, but a called workflow's job may report its status check under a
+  concatenated name rather than as `compliance`, which **RSK014** requires
+  verbatim. `docs/compliance.md` records what is and is not known about that.
 - Re-check every conditional in `.github/workflows/quality.yml`. RSK006 no
   longer accepts a required command that is reachable only under a condition
   policy does not declare, so a gate-chain command behind your own `if`, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,8 +92,10 @@ the changes listed under **Adopters must**.
   in it to carry a 40-character commit SHA.
 - **RSK030 (required): the compliance job has to invoke the checker.** An
   existing, least-privileged, fully pinned compliance workflow could still
-  execute nothing. The rule requires one executed command in
-  `jobs.compliance.steps[*].run` to carry `repo-check` in its argument list.
+  execute nothing. The rule requires the workflow to trigger on
+  `pull_request` — the other three pass on one no pull request ever starts —
+  and requires one executed command in `jobs.compliance.steps[*].run` to carry
+  `repo-check` in its argument list.
   Policy owns the token, and the match is containment rather than an exact
   command, because an adopter runs a released checker with `uvx` while this
   repository runs its own working tree with `uv run` — both correct. The claim
@@ -266,10 +268,12 @@ to see what is left; the list below is what that repairs and what it cannot.
   on your behalf, so an unpinned action you added there is reported, not
   repaired. `docs/quality-gates.md` §5 already required this job; only the
   structural checks are new.
-- Make sure that job actually runs the checker. **RSK030** requires one
-  executed command in `jobs.compliance.steps[*].run` to contain `repo-check`,
-  so a job that only checks out the repository, or one whose invocation sits
-  behind your own `if`, reports a required finding. The prescribed form is the
+- Make sure that job actually runs the checker, on pull requests. **RSK030**
+  requires the workflow to trigger on `pull_request` and one executed command
+  in `jobs.compliance.steps[*].run` to contain `repo-check`, so a workflow
+  reachable only by `workflow_dispatch`, a job that only checks out the
+  repository, or an invocation sitting behind your own `if` each report a
+  required finding. The prescribed form is the
   one in `docs/compliance.md` §Required CI workflow, which the starter kits
   ship; `repo-adopt` appends the starter's invocation step when it finds none.
 - Move any caller of this repository's reusable workflow from

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -84,19 +84,20 @@ status. This CI check does not replace `quality`: compliance verifies the
 standard-owned structure, while quality executes the declared gate chain.
 
 The starter kits and this standards repository all use the canonical
-`.github/workflows/compliance.yml` name and emit a `compliance` job. The
-standards repository's workflow also remains callable by adopters. A repository
-may instead call that reusable workflow from its canonical file, provided the
-resulting required status is named `compliance`.
+`.github/workflows/compliance.yml` name and emit a `compliance` job. A
+repository may instead call the reusable workflow this repository publishes at
+`.github/workflows/compliance-reusable.yml` from its canonical file, provided
+the resulting required status is named `compliance`.
 
-Both adopter forms execute the selected checker with `uvx`. The isolated tool
-environment neither reads nor changes the adopter's `uv.lock`, and
-`repo-standard-kit` does not belong in the adopter's project dependencies.
-Direct pull requests in `repo-standard-kit` are the exception: the root workflow
-runs the checked-out implementation with `uv run --locked --no-dev` so changes
-to the checker itself receive coverage before release. The reusable workflow
-selects these paths from the required `standard-ref` input; it does not use the
-inherited event name, which is still `pull_request` when an adopter calls it.
+An adopter executes the selected checker with `uvx`, in either form. The
+isolated tool environment neither reads nor changes the adopter's `uv.lock`,
+and `repo-standard-kit` does not belong in the adopter's project dependencies.
+Direct pull requests in `repo-standard-kit` are the exception: its own
+`compliance.yml` runs the checked-out implementation with
+`uv run --locked --no-dev` so changes to the checker itself receive coverage
+before release. Each trigger owns a file rather than sharing one, so neither
+workflow branches on the event name — which is still `pull_request` when an
+adopter calls a reusable workflow — nor on whether a ref input was supplied.
 
 Together with the `quality` job, this gives every adopting repository the same
 two required status names and therefore the same branch-protection ruleset.
@@ -117,6 +118,51 @@ repos:
 
 ### Required CI workflow
 
+The required shape is the one both starter kits ship: a workflow the repository
+owns, running the released checker directly.
+
+```yaml
+name: Compliance
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  compliance:
+    name: compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Check repository compliance
+        run: >-
+          uvx --from
+          "git+https://github.com/FP-DevTools/repo-standard-kit.git@v2.0.0"
+          repo-check .
+```
+
+Every remote action SHALL be pinned to a full commit SHA; keep the version
+comment beside it so dependency updates stay readable. The ref in the `--from`
+URL selects the released `repo-standard-kit` revision whose packaged checker
+and compiled policy are executed. A commit SHA gives the strongest
+reproducibility. A human-readable release tag such as `v2.0.0` is permitted
+only when repository governance keeps release tags immutable.
+
+Because the repository owns the command, any option the checker accepts —
+`--strict`, `--check-enforcement`, `--profile` — is an edit to that line rather
+than a request for a new workflow input.
+
+### Alternative: calling the reusable workflow
+
+The caller is one job:
+
 ```yaml
 name: Compliance
 
@@ -125,27 +171,35 @@ on:
 
 jobs:
   compliance:
-    uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@<full-sha>
+    uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml@<full-sha>
     with:
       standard-ref: v2.0.0
 ```
 
-The reusable workflow itself SHALL be pinned to a full commit SHA. That
-immutable `uses:` reference selects the workflow implementation the caller
-trusts. The distinct `standard-ref` input selects the released
-`repo-standard-kit` revision whose packaged checker and compiled policy are
-executed. A commit SHA gives the strongest reproducibility. A human-readable
-release tag such as `v2.0.0` is permitted only when repository governance keeps
-release tags immutable.
-The workflow passes that input through the environment, validates it against a
-narrow Git-ref character allowlist, and never interpolates caller-controlled
-inputs directly into Bash source. Confirm the caller emits the required
-`compliance` status.
+This form is shorter and the runner is maintained centrally, at the cost of
+being limited to the inputs that exist: `standard-ref`, `strict`, and
+`check-enforcement`. The reusable workflow SHALL itself be pinned to a full
+commit SHA, which selects the workflow implementation the caller trusts; the
+distinct `standard-ref` input selects the checker revision, on the same terms
+as the `--from` ref above. The workflow passes that input through the
+environment, validates it against a narrow Git-ref character allowlist, and
+never interpolates caller-controlled inputs directly into Bash source.
 
-`--check-enforcement` remains a distinct, authenticated platform audit. Enable
-the reusable workflow's `check-enforcement` input only when the job has GitHub
-CLI authentication and the repository plan exposes branch protection or
-rulesets. A green default `compliance` job proves structural alignment; it does
+Confirm the caller emits the required `compliance` status before relying on
+this form, and treat the following as the reason it is the alternative rather
+than the prescribed shape. A called workflow's job is widely reported to
+surface as `<caller-job-id> / <called-job-name>`, which would make this example
+report as `compliance / compliance` and not as `compliance`. RSK014 requires
+the context names to be exactly `quality` and `compliance`, and GitHub matches
+a required status check by exact name. **This behaviour is unverified**:
+GitHub's own Actions documentation does not state how a called workflow's check
+is named, and this repository has not observed it. Do not treat it as settled
+in either direction — observe the check name your caller actually produces.
+
+`--check-enforcement` remains a distinct, authenticated platform audit. Add it
+to the command, or set the reusable workflow's `check-enforcement` input, only
+when the job has GitHub CLI authentication and the repository plan exposes
+branch protection or rulesets. A green default `compliance` job proves structural alignment; it does
 not prove that GitHub requires `quality` and `compliance` before merge.
 
 The isolated `uvx` path is portable within the maintained profiles, not fully
@@ -197,9 +251,14 @@ remediation. Markdown explains policy but supplies no executable values.
   in every job in the quality workflow; local and Docker actions are exempt.
 - RSK027 requires `.github/workflows/compliance.yml` to exist. RSK028 and
   RSK029 apply the permission and pin obligations above to that workflow and
-  its `compliance` job. No rule reads its `run` steps: the checker has no one
-  invocation to require, so an existing, least-privileged, fully pinned
-  compliance workflow can still execute nothing.
+  its `compliance` job. RSK030 reads its `run` steps and requires one executed
+  command to contain `repo-check`. Policy owns that token, and the match is
+  containment rather than an exact command, because the released and
+  working-tree invocations differ legitimately. It therefore proves the job
+  invokes the checker, not that the invocation is meaningful: a contrived
+  command naming the token passes, while a token inside a comment or a
+  shell-wrapper string does not, and neither does an invocation reachable only
+  under a guard policy does not declare.
 - RSK014 requires pull request protection, stale approval dismissal, required
   status checks, strict up-to-date branches, conversation resolution, and
   administrator enforcement when platform checks are requested, but permits a

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -177,16 +177,16 @@ jobs:
 ```
 
 This form is shorter and the runner is maintained centrally, at the cost of
-being limited to the inputs that exist: `standard-ref`, `strict`, and
-`check-enforcement`. The reusable workflow SHALL itself be pinned to a full
-commit SHA, which selects the workflow implementation the caller trusts; the
-distinct `standard-ref` input selects the checker revision, on the same terms
-as the `--from` ref above. Every input reaches the step through the
-environment and never through interpolation into Bash source, so a caller's
-value is always one quoted argument and never shell to parse. That single
-property is what keeps the step to one unconditional command: with nothing to
-escape there is nothing to validate, and a boolean input that resolves to its
-own flag needs no branch to append it.
+running exactly one command with no options. `standard-ref` is the sole input,
+and it selects which checker runs rather than what that checker does: a
+repository that wants `--strict`, `--check-enforcement` or `--profile` owns
+the command instead, which is the prescribed form above. The reusable workflow
+SHALL itself be pinned to a full commit SHA, which selects the workflow
+implementation the caller trusts; the distinct `standard-ref` input selects
+the checker revision, on the same terms as the `--from` ref above. That input
+reaches the step through the environment and never through interpolation into
+Bash source, so a caller's value is always one quoted argument and never shell
+to parse — which is why the step needs no validation of its own.
 
 Confirm the caller emits the required `compliance` status before relying on
 this form, and treat the following as the reason it is the alternative rather
@@ -200,10 +200,11 @@ is named, and this repository has not observed it. Do not treat it as settled
 in either direction — observe the check name your caller actually produces.
 
 `--check-enforcement` remains a distinct, authenticated platform audit. Add it
-to the command, or set the reusable workflow's `check-enforcement` input, only
-when the job has GitHub CLI authentication and the repository plan exposes
-branch protection or rulesets. A green default `compliance` job proves structural alignment; it does
-not prove that GitHub requires `quality` and `compliance` before merge.
+to the command only when the job has GitHub CLI authentication and the
+repository plan exposes branch protection or rulesets; wanting it is itself a
+reason to own the command rather than call the reusable workflow. A green
+default `compliance` job proves structural alignment; it does not prove that
+GitHub requires `quality` and `compliance` before merge.
 
 The isolated `uvx` path is portable within the maintained profiles, not fully
 hermetic or universal: it currently assumes GitHub Actions on `ubuntu-latest`,

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -251,8 +251,10 @@ remediation. Markdown explains policy but supplies no executable values.
   in every job in the quality workflow; local and Docker actions are exempt.
 - RSK027 requires `.github/workflows/compliance.yml` to exist. RSK028 and
   RSK029 apply the permission and pin obligations above to that workflow and
-  its `compliance` job. RSK030 reads its `run` steps and requires one executed
-  command to contain `repo-check`. Policy owns that token, and the match is
+  its `compliance` job. RSK030 requires the workflow to trigger on
+  `pull_request` — the other three pass on one that never runs — and reads its
+  `run` steps for one executed command containing `repo-check`. Policy owns
+  that token, and the match is
   containment rather than an exact command, because the released and
   working-tree invocations differ legitimately. It therefore proves the job
   invokes the checker, not that the invocation is meaningful: a contrived

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -181,9 +181,12 @@ being limited to the inputs that exist: `standard-ref`, `strict`, and
 `check-enforcement`. The reusable workflow SHALL itself be pinned to a full
 commit SHA, which selects the workflow implementation the caller trusts; the
 distinct `standard-ref` input selects the checker revision, on the same terms
-as the `--from` ref above. The workflow passes that input through the
-environment, validates it against a narrow Git-ref character allowlist, and
-never interpolates caller-controlled inputs directly into Bash source.
+as the `--from` ref above. Every input reaches the step through the
+environment and never through interpolation into Bash source, so a caller's
+value is always one quoted argument and never shell to parse. That single
+property is what keeps the step to one unconditional command: with nothing to
+escape there is nothing to validate, and a boolean input that resolves to its
+own flag needs no branch to append it.
 
 Confirm the caller emits the required `compliance` status before relying on
 this form, and treat the following as the reason it is the alternative rather

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -467,9 +467,9 @@ Remediation: Pin every remote action and reusable workflow in the compliance wor
 - Enforcement: `structural`
 - Check kind: `github_workflow_invocation`
 
-Rationale: RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.
+Rationale: RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker on pull requests: a workflow that never triggers on one satisfies the other three while leaving the SHALL in section 5 unmet, so the trigger belongs to this claim rather than to a rule of its own. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.
 
-Remediation: Run repo-check from a step of the compliance job, unguarded or under a condition policy declares for the profile.
+Remediation: Trigger the compliance workflow on pull_request, and run repo-check from a step of its compliance job, unguarded or under a condition policy declares for the profile.
 
 | Profile | Permitted guard |
 | --- | --- |

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -431,7 +431,7 @@ Remediation: State each dial in the Agent Operating Mode section of AGENTS.md, i
 - Enforcement: `structural`
 - Check kind: `path_exists`
 
-Rationale: The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims: no rule requires the job to run a particular command, because the checker is invoked one way against a pinned release and another against the working tree, and both forms sit inside conditional branches that RSK006's guard semantics leave unproven. A compliance workflow that exists, grants only contents: read, and pins every action can still execute nothing.
+Rationale: The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims; RSK030 separately requires the job to invoke the checker.
 
 Remediation: Add .github/workflows/compliance.yml with a compliance job that checks the repository against repo-standard-kit on pull requests.
 
@@ -458,6 +458,23 @@ Remediation: Set the compliance job's effective permissions to exactly `contents
 Rationale: The compliance workflow already executes code fetched from outside the repository, so a mutable action reference beside it is the widest unpinned surface the standard ships.
 
 Remediation: Pin every remote action and reusable workflow in the compliance workflow to a 40-character SHA.
+
+### RSK030: Compliance workflow invokes the checker
+
+- Level: `required`
+- Profiles: `python-single`, `python-workspace`
+- Source: [`docs/quality-gates.md` — 5. CI Pull Request Gates](../docs/quality-gates.md)
+- Enforcement: `structural`
+- Check kind: `github_workflow_invocation`
+
+Rationale: RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.
+
+Remediation: Run repo-check from a step of the compliance job, unguarded or under a condition policy declares for the profile.
+
+| Profile | Permitted guard |
+| --- | --- |
+| `python-single` | none |
+| `python-workspace` | none |
 
 ## Retired Rule IDs
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -158,8 +158,11 @@ This workflow fetches and executes the checker from outside the repository, so
 it is the reference set least safe to leave mutable.
 
 RSK030 enforces at the **required** level that the compliance job invokes the
-checker: some command in `jobs.compliance.steps[*].run` shall carry
-`repo-check` in its argument list. The match is containment rather than an
+checker on pull requests: the workflow shall trigger on `pull_request`, and
+some command in `jobs.compliance.steps[*].run` shall carry `repo-check` in its
+argument list. The trigger belongs to this rule because the other three are
+satisfied by a workflow no pull request ever starts, which leaves the SHALL
+above unmet. The match is containment rather than an
 exact command, because an adopter runs a released checker with `uvx` while this
 standards repository runs its own working tree with `uv run`, and both are
 correct. The guard semantics above apply unchanged, and no profile declares a

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -157,13 +157,18 @@ compliance workflow references is pinned to a full 40-character commit SHA.
 This workflow fetches and executes the checker from outside the repository, so
 it is the reference set least safe to leave mutable.
 
-No rule requires the compliance job to run any particular command. The checker
-is invoked one way against a pinned release and another against the working
-tree, and both forms sit inside conditional branches that the guard semantics
-above leave unproven, so a compliance workflow that exists, is
-least-privileged, and is fully pinned can still execute nothing. Section 10
-enforcement keeps the status check mandatory; whether the job is worth running
-stays a maintainer's judgement.
+RSK030 enforces at the **required** level that the compliance job invokes the
+checker: some command in `jobs.compliance.steps[*].run` shall carry
+`repo-check` in its argument list. The match is containment rather than an
+exact command, because an adopter runs a released checker with `uvx` while this
+standards repository runs its own working tree with `uv run`, and both are
+correct. The guard semantics above apply unchanged, and no profile declares a
+permitted guard for this rule, so the invocation shall be unguarded. What
+containment buys is honest but limited: it cannot tell a real compliance run
+from a command that merely names the token, and it establishes only that the
+job invokes the checker at all. It does exclude a token that appears solely in
+a comment, which the shell lexer discards. Section 10 enforcement keeps the
+status check mandatory.
 
 ### Environment reproducibility
 

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -603,6 +603,7 @@ rules:
       config:
         path: .github/workflows/compliance.yml
         job: compliance
+        trigger: pull_request
         token: repo-check
         guards_by_profile:
           python-single: []
@@ -610,7 +611,10 @@ rules:
     rationale: >-
       RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants
       only contents: read, and pins every action free to execute nothing. This
-      rule requires the job to run the checker. It matches by containment
+      rule requires the job to run the checker on pull requests: a workflow
+      that never triggers on one satisfies the other three while leaving the
+      SHALL in section 5 unmet, so the trigger belongs to this claim rather
+      than to a rule of its own. It matches by containment
       rather than by exact command because the same correct invocation is
       spelled differently in different repositories, so the guarantee is
       correspondingly weak: it proves that an executed command's argument list
@@ -620,5 +624,6 @@ rules:
       the shell lexer discards, and an invocation reachable only under a
       condition policy does not declare for the profile.
     remediation: >-
-      Run repo-check from a step of the compliance job, unguarded or under a
-      condition policy declares for the profile.
+      Trigger the compliance workflow on pull_request, and run repo-check from
+      a step of its compliance job, unguarded or under a condition policy
+      declares for the profile.

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -543,12 +543,7 @@ rules:
     rationale: >-
       The compliance job is what stops the rest of the standard from drifting,
       so its absence has to be a finding of its own. Existence is all this rule
-      claims: no rule requires the job to run a particular command, because the
-      checker is invoked one way against a pinned release and another against
-      the working tree, and both forms sit inside conditional branches that
-      RSK006's guard semantics leave unproven. A compliance workflow that
-      exists, grants only contents: read, and pins every action can still
-      execute nothing.
+      claims; RSK030 separately requires the job to invoke the checker.
     remediation: >-
       Add .github/workflows/compliance.yml with a compliance job that checks the
       repository against repo-standard-kit on pull requests.
@@ -594,3 +589,36 @@ rules:
     remediation: >-
       Pin every remote action and reusable workflow in the compliance workflow
       to a 40-character SHA.
+
+  - id: RSK030
+    title: Compliance workflow invokes the checker
+    level: required
+    profiles: [python-single, python-workspace]
+    source:
+      document: docs/quality-gates.md
+      section: 5. CI Pull Request Gates
+    enforcement: structural
+    check:
+      kind: github_workflow_invocation
+      config:
+        path: .github/workflows/compliance.yml
+        job: compliance
+        token: repo-check
+        guards_by_profile:
+          python-single: []
+          python-workspace: []
+    rationale: >-
+      RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants
+      only contents: read, and pins every action free to execute nothing. This
+      rule requires the job to run the checker. It matches by containment
+      rather than by exact command because the same correct invocation is
+      spelled differently in different repositories, so the guarantee is
+      correspondingly weak: it proves that an executed command's argument list
+      carries the token policy names, not that the command is a genuine
+      compliance run, and a contrived command mentioning the token satisfies
+      it. What it does exclude is a token appearing only in a comment, which
+      the shell lexer discards, and an invocation reachable only under a
+      condition policy does not declare for the profile.
+    remediation: >-
+      Run repo-check from a step of the compliance job, unguarded or under a
+      condition policy declares for the profile.

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -712,18 +712,33 @@ def _github_workflow_invocation(
         return errors
     assert document is not None
     assert job is not None
+    assert isinstance(document.data, dict)
+    issues: list[Issue] = []
+    # A job that never starts invokes nothing, so the trigger is part of the
+    # claim rather than a separate rule's business.
+    if not _trigger_present(document.data.get("on"), config["trigger"]):
+        issues.append(
+            Issue(
+                config["path"],
+                f"Workflow does not trigger on {config['trigger']}.",
+                document.data.get("on"),
+                config["trigger"],
+                document.line("on"),
+            )
+        )
     commands, error = _job_shell_commands(document, job, config)
     if error is not None:
-        return [error]
+        issues.append(error)
+        return issues
     token = config["token"]
     declared_guards = config["guards_by_profile"][context.profile]
     permitted = _permitted_guards(declared_guards)
     invocations = [command for command in commands if token in command.tokens]
     line = document.line("jobs", config["job"], "steps")
     if any(_is_executed(command, permitted) for command in invocations):
-        return []
+        return issues
     if invocations:
-        return [
+        issues.append(
             Issue(
                 config["path"],
                 f"Job {config['job']!r} invokes {token} only under an undeclared "
@@ -732,8 +747,9 @@ def _github_workflow_invocation(
                 list(declared_guards),
                 line,
             )
-        ]
-    return [
+        )
+        return issues
+    issues.append(
         Issue(
             config["path"],
             f"Job {config['job']!r} executes no command invoking {token}.",
@@ -741,7 +757,8 @@ def _github_workflow_invocation(
             token,
             line,
         )
-    ]
+    )
+    return issues
 
 
 def _normalized_tokens(

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -600,6 +600,33 @@ def _workflow_job(
     return document, jobs[config["job"]], []
 
 
+def _job_shell_commands(
+    document: YamlDocument, job: dict[str, Any], config: dict[str, Any]
+) -> tuple[list[ShellCommand], Issue | None]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return [], Issue(
+            config["path"],
+            f"Job {config['job']!r} has no executable steps.",
+            steps,
+            "list of run steps",
+            document.line("jobs", config["job"], "steps"),
+        )
+    commands: list[ShellCommand] = []
+    for step in steps:
+        if isinstance(step, dict) and isinstance(step.get("run"), str):
+            commands.extend(_shell_commands(step["run"]))
+    return commands, None
+
+
+def _permitted_guards(declared: list[str]) -> set[tuple[str, ...]]:
+    return {tuple(shlex.split(guard)) for guard in declared}
+
+
+def _is_executed(command: ShellCommand, permitted: set[tuple[str, ...]]) -> bool:
+    return all(guard in permitted for guard in command.guards)
+
+
 def _github_workflow_commands(
     context: CheckContext, config: dict[str, Any]
 ) -> list[Issue]:
@@ -620,29 +647,17 @@ def _github_workflow_commands(
                 document.line("on"),
             )
         )
-    steps = job.get("steps")
-    if not isinstance(steps, list):
-        issues.append(
-            Issue(
-                config["path"],
-                f"Job {config['job']!r} has no executable steps.",
-                steps,
-                "list of run steps",
-                document.line("jobs", config["job"], "steps"),
-            )
-        )
+    actual_commands, error = _job_shell_commands(document, job, config)
+    if error is not None:
+        issues.append(error)
         return issues
-    actual_commands: list[ShellCommand] = []
-    for step in steps:
-        if isinstance(step, dict) and isinstance(step.get("run"), str):
-            actual_commands.extend(_shell_commands(step["run"]))
     declared_guards = config["guards_by_profile"][context.profile]
-    permitted = {tuple(shlex.split(guard)) for guard in declared_guards}
+    permitted = _permitted_guards(declared_guards)
     present = {command.tokens for command in actual_commands}
     executed = {
         command.tokens
         for command in actual_commands
-        if all(guard in permitted for guard in command.guards)
+        if _is_executed(command, permitted)
     }
     required = [
         tuple(shlex.split(command))
@@ -677,6 +692,56 @@ def _github_workflow_commands(
             )
         )
     return issues
+
+
+def _github_workflow_invocation(
+    context: CheckContext, config: dict[str, Any]
+) -> list[Issue]:
+    """Require a job to execute a command carrying the token policy names.
+
+    The same correct invocation is spelled differently in different
+    repositories — an adopter runs a released checker with `uvx`, this
+    repository runs its own working tree with `uv run` — so an exact argv, the
+    way `_github_workflow_commands` matches, cannot express the requirement.
+    Containment can, at the cost of a weaker claim: the job satisfies the rule
+    when an executed command's argument list contains the token, whatever else
+    that command does.
+    """
+    document, job, errors = _workflow_job(context, config)
+    if errors:
+        return errors
+    assert document is not None
+    assert job is not None
+    commands, error = _job_shell_commands(document, job, config)
+    if error is not None:
+        return [error]
+    token = config["token"]
+    declared_guards = config["guards_by_profile"][context.profile]
+    permitted = _permitted_guards(declared_guards)
+    invocations = [command for command in commands if token in command.tokens]
+    line = document.line("jobs", config["job"], "steps")
+    if any(_is_executed(command, permitted) for command in invocations):
+        return []
+    if invocations:
+        return [
+            Issue(
+                config["path"],
+                f"Job {config['job']!r} invokes {token} only under an undeclared "
+                "guard.",
+                [shlex.join(command.tokens) for command in invocations],
+                list(declared_guards),
+                line,
+            )
+        ]
+    return [
+        Issue(
+            config["path"],
+            f"Job {config['job']!r} executes no command invoking {token}.",
+            [shlex.join(command.tokens) for command in commands],
+            token,
+            line,
+        )
+    ]
 
 
 def _normalized_tokens(
@@ -1610,6 +1675,7 @@ CHECK_HANDLERS: dict[str, CheckHandler] = {
     "agents_operating_dials": _agents_operating_dials,
     "text_pattern_each": _text_pattern_each,
     "github_workflow_commands": _github_workflow_commands,
+    "github_workflow_invocation": _github_workflow_invocation,
     "pre_commit_hooks": _pre_commit_hooks,
     "uv_build_backend": _uv_build_backend,
     "ruff_baseline": _ruff_baseline,

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -855,7 +855,8 @@
           },
           "job": "compliance",
           "path": ".github/workflows/compliance.yml",
-          "token": "repo-check"
+          "token": "repo-check",
+          "trigger": "pull_request"
         },
         "kind": "github_workflow_invocation"
       },
@@ -866,8 +867,8 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.",
-      "remediation": "Run repo-check from a step of the compliance job, unguarded or under a condition policy declares for the profile.",
+      "rationale": "RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker on pull requests: a workflow that never triggers on one satisfies the other three while leaving the SHALL in section 5 unmet, so the trigger belongs to this claim rather than to a rule of its own. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.",
+      "remediation": "Trigger the compliance workflow on pull_request, and run repo-check from a step of its compliance job, unguarded or under a condition policy declares for the profile.",
       "source": {
         "document": "docs/quality-gates.md",
         "section": "5. CI Pull Request Gates"

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -790,7 +790,7 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims: no rule requires the job to run a particular command, because the checker is invoked one way against a pinned release and another against the working tree, and both forms sit inside conditional branches that RSK006's guard semantics leave unproven. A compliance workflow that exists, grants only contents: read, and pins every action can still execute nothing.",
+      "rationale": "The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims; RSK030 separately requires the job to invoke the checker.",
       "remediation": "Add .github/workflows/compliance.yml with a compliance job that checks the repository against repo-standard-kit on pull requests.",
       "source": {
         "document": "docs/quality-gates.md",
@@ -845,6 +845,34 @@
         "section": "5. CI Pull Request Gates"
       },
       "title": "Compliance workflow pins remote actions immutably"
+    },
+    {
+      "check": {
+        "config": {
+          "guards_by_profile": {
+            "python-single": [],
+            "python-workspace": []
+          },
+          "job": "compliance",
+          "path": ".github/workflows/compliance.yml",
+          "token": "repo-check"
+        },
+        "kind": "github_workflow_invocation"
+      },
+      "enforcement": "structural",
+      "id": "RSK030",
+      "level": "required",
+      "profiles": [
+        "python-single",
+        "python-workspace"
+      ],
+      "rationale": "RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.",
+      "remediation": "Run repo-check from a step of the compliance job, unguarded or under a condition policy declares for the profile.",
+      "source": {
+        "document": "docs/quality-gates.md",
+        "section": "5. CI Pull Request Gates"
+      },
+      "title": "Compliance workflow invokes the checker"
     }
   ],
   "schema_version": 1,

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -49,7 +49,7 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
         set(),
     ),
     "github_workflow_invocation": (
-        {"path", "job", "token", "guards_by_profile"},
+        {"path", "job", "trigger", "token", "guards_by_profile"},
         set(),
     ),
     "pre_commit_hooks": ({"path", "hooks"}, set()),

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -48,6 +48,10 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
         {"path", "job", "trigger", "commands_by_profile", "guards_by_profile"},
         set(),
     ),
+    "github_workflow_invocation": (
+        {"path", "job", "token", "guards_by_profile"},
+        set(),
+    ),
     "pre_commit_hooks": ({"path", "hooks"}, set()),
     "uv_build_backend": ({"path", "backend"}, {"allow_missing_profiles"}),
     "ruff_baseline": ({"path", "required_select", "require_line_length"}, set()),
@@ -380,6 +384,7 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         "standard_major",
         "shape",
         "section",
+        "token",
     ):
         if key in config:
             _string(config[key], f"{location}.{key}")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1019,6 +1019,7 @@ def test_rsk030_owns_the_invocation_token_and_declares_every_guard() -> None:
     assert rule.check.config == {
         "path": ".github/workflows/compliance.yml",
         "job": "compliance",
+        "trigger": "pull_request",
         "token": "repo-check",
         "guards_by_profile": {"python-single": [], "python-workspace": []},
     }
@@ -1054,6 +1055,22 @@ def test_a_compliance_job_that_never_invokes_the_checker_reports_rsk030(
     assert finding.message == (
         "Job 'compliance' executes no command invoking repo-check."
     )
+
+
+def test_a_compliance_workflow_that_no_pull_request_starts_reports_rsk030(
+    tmp_path: Path,
+) -> None:
+    """A job that never starts invokes nothing, however well it is written."""
+    root = _minimal_repo(tmp_path)
+    path = root / ".github" / "workflows" / "compliance.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "on:\n  pull_request:\n", "on:\n  workflow_dispatch:\n"
+        ),
+        encoding="utf-8",
+    )
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK030"]
+    assert finding.message == "Workflow does not trigger on pull_request."
 
 
 def test_an_invocation_under_an_undeclared_guard_reports_rsk030(

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import re
 import shutil
@@ -1003,13 +1004,117 @@ def test_shipped_compliance_workflows_satisfy_their_rules(profile: str) -> None:
     for root in (REPO_ROOT, kit):
         issues = [
             issue
-            for rule_id in ("RSK027", "RSK028", "RSK029")
+            for rule_id in ("RSK027", "RSK028", "RSK029", "RSK030")
             for issue in CHECK_HANDLERS[POLICY.rule(rule_id).check.kind](
                 checks.CheckContext(root=root, policy=POLICY, profile=profile),
                 POLICY.rule(rule_id).check.config,
             )
         ]
         assert issues == []
+
+
+def test_rsk030_owns_the_invocation_token_and_declares_every_guard() -> None:
+    rule = POLICY.rule("RSK030")
+    assert rule.level == "required"
+    assert rule.check.config == {
+        "path": ".github/workflows/compliance.yml",
+        "job": "compliance",
+        "token": "repo-check",
+        "guards_by_profile": {"python-single": [], "python-workspace": []},
+    }
+    assert rule.check.config["token"] not in inspect.getsource(
+        CHECK_HANDLERS[rule.check.kind]
+    )
+
+
+def _rewrite_compliance_step(root: Path, run: str) -> None:
+    path = root / ".github" / "workflows" / "compliance.yml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("      - run: repo-check .\n", run),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        "      - run: echo checked\n",
+        "      - run: bash -c 'repo-check .'\n",
+        "      - run: |\n          echo checked\n          # repo-check .\n",
+        "      - name: repo-check .\n        run: echo checked\n",
+    ],
+    ids=["absent", "shell-wrapper", "comment", "step-name"],
+)
+def test_a_compliance_job_that_never_invokes_the_checker_reports_rsk030(
+    tmp_path: Path, run: str
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _rewrite_compliance_step(root, run)
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK030"]
+    assert finding.message == (
+        "Job 'compliance' executes no command invoking repo-check."
+    )
+
+
+def test_an_invocation_under_an_undeclared_guard_reports_rsk030(
+    tmp_path: Path,
+) -> None:
+    """A skipped compliance run still exits zero, so the guard has to be owned."""
+    root = _minimal_repo(tmp_path)
+    _rewrite_compliance_step(
+        root,
+        "      - run: |\n"
+        '          if [ -n "$SKIP" ]; then\n'
+        "            repo-check .\n"
+        "          fi\n",
+    )
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK030"]
+    assert finding.message == (
+        "Job 'compliance' invokes repo-check only under an undeclared guard."
+    )
+    assert finding.expected == []
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        "      - run: uv run --locked --no-dev repo-check . --format text\n",
+        '      - run: uvx --from "git+https://host/kit.git@v2.0.0" repo-check .\n',
+    ],
+    ids=["working-tree", "released"],
+)
+def test_either_legitimate_invocation_satisfies_rsk030(
+    tmp_path: Path, run: str
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _rewrite_compliance_step(root, run)
+    assert "RSK030" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_rsk030_accepts_a_command_that_only_mentions_the_token(
+    tmp_path: Path,
+) -> None:
+    """Containment cannot tell a real run from a contrived one; policy says so."""
+    root = _minimal_repo(tmp_path)
+    _rewrite_compliance_step(root, "      - run: echo repo-check\n")
+    assert "RSK030" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_the_reusable_compliance_workflow_is_pinned_and_least_privileged() -> None:
+    """No rule reads this file: RSK029's path is fixed and adopters have no such
+    file, so the kit refuses to ship the surface it forbids elsewhere."""
+    context = checks.CheckContext(
+        root=REPO_ROOT, policy=POLICY, profile="python-single"
+    )
+    path = ".github/workflows/compliance-reusable.yml"
+    assert CHECK_HANDLERS["github_workflow_pins"](context, {"path": path}) == []
+    assert (
+        CHECK_HANDLERS["github_workflow_permissions"](
+            context,
+            {"path": path, "job": "compliance", "permissions": {"contents": "read"}},
+        )
+        == []
+    )
 
 
 # --- pre-commit structure -------------------------------------------------

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -430,6 +430,33 @@ def test_recognized_older_compliance_step_is_updated_in_place(tmp_path: Path) ->
     assert f"@v{_kit_version()}" in compliance_steps[0]["run"]
 
 
+def test_a_compliance_job_that_invokes_nothing_gains_the_invocation(
+    tmp_path: Path,
+) -> None:
+    """RSK030 is repairable through the existing merge: no new repair path."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    workflow = root / ".github" / "workflows" / "compliance.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "name: Compliance\n"
+        "on: pull_request\n"
+        "jobs:\n"
+        "  compliance:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: Say nothing\n"
+        "        run: echo compliant\n",
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    assert "RSK030" not in {
+        finding.rule_id for finding in check_repo(root, load_policy())
+    }
+
+
 def test_interrupted_command_reports_the_exact_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -432,11 +432,9 @@ def test_reusable_compliance_workflow_is_the_only_workflow_call_surface() -> Non
     workflow = load_yaml(workflow_text)
 
     assert set(workflow["on"]) == {"workflow_call"}
-    assert set(workflow["on"]["workflow_call"]["inputs"]) == {
-        "standard-ref",
-        "strict",
-        "check-enforcement",
-    }
+    # The one input selects which checker runs. Tuning what it checks is the
+    # uvx-direct form's job, which is why that form is the prescribed one.
+    assert set(workflow["on"]["workflow_call"]["inputs"]) == {"standard-ref"}
     assert workflow["permissions"] == {"contents": "read"}
     assert "  compliance:\n    name: compliance\n" in workflow_text
     assert "uvx \\" in workflow_text
@@ -451,20 +449,14 @@ def test_reusable_compliance_workflow_keeps_inputs_out_of_shell_source() -> None
         if step.get("name") == "Run repo-check"
     )
 
-    assert run_step["env"] == {
-        "REPO_STANDARD_REF": "${{ inputs.standard-ref }}",
-        "STRICT": "${{ inputs.strict && '--strict' || '' }}",
-        "CHECK_ENFORCEMENT": (
-            "${{ inputs.check-enforcement && '--check-enforcement' || '' }}"
-        ),
-    }
+    assert run_step["env"] == {"REPO_STANDARD_REF": "${{ inputs.standard-ref }}"}
     run = run_step["run"]
     assert "${{ inputs." not in run
     assert "$REPO_STANDARD_REF" in run
 
 
 def test_reusable_compliance_workflow_step_holds_no_conditional() -> None:
-    """The env indirection carries every input, so the step is one command."""
+    """One input that only selects a ref leaves nothing for the step to decide."""
     workflow = load_yaml(REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8"))
     run = next(
         step["run"]
@@ -475,7 +467,7 @@ def test_reusable_compliance_workflow_step_holds_no_conditional() -> None:
     assert not re.search(r"\b(if|elif|else|fi|case|esac|for|while)\b", run)
 
 
-def _reusable_workflow_argv(tmp_path: Path, **env_overrides: str) -> tuple[str, ...]:
+def _reusable_workflow_argv(tmp_path: Path, standard_ref: str) -> tuple[str, ...]:
     """Execute the reusable workflow's step against a uvx stub, returning argv."""
     workflow = load_yaml(REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8"))
     run = next(
@@ -495,7 +487,7 @@ def _reusable_workflow_argv(tmp_path: Path, **env_overrides: str) -> tuple[str, 
         pytest.skip("Bash is required to execute the reusable-workflow step")
 
     bin_dir = tmp_path / "bin"
-    bin_dir.mkdir(exist_ok=True)
+    bin_dir.mkdir()
     stub = bin_dir / "uvx"
     stub.write_text(
         '#!/usr/bin/env bash\nfor a in "$@"; do printf "%s\\n" "$a"; done\n',
@@ -508,10 +500,7 @@ def _reusable_workflow_argv(tmp_path: Path, **env_overrides: str) -> tuple[str, 
     env.update(
         {
             "PATH": os.pathsep.join((str(bin_dir), env["PATH"])),
-            "REPO_STANDARD_REF": "v1.2.0",
-            "STRICT": "",
-            "CHECK_ENFORCEMENT": "",
-            **env_overrides,
+            "REPO_STANDARD_REF": standard_ref,
         }
     )
     result = subprocess.run(
@@ -525,14 +514,14 @@ def _reusable_workflow_argv(tmp_path: Path, **env_overrides: str) -> tuple[str, 
     return tuple(result.stdout.splitlines())
 
 
-def test_reusable_compliance_workflow_passes_only_the_requested_flags(
-    tmp_path: Path,
-) -> None:
-    """Empty flag variables vanish; set ones arrive as single arguments."""
-    assert _reusable_workflow_argv(tmp_path)[-2:] == ("repo-check", ".")
-    assert _reusable_workflow_argv(
-        tmp_path, STRICT="--strict", CHECK_ENFORCEMENT="--check-enforcement"
-    )[-4:] == ("repo-check", ".", "--strict", "--check-enforcement")
+def test_reusable_compliance_workflow_runs_one_fixed_command(tmp_path: Path) -> None:
+    """The ref is the only thing a caller can move; the argv is otherwise fixed."""
+    assert _reusable_workflow_argv(tmp_path, "v1.2.0") == (
+        "--from",
+        "git+https://github.com/FP-DevTools/repo-standard-kit.git@v1.2.0",
+        "repo-check",
+        ".",
+    )
 
 
 def test_reusable_compliance_workflow_cannot_be_escaped_by_a_hostile_ref(
@@ -543,7 +532,7 @@ def test_reusable_compliance_workflow_cannot_be_escaped_by_a_hostile_ref(
     This is why the step needs no character allowlist of its own: nothing a
     caller supplies is ever parsed as Bash, so there is no escape to reject.
     """
-    argv = _reusable_workflow_argv(tmp_path, REPO_STANDARD_REF="v1.2.0; rm -rf /")
+    argv = _reusable_workflow_argv(tmp_path, "v1.2.0; rm -rf /")
 
     assert argv == (
         "--from",

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -453,35 +453,30 @@ def test_reusable_compliance_workflow_keeps_inputs_out_of_shell_source() -> None
 
     assert run_step["env"] == {
         "REPO_STANDARD_REF": "${{ inputs.standard-ref }}",
-        "STRICT": "${{ inputs.strict }}",
-        "CHECK_ENFORCEMENT": "${{ inputs.check-enforcement }}",
+        "STRICT": "${{ inputs.strict && '--strict' || '' }}",
+        "CHECK_ENFORCEMENT": (
+            "${{ inputs.check-enforcement && '--check-enforcement' || '' }}"
+        ),
     }
     run = run_step["run"]
     assert "${{ inputs." not in run
     assert "$REPO_STANDARD_REF" in run
-    assert '$STRICT" = "true' in run
-    assert '$CHECK_ENFORCEMENT" = "true' in run
 
 
-def test_reusable_compliance_workflow_validates_standard_ref() -> None:
-    workflow_text = REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8")
+def test_reusable_compliance_workflow_step_holds_no_conditional() -> None:
+    """The env indirection carries every input, so the step is one command."""
+    workflow = load_yaml(REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8"))
+    run = next(
+        step["run"]
+        for step in workflow["jobs"]["compliance"]["steps"]
+        if step.get("name") == "Run repo-check"
+    )
 
-    assert '[[ ! "$REPO_STANDARD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]' in workflow_text
-    assert 'echo "Invalid repo-standard-kit ref" >&2' in workflow_text
-    assert "exit 2" in workflow_text
-    assert "repo-standard-kit.git@$REPO_STANDARD_REF" in workflow_text
+    assert not re.search(r"\b(if|elif|else|fi|case|esac|for|while)\b", run)
 
 
-@pytest.mark.parametrize(
-    ("standard_ref", "expected_returncode"),
-    [("v1.2.0", 42), ("", 2), ("v1.2.0; rm -rf /", 2)],
-    ids=["released-ref", "empty-ref", "rejected-ref"],
-)
-def test_reusable_compliance_workflow_runs_uvx_only_for_an_accepted_ref(
-    tmp_path: Path,
-    standard_ref: str,
-    expected_returncode: int,
-) -> None:
+def _reusable_workflow_argv(tmp_path: Path, **env_overrides: str) -> tuple[str, ...]:
+    """Execute the reusable workflow's step against a uvx stub, returning argv."""
     workflow = load_yaml(REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8"))
     run = next(
         step["run"]
@@ -500,23 +495,62 @@ def test_reusable_compliance_workflow_runs_uvx_only_for_an_accepted_ref(
         pytest.skip("Bash is required to execute the reusable-workflow step")
 
     bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
+    bin_dir.mkdir(exist_ok=True)
     stub = bin_dir / "uvx"
-    stub.write_text("#!/usr/bin/env bash\nexit 42\n", encoding="utf-8", newline="\n")
+    stub.write_text(
+        '#!/usr/bin/env bash\nfor a in "$@"; do printf "%s\\n" "$a"; done\n',
+        encoding="utf-8",
+        newline="\n",
+    )
     stub.chmod(0o755)
 
     env = os.environ.copy()
     env.update(
         {
             "PATH": os.pathsep.join((str(bin_dir), env["PATH"])),
-            "REPO_STANDARD_REF": standard_ref,
-            "STRICT": "false",
-            "CHECK_ENFORCEMENT": "false",
+            "REPO_STANDARD_REF": "v1.2.0",
+            "STRICT": "",
+            "CHECK_ENFORCEMENT": "",
+            **env_overrides,
         }
     )
-    result = subprocess.run([bash, "-c", run], cwd=REPO_ROOT, env=env, check=False)
+    result = subprocess.run(
+        [bash, "-c", run],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(result.stdout.splitlines())
 
-    assert result.returncode == expected_returncode
+
+def test_reusable_compliance_workflow_passes_only_the_requested_flags(
+    tmp_path: Path,
+) -> None:
+    """Empty flag variables vanish; set ones arrive as single arguments."""
+    assert _reusable_workflow_argv(tmp_path)[-2:] == ("repo-check", ".")
+    assert _reusable_workflow_argv(
+        tmp_path, STRICT="--strict", CHECK_ENFORCEMENT="--check-enforcement"
+    )[-4:] == ("repo-check", ".", "--strict", "--check-enforcement")
+
+
+def test_reusable_compliance_workflow_cannot_be_escaped_by_a_hostile_ref(
+    tmp_path: Path,
+) -> None:
+    """A ref is quoted into one argument, so shell metacharacters stay inert.
+
+    This is why the step needs no character allowlist of its own: nothing a
+    caller supplies is ever parsed as Bash, so there is no escape to reject.
+    """
+    argv = _reusable_workflow_argv(tmp_path, REPO_STANDARD_REF="v1.2.0; rm -rf /")
+
+    assert argv == (
+        "--from",
+        "git+https://github.com/FP-DevTools/repo-standard-kit.git@v1.2.0; rm -rf /",
+        "repo-check",
+        ".",
+    )
 
 
 def test_root_pyproject_uses_uv_build_backend() -> None:

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -57,6 +57,10 @@ MANDATORY_PRE_COMMIT_ENTRIES = [
 
 STARTER_KIT_PROFILES = ("python-single", "python-workspace")
 
+REUSABLE_COMPLIANCE_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "compliance-reusable.yml"
+)
+
 STARTER_KIT_ROOT = Path("src") / "repo_standard" / "starter_kits"
 
 
@@ -397,9 +401,8 @@ def test_compliance_workflows_emit_an_independent_required_status() -> None:
     assert len(setup_uv_refs) == 1
 
     root_workflow = workflow_paths[0].read_text(encoding="utf-8")
-    assert "  workflow_call:\n" in root_workflow
+    assert "  workflow_call:\n" not in root_workflow
     assert "uv run --locked --no-dev repo-check ." in root_workflow
-    assert "uvx \\" in root_workflow
     version = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
         "project"
     ]["version"]
@@ -409,9 +412,38 @@ def test_compliance_workflows_emit_an_independent_required_status() -> None:
         )
 
 
+@pytest.mark.parametrize("profile", STARTER_KIT_PROFILES)
+def test_documented_required_workflow_is_the_shape_the_kits_ship(profile: str) -> None:
+    """The prescribed shape and the shipped starter must not drift apart."""
+    starter = (
+        starter_kit_dir(profile) / ".github" / "workflows" / "compliance.yml"
+    ).read_text(encoding="utf-8")
+    documented = re.findall(
+        r"```yaml\n(.*?)```",
+        (REPO_ROOT / "docs" / "compliance.md").read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+
+    assert starter in documented
+
+
+def test_reusable_compliance_workflow_is_the_only_workflow_call_surface() -> None:
+    workflow_text = REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8")
+    workflow = load_yaml(workflow_text)
+
+    assert set(workflow["on"]) == {"workflow_call"}
+    assert set(workflow["on"]["workflow_call"]["inputs"]) == {
+        "standard-ref",
+        "strict",
+        "check-enforcement",
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    assert "  compliance:\n    name: compliance\n" in workflow_text
+    assert "uvx \\" in workflow_text
+
+
 def test_reusable_compliance_workflow_keeps_inputs_out_of_shell_source() -> None:
-    workflow_path = REPO_ROOT / ".github" / "workflows" / "compliance.yml"
-    workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow_text = REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8")
     workflow = load_yaml(workflow_text)
     run_step = next(
         step
@@ -432,9 +464,7 @@ def test_reusable_compliance_workflow_keeps_inputs_out_of_shell_source() -> None
 
 
 def test_reusable_compliance_workflow_validates_standard_ref() -> None:
-    workflow_text = (REPO_ROOT / ".github" / "workflows" / "compliance.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow_text = REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8")
 
     assert '[[ ! "$REPO_STANDARD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]' in workflow_text
     assert 'echo "Invalid repo-standard-kit ref" >&2' in workflow_text
@@ -444,16 +474,15 @@ def test_reusable_compliance_workflow_validates_standard_ref() -> None:
 
 @pytest.mark.parametrize(
     ("standard_ref", "expected_returncode"),
-    [("v1.2.0", 42), ("", 41)],
-    ids=["adopter-pull-request", "direct-pull-request"],
+    [("v1.2.0", 42), ("", 2), ("v1.2.0; rm -rf /", 2)],
+    ids=["released-ref", "empty-ref", "rejected-ref"],
 )
-def test_reusable_compliance_workflow_selects_the_correct_checker_environment(
+def test_reusable_compliance_workflow_runs_uvx_only_for_an_accepted_ref(
     tmp_path: Path,
     standard_ref: str,
     expected_returncode: int,
 ) -> None:
-    workflow_path = REPO_ROOT / ".github" / "workflows" / "compliance.yml"
-    workflow = load_yaml(workflow_path.read_text(encoding="utf-8"))
+    workflow = load_yaml(REUSABLE_COMPLIANCE_WORKFLOW.read_text(encoding="utf-8"))
     run = next(
         step["run"]
         for step in workflow["jobs"]["compliance"]["steps"]
@@ -472,20 +501,14 @@ def test_reusable_compliance_workflow_selects_the_correct_checker_environment(
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    for command, returncode in (("uv", 41), ("uvx", 42)):
-        stub = bin_dir / command
-        stub.write_text(
-            f"#!/usr/bin/env bash\nexit {returncode}\n",
-            encoding="utf-8",
-            newline="\n",
-        )
-        stub.chmod(0o755)
+    stub = bin_dir / "uvx"
+    stub.write_text("#!/usr/bin/env bash\nexit 42\n", encoding="utf-8", newline="\n")
+    stub.chmod(0o755)
 
     env = os.environ.copy()
     env.update(
         {
             "PATH": os.pathsep.join((str(bin_dir), env["PATH"])),
-            "GITHUB_EVENT_NAME": "pull_request",
             "REPO_STANDARD_REF": standard_ref,
             "STRICT": "false",
             "CHECK_ENFORCEMENT": "false",


### PR DESCRIPTION
Phase 9 of the v2.0.0 correction plan. Targets `chore/release-v2.0.0`, before
the tag.

## The rule

**RSK030 — Compliance workflow invokes the checker**, `required`, both
profiles, check kind `github_workflow_invocation`:

```yaml
path: .github/workflows/compliance.yml
job: compliance
token: repo-check
guards_by_profile:
  python-single: []
  python-workspace: []
```

The handler matches **containment**, not an exact argv: an executed command
satisfies the rule when its argument list contains the token policy names.
That is what lets `uvx --from "git+…@v2.0.0" repo-check .` and
`uv run --locked --no-dev repo-check .` both count, and it is why the rule's
rationale states plainly that a contrived command mentioning the token also
counts. The token lives in policy; a test asserts it does not appear in the
handler's source. Phase 4's `ShellCommand` is reused unchanged, so an
invocation reachable only under an undeclared condition does not satisfy the
rule; neither profile declares a permitted guard, and the mechanism is wired
rather than omitted.

## The split

- `.github/workflows/compliance.yml` — `on: pull_request` only, one unguarded
  `uv run --locked --no-dev repo-check .`. Job id, job name, `contents: read`
  and both SHA pins unchanged, so RSK027/028/029 keep passing untouched.
- `.github/workflows/compliance-reusable.yml` — `on: workflow_call` only, all
  three inputs, the ref allowlist validation, the args building, and no ref
  conditional. No rule reads this file's pins, so a test asserts them and its
  `contents: read` through the existing handlers.

## Documentation

`docs/compliance.md` now prescribes the uvx-direct shape, byte-identical to
what both starter kits ship (a test asserts the documented YAML block equals
the starter file). The reusable workflow is documented as a supported
alternative at its new path, with its trade-off and the pinning and
`standard-ref` guidance carried over. The unverified status-check naming
caveat is recorded there as unverified.

The three places stating that no rule checks the compliance job's commands —
`docs/quality-gates.md` §5, `docs/compliance.md` structural boundaries, and
RSK027's rationale — are corrected.

## Verification

- `uv run pre-commit run --all-files`, `uv run pytest` (445 passed),
  `uv run repo-check . --strict`, and regeneration with `git diff --exit-code`
  all pass.
- Freshly generated `python-single` and `python-workspace` repositories pass
  `repo-check` (only the pre-existing recommended RSK018 finding for the
  unselected licence; exit 0).
- Both negative cases were built from a generated repository and reported:
  a compliance job with no invocation, and one whose invocation sits under an
  undeclared guard.

Addresses #66.
