### PR TITLE
fix: index docs/compliance.md as a normative companion document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,9 @@ the changes listed under **Adopters must**.
   than restating them.
 - Both starter kits pinned the same action at two different versions across
   `quality.yml` and `compliance.yml`; the pins now agree.
+- `docs/compliance.md` issued `SHALL` requirements while absent from the
+  companion-document index, so a document declared non-normative was issuing
+  requirements; it is now indexed in `docs/repo-standard.md`.
 
 ### Adopters must
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ This repository provides:
 [docs/repo-standard.md](docs/repo-standard.md) is the normative entry point. It
 states the contract a repository must satisfy and indexes the companion
 documents covering quality gates, the agent operating model, Git workflow,
-repository layout, bootstrapping, compliance checking, and the Python
-profiles.
+repository layout, bootstrapping, compliance checking, and the Python profiles.
 
 Templates and starter kits implement that standard; the documents it indexes
 define the intent and rules.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This repository provides:
 [docs/repo-standard.md](docs/repo-standard.md) is the normative entry point. It
 states the contract a repository must satisfy and indexes the companion
 documents covering quality gates, the agent operating model, Git workflow,
-repository layout, bootstrapping, and the Python profiles.
+repository layout, bootstrapping, compliance checking, and the Python
+profiles.
 
 Templates and starter kits implement that standard; the documents it indexes
 define the intent and rules.

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -109,6 +109,7 @@ including its `README.md`, templates, and starter kits, implements them.
 - `docs/git-workflow.md`: branching, collaboration, and history rules
 - `docs/repo-layout.md`: canonical directory layout and scope boundaries
 - `docs/bootstrap-workflow.md`: how new repositories are generated
+- `docs/compliance.md`: how `repo-check` evaluates and reports compliance
 - `docs/policy-reference.md#profiles`: the supported profiles and their
   canonical detection metadata
 

--- a/templates/content/README/overview.kit.md
+++ b/templates/content/README/overview.kit.md
@@ -30,8 +30,7 @@ This repository provides:
 [docs/repo-standard.md](docs/repo-standard.md) is the normative entry point. It
 states the contract a repository must satisfy and indexes the companion
 documents covering quality gates, the agent operating model, Git workflow,
-repository layout, bootstrapping, compliance checking, and the Python
-profiles.
+repository layout, bootstrapping, compliance checking, and the Python profiles.
 
 Templates and starter kits implement that standard; the documents it indexes
 define the intent and rules.

--- a/templates/content/README/overview.kit.md
+++ b/templates/content/README/overview.kit.md
@@ -30,7 +30,8 @@ This repository provides:
 [docs/repo-standard.md](docs/repo-standard.md) is the normative entry point. It
 states the contract a repository must satisfy and indexes the companion
 documents covering quality gates, the agent operating model, Git workflow,
-repository layout, bootstrapping, and the Python profiles.
+repository layout, bootstrapping, compliance checking, and the Python
+profiles.
 
 Templates and starter kits implement that standard; the documents it indexes
 define the intent and rules.


### PR DESCRIPTION
Part of #70

## Why

`docs/repo-standard.md` declares the complete normative set and lists six
companion documents, stating that everything else in the repo — including
this repository's own README, templates, and starter kits — merely
*implements* them. `docs/compliance.md` was not in that list, yet it issued
requirements using the normative keywords `docs/repo-standard.md` defines
(`docs/compliance.md:82,151,184`). A document declared non-normative cannot
issue requirements.

## Changes

- Add `docs/compliance.md` to the companion index in
  `docs/repo-standard.md`'s `## Required Companion Documents` section, in the
  established voice of its neighbours. It plainly owns the compliance
  surface, so the `SHALL`s become legitimate.
- Update the `templates/content/README/overview.kit.md` fragment, which
  enumerates the companion documents by topic, to mention compliance
  checking, and regenerate `README.md` from it (`README.md` is generated;
  the fragment is the source of truth).
- Add a `CHANGELOG.md` entry under `## [2.0.0]` → `### Fixed`.

No contradiction was found between `docs/compliance.md` and
`docs/repo-standard.md` or `docs/quality-gates.md`: the three SHALL
statements restate obligations that `docs/quality-gates.md` already places on
RSK021/RSK028/RSK029/RSK030 in compatible terms (e.g. "full commit SHA" vs.
quality-gates.md's "full 40-character commit SHA"), not conflicting ones.

No test or policy rule enumerates the companion-document list, and no
`policy/base.yaml` rule cites `docs/compliance.md` as a `source.document`, so
adding it to the index has no other interactions.

## Verification

`git grep -nE "\b(SHALL|MUST)\b" -- docs/` returns hits only in
`docs/compliance.md`, `docs/policy-reference.md`, `docs/quality-gates.md`,
and `docs/repo-standard.md` — all now named by the index (or, for
`repo-standard.md`, the entry point itself).

Gates: `uv sync --locked`, `uv run pre-commit run --all-files`,
`uv run pytest` (445 passed), `uv build`, and `uv run repo-check . --strict`
all pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
