### PR TITLE
fix: widen uv_build pin and derive root pyproject assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@ the changes listed under **Adopters must**.
 
 ### Changed
 
+- **The shipped `uv_build` pin widens from `>=0.11.20,<0.12` to `>=0.12.5,<0.13`**
+  so `uv build` no longer warns against current `uv` releases; this reaches
+  every repository `repo-init` creates and every package `repo-add-package`
+  adds.
 - **The standard major moves to `2`.** Every adopting repository must declare
   `standard = "2"` under `[tool.repo-standard]`; `standard = "1"` is now an
   RSK019 required finding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.20,<0.12"]
+requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/src/repo_standard/bootstrap_defaults.py
+++ b/src/repo_standard/bootstrap_defaults.py
@@ -6,4 +6,4 @@ dependency version pin.
 """
 
 DEFAULT_PYTHON_VERSION = "3.12"
-DEFAULT_UV_BUILD_REQUIREMENT = "uv_build>=0.11.20,<0.12"
+DEFAULT_UV_BUILD_REQUIREMENT = "uv_build>=0.12.5,<0.13"

--- a/src/repo_standard/starter_kits/python-single/pyproject.toml
+++ b/src/repo_standard/starter_kits/python-single/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.20,<0.12"]
+requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -546,7 +546,7 @@ def test_root_pyproject_uses_uv_build_backend() -> None:
     pyproject_text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
         encoding="utf-8"
     )
-    assert 'requires = ["uv_build>=0.11.20,<0.12"]' in pyproject_text
+    assert f'requires = ["{DEFAULT_UV_BUILD_REQUIREMENT}"]' in pyproject_text
     assert 'build-backend = "uv_build"' in pyproject_text
     assert 'module-name = "repo_standard"' in pyproject_text
     assert "source-exclude" in pyproject_text


### PR DESCRIPTION
Part of #69

## What changed

1. **Widened the shipped `uv_build` build-system pin** from `>=0.11.20,<0.12`
   to `>=0.12.5,<0.13`, mirroring the original authoring pattern (floor at the
   current release, cap at the next minor boundary). `0.12.5` is confirmed on
   PyPI and matches the installed `uv 0.12.5` exactly.
   - `src/repo_standard/bootstrap_defaults.py:9` — canonical constant
     `DEFAULT_UV_BUILD_REQUIREMENT`.
   - `pyproject.toml:35` and
     `src/repo_standard/starter_kits/python-single/pyproject.toml:22` — mirrored.
2. **Fixed the SSOT violation that let it go stale.**
   `test_root_pyproject_uses_uv_build_backend` in `tests/test_repo_init.py:549`
   asserted the hardcoded literal instead of deriving it from
   `DEFAULT_UV_BUILD_REQUIREMENT`, so the root manifest and its guarding test
   held the same copy and drifted together while the suite stayed green. It
   now asserts `f'requires = ["{DEFAULT_UV_BUILD_REQUIREMENT}"]'`, matching
   the pattern already used at `tests/test_repo_init.py:333`.
   - Verified this actually has teeth: temporarily changed the root
     `pyproject.toml` requirement to disagree with the constant, confirmed
     `test_root_pyproject_uses_uv_build_backend` fails, then reverted.
3. One `CHANGELOG.md` line under `## [2.0.0]` → `### Changed` (adopter-visible:
   every repo `repo-init` creates and every package `repo-add-package` adds
   ships this constraint).

`tests/test_compliance.py` and `tests/test_repo_adopt.py` also contain the old
literal, but only as inline fixture data for synthetic test repos (not
asserting the canonical value), so left as-is per the issue's scope.

## Quality gates — all pass

```
$ uv sync --locked
Resolved 39 packages in 1ms
   Building repo-standard-kit @ file:///.../repo-standard-kit
      Built repo-standard-kit @ file:///.../repo-standard-kit
Prepared 1 package in 20ms
Uninstalled 1 package in 2ms
Installed 1 package in 42ms
 ~ repo-standard-kit==2.0.0 (from file:///.../repo-standard-kit)
```

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
check toml...............................................................Passed
check json...............................................................Passed
trim trailing whitespace.................................................Passed
fix final newline........................................................Passed
check merge conflict markers.............................................Passed
detect private keys......................................................Passed
detect secrets...........................................................Passed
prevent oversized files..................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
ty check.................................................................Passed
markdown lint............................................................Passed
```

```
$ uv run pytest
============================= test session starts =============================
collected 445 items
...
============================ 445 passed in 13.70s =============================
```

```
$ uv build
Building source distribution...
Building wheel from source distribution...
Successfully built dist\repo_standard_kit-2.0.0.tar.gz
Successfully built dist\repo_standard_kit-2.0.0-py3-none-any.whl
```

No `does not contain the current uv version` warning — the acceptance
criterion.

```
$ uv run repo-check . --strict
All checks passed!
```

Not merging — targeting `chore/release-v2.0.0` per issue instructions.