### PR TITLE
docs: state the new-repository flow once and name generate_docs.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,8 @@ end in a temporary directory, on every platform.
 - `src/repo_standard/policy/`: strict models and compiled runtime policy
 - `src/repo_standard/compliance/`: the `repo-check` dispatcher and handlers; see
   `docs/compliance.md`
-- `scripts/`: developer scripts, including `generate_policy.py`
+- `scripts/`: developer scripts — `generate_policy.py` compiles the canonical
+  policy, `generate_docs.py` renders every governed Markdown document
 - `tests/`: automated tests
 - `docs/`: normative standards
 - `policy/`: canonical machine-enforced policy and profile detection metadata

--- a/README.md
+++ b/README.md
@@ -119,14 +119,10 @@ a real `LICENSE` and declare it in `pyproject.toml`. Without it the repository
 starts with no licence file and a `License` section saying terms have not been
 chosen, which RSK018 keeps reporting as a recommendation until they are.
 
-Then:
-
-1. Review the generated `AGENTS.md`, `README.md`, and CI workflow.
-2. Run the quality gates in the generated repository.
-3. Make the initial commit on `main`.
-
-See [docs/bootstrap-workflow.md](docs/bootstrap-workflow.md) for the full
-option reference and the expected generated output.
+The golden path in
+[docs/bootstrap-workflow.md](docs/bootstrap-workflow.md#recommended-new-repository-flow)
+states what to do after generation, along with the full option reference and
+the expected generated output.
 
 ### Add A Package To A Workspace
 
@@ -200,7 +196,8 @@ uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git@v2.0.0" r
 - `src/repo_standard/`: packaged bootstrap implementation
 - `src/repo_standard/policy/`: strict policy models and compiled runtime policy
 - `src/repo_standard/starter_kits/`: copyable repository skeletons
-- `scripts/`: developer scripts, including `generate_policy.py`
+- `scripts/`: developer scripts — `generate_policy.py` compiles the canonical
+  policy, `generate_docs.py` renders every governed Markdown document
 - `tests/`: automated tests
 
 For the layout the standard prescribes for *your* repository, see

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ a real `LICENSE` and declare it in `pyproject.toml`. Without it the repository
 starts with no licence file and a `License` section saying terms have not been
 chosen, which RSK018 keeps reporting as a recommendation until they are.
 
-The golden path in
+The golden path for your profile in
 [docs/bootstrap-workflow.md](docs/bootstrap-workflow.md#recommended-new-repository-flow)
 states what to do after generation, along with the full option reference and
 the expected generated output.

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -110,27 +110,12 @@ Do not clone the standards repository as the base of a product repository.
 
 ## Recommended New Repository Flow
 
-1. Run the initializer directly with `uvx`:
-
-   ```bash
-   uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git" repo-init --profile python-single --repo-name widget-service
-   ```
-
-   `uvx` is the short form of `uv tool run`. It installs the bootstrap package
-   from this standards repository into an isolated tool environment, then runs
-   the packaged `repo-init` command.
-
-2. Either create and enter an empty target directory, or run `repo-init` through
-   `uvx` from the parent directory with `--repo-name` so it creates the
-   repository folder for you.
-3. Run `repo-init` with the Python profile and repository metadata.
-4. Review generated `AGENTS.md`, `README.md`, package naming, and CI.
-5. Run the generated repository quality gates.
-6. Make the initial commit on `main`.
-
-If the target directory is not yet a Git repository, `repo-init` initializes
-one automatically on `main` before installing pre-commit hooks. Add or change
-the remote afterward as needed.
+The flow is the golden path for your profile:
+[Golden Path: Single Package](#golden-path-single-package) or
+[Golden Path: Workspace](#golden-path-workspace). Both run the initializer
+directly with `uvx`, the short form of `uv tool run`. It installs the bootstrap
+package from this standards repository into an isolated tool environment, then
+runs the packaged `repo-init` command.
 
 For repeated use, install the tool once:
 
@@ -201,6 +186,9 @@ repo-add-package \
   --description "Service package for widget API behavior"
 ```
 
+Then continue from step 1 of the single-package path above; the steps after
+generation are the same.
+
 If you prefer HTTPS instead of SSH, use the same command shape with the HTTPS
 Git URL for this repository.
 
@@ -223,6 +211,13 @@ Optional:
 - `--no-lock`
 - `--no-install`
 
+By default, `repo-init` infers the repository name from the target directory.
+If you pass `--repo-name` without `--output-dir`, `repo-init` creates
+`./<repo-name>` and bootstraps into that new directory. If you pass both,
+`--output-dir` remains the explicit target and `--repo-name` overrides only the
+rendered repository metadata. Without `--description`, the generated files
+carry a placeholder description to refine later in `README.md`.
+
 `--python-version` sets `requires-python`, and `--author` becomes the
 `authors` entry in `pyproject.toml`; an unnamed author leaves the key out
 rather than shipping it empty.
@@ -241,6 +236,10 @@ constrained environment may permit one operation but not the other. `uv sync`
 writes `uv.lock` when none exists, so `--no-lock` on its own still leaves a
 lock file behind. Whenever bootstrap ends with no `uv.lock`, `repo-init` names
 RSK009 and the `uv lock` command that resolves it.
+
+When the target is not yet a Git repository, `repo-init` initializes one on
+`main` before installing pre-commit hooks, so hook installation works in a
+fresh directory. Add or change the remote afterward as needed.
 
 ## Expected Output
 
@@ -309,30 +308,20 @@ Each later `repo-add-package --package-name widget_api` run adds:
 
 ### What Good Looks Like
 
+Accept the generated repository on what generation itself decided. Everything
+else it must satisfy is the standard, so leave that to `repo-check` and
+[docs/policy-reference.md](policy-reference.md) rather than restating rule
+values here.
+
 - No unresolved placeholders remain in generated files
 - The package directory matches the requested package name
 - `AGENTS.md` is concrete enough to use immediately, with no generic filler
-- The repository passes the full `docs/quality-gates.md` chain, which needs the
-  `uv.lock` the default path produces
-- `[tool.repo-standard]` declares the generated profile and standard major
-- Both workflows grant only `contents: read` and pin remote actions to full
-  commit SHAs; Dependabot is configured to propose GitHub Actions updates
-- Separate `quality` and `compliance` status checks run on pull requests and
-  are suitable for branch-protection enforcement
+- `repo-check .` reports no required findings, and the full
+  `docs/quality-gates.md` chain passes on the `uv.lock` the default path
+  produces
 
 The generated compliance workflow runs the released checker through `uvx` in
 an isolated tool environment. It does not add `repo-standard-kit` to the new
 repository's dependencies or couple compliance to the generated `uv.lock`.
 See [Compliance Checking](compliance.md) for the equivalent reusable-workflow
 caller and its immutable workflow pin.
-
-By default, `repo-init` infers the repository name from the target directory.
-If you pass `--repo-name` without `--output-dir`, `repo-init` creates
-`./<repo-name>` and bootstraps into that new directory. If you pass both,
-`--output-dir` remains the explicit target and `--repo-name` overrides only the
-rendered repository metadata.
-By default, `repo-init` uses a placeholder description that you can refine
-later in `README.md`.
-By default, `repo-init` also initializes Git on `main` when needed so hook
-installation works in a fresh directory. Use `--no-install` if you want
-bootstrap to stop before environment setup and hook installation.

--- a/templates/content/AGENTS/repository-layout.kit.md
+++ b/templates/content/AGENTS/repository-layout.kit.md
@@ -4,7 +4,8 @@
 - `src/repo_standard/policy/`: strict models and compiled runtime policy
 - `src/repo_standard/compliance/`: the `repo-check` dispatcher and handlers; see
   `docs/compliance.md`
-- `scripts/`: developer scripts, including `generate_policy.py`
+- `scripts/`: developer scripts — `generate_policy.py` compiles the canonical
+  policy, `generate_docs.py` renders every governed Markdown document
 - `tests/`: automated tests
 - `docs/`: normative standards
 - `policy/`: canonical machine-enforced policy and profile detection metadata

--- a/templates/content/README/repo-structure.kit.md
+++ b/templates/content/README/repo-structure.kit.md
@@ -6,7 +6,8 @@
 - `src/repo_standard/`: packaged bootstrap implementation
 - `src/repo_standard/policy/`: strict policy models and compiled runtime policy
 - `src/repo_standard/starter_kits/`: copyable repository skeletons
-- `scripts/`: developer scripts, including `generate_policy.py`
+- `scripts/`: developer scripts — `generate_policy.py` compiles the canonical
+  policy, `generate_docs.py` renders every governed Markdown document
 - `tests/`: automated tests
 
 For the layout the standard prescribes for *your* repository, see

--- a/templates/content/README/usage.kit.md
+++ b/templates/content/README/usage.kit.md
@@ -35,14 +35,10 @@ a real `LICENSE` and declare it in `pyproject.toml`. Without it the repository
 starts with no licence file and a `License` section saying terms have not been
 chosen, which RSK018 keeps reporting as a recommendation until they are.
 
-Then:
-
-1. Review the generated `AGENTS.md`, `README.md`, and CI workflow.
-2. Run the quality gates in the generated repository.
-3. Make the initial commit on `main`.
-
-See [docs/bootstrap-workflow.md](docs/bootstrap-workflow.md) for the full
-option reference and the expected generated output.
+The golden path in
+[docs/bootstrap-workflow.md](docs/bootstrap-workflow.md#recommended-new-repository-flow)
+states what to do after generation, along with the full option reference and
+the expected generated output.
 
 ### Add A Package To A Workspace
 

--- a/templates/content/README/usage.kit.md
+++ b/templates/content/README/usage.kit.md
@@ -35,7 +35,7 @@ a real `LICENSE` and declare it in `pyproject.toml`. Without it the repository
 starts with no licence file and a `License` section saying terms have not been
 chosen, which RSK018 keeps reporting as a recommendation until they are.
 
-The golden path in
+The golden path for your profile in
 [docs/bootstrap-workflow.md](docs/bootstrap-workflow.md#recommended-new-repository-flow)
 states what to do after generation, along with the full option reference and
 the expected generated output.


### PR DESCRIPTION
Part of #74.

## 6a — the new-repository flow is stated once

`docs/bootstrap-workflow.md` stated it three times and `README.md` a fourth.
The **Golden Path per profile** is the copy kept: it is the copy-pasteable one,
it is the only copy that covers both profiles, and it is the one the two other
copies were paraphrasing.

- `Recommended New Repository Flow` reduces to a pointer at the two golden
  paths, keeping only what was unique to it — the `uvx` explanation, the
  install-once command, the version pin, and the derivation note.
- The workspace golden path now says to continue from the single-package steps,
  so the pointer is honest for both profiles.
- `What Good Looks Like` earns a place as an acceptance checklist, not as a
  flow, so it stays in reduced form: the three outcomes generation itself
  decides, plus one line deferring to `repo-check` and the gate chain. The
  three bullets restating policy-owned rule values (workflow permissions, SHA
  pins, Dependabot, the two status checks, `[tool.repo-standard]`) are gone —
  `docs/policy-reference.md` owns those, and the paragraph above the list now
  says so.
- The trailing three ungrouped `By default, …` paragraphs fold into
  `## repo-init Inputs`. The Git-init note absorbs the duplicate of itself that
  sat under the old flow.
- The README's fourth copy becomes the same pointer, edited in
  `templates/content/README/usage.kit.md` and re-rendered.

## 6b — `scripts/` names both its scripts

`templates/content/README/repo-structure.kit.md` and
`templates/content/AGENTS/repository-layout.kit.md` now read
`generate_policy.py` compiles the canonical policy, `generate_docs.py` renders
every governed Markdown document. `README.md` and `AGENTS.md` are regenerated.

## Gates

| Gate | Result |
| --- | --- |
| `uv sync --locked` | pass |
| `uv run pre-commit run --all-files` | pass |
| `uv run pytest` | 445 passed |
| `uv build` | pass |
| `uv run repo-check . --strict` | All checks passed |

`uv run python scripts/generate_docs.py && git diff --exit-code` is clean after
the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
