### PR TITLE
refactor(policy): cap rule rationales at one register and enforce it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,10 +99,10 @@ the changes listed under **Adopters must**.
   Policy owns the token, and the match is containment rather than an exact
   command, because an adopter runs a released checker with `uvx` while this
   repository runs its own working tree with `uv run` — both correct. The claim
-  is correspondingly modest and its rationale says so: a contrived command
-  naming the token passes. Reusing RSK006's guard machinery, an invocation
-  reachable only under a condition policy does not declare does not count, and
-  neither profile declares one.
+  is correspondingly modest and section 5 of `docs/quality-gates.md` says so: a
+  contrived command naming the token passes. Reusing RSK006's guard machinery,
+  an invocation reachable only under a condition policy does not declare does
+  not count, and neither profile declares one.
 - **The `advisory` policy level**, below `recommended`: always reported, never
   blocking, not even under `--strict`. It exists for a rule that names a
   preferred value for a decision the normative prose leaves to the repository.
@@ -191,6 +191,14 @@ the changes listed under **Adopters must**.
 - Branch protection is queried once per run and cached on the check context,
   rather than once per rule, so two rules can no longer disagree because one
   round-trip flaked.
+- **A rule's `rationale` is now capped at 200 characters** by the policy
+  schema, so a policy author who writes an essay into `policy/base.yaml` gets a
+  `PolicyError` instead of a review comment. Every word of the field is
+  reproduced into `docs/policy-reference.md`, a catalogue meant to be scanned;
+  RSK026 through RSK030 are trimmed back to the one-or-two-sentence register
+  the other twenty-four rules already keep, and the limitation analysis RSK030
+  carried was already stated in section 5 of `docs/quality-gates.md`, which is
+  where it stays.
 
 ### Removed
 

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -414,7 +414,7 @@ Remediation: Order the declared pyproject tables as the pyproject shape declares
 - Enforcement: `structural`
 - Check kind: `agents_operating_dials`
 
-Rationale: Agent behaviour left to model defaults varies between runs and between repositories. Stating the calibration where agents already read their operating boundaries is what makes the work consistent across every repository adopting the standard.
+Rationale: Agent behaviour left to model defaults varies between runs and between repositories, which is the opposite of what a standard is for.
 
 Remediation: State each dial in the Agent Operating Mode section of AGENTS.md, in the declared order and at the declared level.
 
@@ -431,7 +431,7 @@ Remediation: State each dial in the Agent Operating Mode section of AGENTS.md, i
 - Enforcement: `structural`
 - Check kind: `path_exists`
 
-Rationale: The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims; RSK030 separately requires the job to invoke the checker.
+Rationale: The job that keeps the rest of the standard from drifting cannot itself go missing unnoticed. Existence is all this rule claims.
 
 Remediation: Add .github/workflows/compliance.yml with a compliance job that checks the repository against repo-standard-kit on pull requests.
 
@@ -443,7 +443,7 @@ Remediation: Add .github/workflows/compliance.yml with a compliance job that che
 - Enforcement: `structural`
 - Check kind: `github_workflow_permissions`
 
-Rationale: The compliance job reads the repository and reports on it. A write scope on the token that runs a checker fetched from outside the repository would let that fetched code change what it is auditing.
+Rationale: The compliance job only reads the repository and reports on it, so a write scope would let the checker it fetches from outside change what it is auditing.
 
 Remediation: Set the compliance job's effective permissions to exactly `contents: read`.
 
@@ -455,7 +455,7 @@ Remediation: Set the compliance job's effective permissions to exactly `contents
 - Enforcement: `structural`
 - Check kind: `github_workflow_pins`
 
-Rationale: The compliance workflow already executes code fetched from outside the repository, so a mutable action reference beside it is the widest unpinned surface the standard ships.
+Rationale: The compliance workflow executes code fetched from outside the repository, so an unpinned action beside it is the widest mutable surface the standard ships.
 
 Remediation: Pin every remote action and reusable workflow in the compliance workflow to a 40-character SHA.
 
@@ -467,7 +467,7 @@ Remediation: Pin every remote action and reusable workflow in the compliance wor
 - Enforcement: `structural`
 - Check kind: `github_workflow_invocation`
 
-Rationale: RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker on pull requests: a workflow that never triggers on one satisfies the other three while leaving the SHALL in section 5 unmet, so the trigger belongs to this claim rather than to a rule of its own. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.
+Rationale: An existing, least-privileged, fully pinned compliance workflow can still execute nothing. This rule requires the compliance job to run the checker on pull requests.
 
 Remediation: Trigger the compliance workflow on pull_request, and run repo-check from a step of its compliance job, unguarded or under a condition policy declares for the profile.
 

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -520,9 +520,7 @@ rules:
             scale: 5
     rationale: >-
       Agent behaviour left to model defaults varies between runs and between
-      repositories. Stating the calibration where agents already read their
-      operating boundaries is what makes the work consistent across every
-      repository adopting the standard.
+      repositories, which is the opposite of what a standard is for.
     remediation: >-
       State each dial in the Agent Operating Mode section of AGENTS.md, in the
       declared order and at the declared level.
@@ -541,9 +539,8 @@ rules:
         path: .github/workflows/compliance.yml
         path_type: file
     rationale: >-
-      The compliance job is what stops the rest of the standard from drifting,
-      so its absence has to be a finding of its own. Existence is all this rule
-      claims; RSK030 separately requires the job to invoke the checker.
+      The job that keeps the rest of the standard from drifting cannot itself
+      go missing unnoticed. Existence is all this rule claims.
     remediation: >-
       Add .github/workflows/compliance.yml with a compliance job that checks the
       repository against repo-standard-kit on pull requests.
@@ -564,9 +561,9 @@ rules:
         permissions:
           contents: read
     rationale: >-
-      The compliance job reads the repository and reports on it. A write scope
-      on the token that runs a checker fetched from outside the repository
-      would let that fetched code change what it is auditing.
+      The compliance job only reads the repository and reports on it, so a
+      write scope would let the checker it fetches from outside change what it
+      is auditing.
     remediation: >-
       Set the compliance job's effective permissions to exactly `contents: read`.
 
@@ -583,9 +580,9 @@ rules:
       config:
         path: .github/workflows/compliance.yml
     rationale: >-
-      The compliance workflow already executes code fetched from outside the
-      repository, so a mutable action reference beside it is the widest
-      unpinned surface the standard ships.
+      The compliance workflow executes code fetched from outside the
+      repository, so an unpinned action beside it is the widest mutable surface
+      the standard ships.
     remediation: >-
       Pin every remote action and reusable workflow in the compliance workflow
       to a 40-character SHA.
@@ -609,20 +606,9 @@ rules:
           python-single: []
           python-workspace: []
     rationale: >-
-      RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants
-      only contents: read, and pins every action free to execute nothing. This
-      rule requires the job to run the checker on pull requests: a workflow
-      that never triggers on one satisfies the other three while leaving the
-      SHALL in section 5 unmet, so the trigger belongs to this claim rather
-      than to a rule of its own. It matches by containment
-      rather than by exact command because the same correct invocation is
-      spelled differently in different repositories, so the guarantee is
-      correspondingly weak: it proves that an executed command's argument list
-      carries the token policy names, not that the command is a genuine
-      compliance run, and a contrived command mentioning the token satisfies
-      it. What it does exclude is a token appearing only in a comment, which
-      the shell lexer discards, and an invocation reachable only under a
-      condition policy does not declare for the profile.
+      An existing, least-privileged, fully pinned compliance workflow can still
+      execute nothing. This rule requires the compliance job to run the checker
+      on pull requests.
     remediation: >-
       Trigger the compliance workflow on pull_request, and run repo-check from
       a step of its compliance job, unguarded or under a condition policy

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -767,7 +767,7 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "Agent behaviour left to model defaults varies between runs and between repositories. Stating the calibration where agents already read their operating boundaries is what makes the work consistent across every repository adopting the standard.",
+      "rationale": "Agent behaviour left to model defaults varies between runs and between repositories, which is the opposite of what a standard is for.",
       "remediation": "State each dial in the Agent Operating Mode section of AGENTS.md, in the declared order and at the declared level.",
       "source": {
         "document": "docs/repo-standard.md",
@@ -790,7 +790,7 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "The compliance job is what stops the rest of the standard from drifting, so its absence has to be a finding of its own. Existence is all this rule claims; RSK030 separately requires the job to invoke the checker.",
+      "rationale": "The job that keeps the rest of the standard from drifting cannot itself go missing unnoticed. Existence is all this rule claims.",
       "remediation": "Add .github/workflows/compliance.yml with a compliance job that checks the repository against repo-standard-kit on pull requests.",
       "source": {
         "document": "docs/quality-gates.md",
@@ -816,7 +816,7 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "The compliance job reads the repository and reports on it. A write scope on the token that runs a checker fetched from outside the repository would let that fetched code change what it is auditing.",
+      "rationale": "The compliance job only reads the repository and reports on it, so a write scope would let the checker it fetches from outside change what it is auditing.",
       "remediation": "Set the compliance job's effective permissions to exactly `contents: read`.",
       "source": {
         "document": "docs/quality-gates.md",
@@ -838,7 +838,7 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "The compliance workflow already executes code fetched from outside the repository, so a mutable action reference beside it is the widest unpinned surface the standard ships.",
+      "rationale": "The compliance workflow executes code fetched from outside the repository, so an unpinned action beside it is the widest mutable surface the standard ships.",
       "remediation": "Pin every remote action and reusable workflow in the compliance workflow to a 40-character SHA.",
       "source": {
         "document": "docs/quality-gates.md",
@@ -867,7 +867,7 @@
         "python-single",
         "python-workspace"
       ],
-      "rationale": "RSK027, RSK028 and RSK029 leave a compliance workflow that exists, grants only contents: read, and pins every action free to execute nothing. This rule requires the job to run the checker on pull requests: a workflow that never triggers on one satisfies the other three while leaving the SHALL in section 5 unmet, so the trigger belongs to this claim rather than to a rule of its own. It matches by containment rather than by exact command because the same correct invocation is spelled differently in different repositories, so the guarantee is correspondingly weak: it proves that an executed command's argument list carries the token policy names, not that the command is a genuine compliance run, and a contrived command mentioning the token satisfies it. What it does exclude is a token appearing only in a comment, which the shell lexer discards, and an invocation reachable only under a condition policy does not declare for the profile.",
+      "rationale": "An existing, least-privileged, fully pinned compliance workflow can still execute nothing. This rule requires the compliance job to run the checker on pull requests.",
       "remediation": "Trigger the compliance workflow on pull_request, and run repo-check from a step of its compliance job, unguarded or under a condition policy declares for the profile.",
       "source": {
         "document": "docs/quality-gates.md",

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -32,6 +32,13 @@ SECTION_LEVELS = {"required", "optional"}
 # names a shape always dispatches to the handler built for that shape's kind.
 SHAPE_KINDS = {"markdown_shape", "toml_table_order"}
 MARKDOWN_SHAPE_KINDS = {"markdown_shape"}
+# A rationale says why a rule exists in one or two sentences, because every word
+# of it is reproduced into a catalogue that is scanned rather than read. Two
+# lines at the 88-column prose width this standard recommends is about 176
+# characters; the ceiling rounds that up. Limitation analysis and design
+# argument belong in the normative document the rule already cites as its
+# source, and drift back into an essay fails here rather than at review.
+RATIONALE_MAX_LENGTH = 200
 
 # Each check kind owns its accepted configuration keys. Required keys are the
 # first set; optional keys are the second. Value-level validation follows in
@@ -91,9 +98,17 @@ def _mapping(value: Any, location: str) -> dict[str, Any]:
     return value
 
 
-def _string(value: Any, location: str, *, non_empty: bool = True) -> str:
+def _string(
+    value: Any,
+    location: str,
+    *,
+    non_empty: bool = True,
+    max_length: int | None = None,
+) -> str:
     if not isinstance(value, str) or (non_empty and not value.strip()):
         _fail(location, "expected a non-empty string")
+    if max_length is not None and len(value) > max_length:
+        _fail(location, f"expected at most {max_length} characters, got {len(value)}")
     return value
 
 
@@ -522,7 +537,11 @@ class Rule:
             source=Source.from_data(data["source"], f"{location}.source"),
             enforcement=enforcement,
             check=Check.from_data(data["check"], f"{location}.check"),
-            rationale=_string(data["rationale"], f"{location}.rationale"),
+            rationale=_string(
+                data["rationale"],
+                f"{location}.rationale",
+                max_length=RATIONALE_MAX_LENGTH,
+            ),
             remediation=_string(data["remediation"], f"{location}.remediation"),
         )
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -32,7 +32,11 @@ from repo_standard.policy import (
     load_source_policy,
 )
 from repo_standard.policy.compiler import render_compiled, render_reference
-from repo_standard.policy.models import CHECK_SCHEMAS, LEVELS
+from repo_standard.policy.models import (
+    CHECK_SCHEMAS,
+    LEVELS,
+    RATIONALE_MAX_LENGTH,
+)
 from repo_standard.repo_init import bootstrap_repo
 
 POLICY = load_policy()
@@ -251,6 +255,23 @@ def test_invalid_policy_is_rejected(
     root = _policy_checkout(tmp_path)
     _mutate_base(root, mutation)
     with pytest.raises(PolicyError, match=message):
+        load_source_policy(root)
+
+
+def test_an_over_long_rationale_is_rejected(tmp_path: Path) -> None:
+    """The rationale register is a ceiling in the schema, not a review habit."""
+    root = _policy_checkout(tmp_path)
+
+    def mutation(data: dict[str, object]) -> None:
+        rules = data["rules"]
+        assert isinstance(rules, list)
+        rules[0]["rationale"] = "Why the rule exists. " * 20
+
+    _mutate_base(root, mutation)
+    with pytest.raises(
+        PolicyError,
+        match=rf"rationale: expected at most {RATIONALE_MAX_LENGTH} characters",
+    ):
         load_source_policy(root)
 
 


### PR DESCRIPTION
Part of #71.

## What

`policy/base.yaml` rationales ranged from 51 characters (RSK001) to 944
(RSK030), and every word is reproduced verbatim into
`docs/policy-reference.md` — the catalogue meant to be *scanned*. Five rules
had drifted out of the register the other twenty-four keep.

- **Trimmed** RSK026, RSK027, RSK028, RSK029, RSK030 to one or two sentences
  stating why the rule exists. The whole set is now 51–165 characters.
- **Enforced it**: `RATIONALE_MAX_LENGTH = 200` in
  `src/repo_standard/policy/models.py`, applied through the existing `_string`
  helper (a new `max_length` keyword, matching the existing `non_empty` one)
  rather than a parallel validator. A test proves an over-long rationale is
  rejected.
- **Regenerated** `src/repo_standard/policy/compiled.json` and
  `docs/policy-reference.md`.

## Nothing was deleted that was not already stated elsewhere

RSK030's limitation analysis is honest and load-bearing, so it was checked
claim by claim against `docs/quality-gates.md` §5 before being cut. All six of
its claims already stand there:

| RSK030 rationale claim | Where it already lives in §5 |
| --- | --- |
| the other three rules leave the workflow free to execute nothing | "the other three are satisfied by a workflow no pull request ever starts" |
| the trigger belongs to this rule | "The trigger belongs to this rule because…" |
| containment, not exact command, because spellings differ | "an adopter runs a released checker with `uvx` while this standards repository runs its own working tree with `uv run`, and both are correct" |
| the guarantee is weak — naming the token is not a genuine run | "it cannot tell a real compliance run from a command that merely names the token" |
| a token in a comment is excluded | "It does exclude a token that appears solely in a comment, which the shell lexer discards." |
| an undeclared guard leaves it unproven | "The guard semantics above apply unchanged, and no profile declares a permitted guard for this rule" |

So `docs/quality-gates.md` is **unchanged**: moving the prose would have
created the exact duplication this repo forbids. The same check was applied to
RSK026 (its argument is in `docs/repo-standard.md` § Agent Operating Mode) and
RSK027 (§5 already states that RSK027 requires existence and RSK030 requires
invocation).

## Before / after

**RSK030** — 944 → 165 characters:

> **Before:** RSK027, RSK028 and RSK029 leave a compliance workflow that
> exists, grants only contents: read, and pins every action free to execute
> nothing. This rule requires the job to run the checker on pull requests: a
> workflow that never triggers on one satisfies the other three while leaving
> the SHALL in section 5 unmet, so the trigger belongs to this claim rather
> than to a rule of its own. It matches by containment rather than by exact
> command because the same correct invocation is spelled differently in
> different repositories, so the guarantee is correspondingly weak: it proves
> that an executed command's argument list carries the token policy names, not
> that the command is a genuine compliance run, and a contrived command
> mentioning the token satisfies it. What it does exclude is a token appearing
> only in a comment, which the shell lexer discards, and an invocation
> reachable only under a condition policy does not declare for the profile.

> **After:** An existing, least-privileged, fully pinned compliance workflow
> can still execute nothing. This rule requires the compliance job to run the
> checker on pull requests.

**RSK026** — 242 → 133 characters:

> **Before:** Agent behaviour left to model defaults varies between runs and
> between repositories. Stating the calibration where agents already read
> their operating boundaries is what makes the work consistent across every
> repository adopting the standard.

> **After:** Agent behaviour left to model defaults varies between runs and
> between repositories, which is the opposite of what a standard is for.

## Why 200

The register is one or two sentences. Two wrapped lines at the 88-column prose
width this standard recommends is about 176 characters, so 200 rounds that up.
It sits 35 characters above the longest surviving rationale (RSK030, 165) and
rejects every essay in the pre-trim set, including RSK029's old 173 — so the
ceiling bites on the register rather than only on the one extreme outlier.

## Remediation fields

Surveyed; none trimmed. The longest is 166 characters (RSK030) and every one
of them is an actionable instruction rather than an argument, which is what
`remediation` is for.

## Gates

| Gate | Result |
| --- | --- |
| `uv sync --locked` | pass |
| `uv run pre-commit run --all-files` | pass (13 hooks) |
| `uv run pytest` | 446 passed |
| `uv build` | sdist + wheel `2.0.0` |
| `uv run repo-check . --strict` | All checks passed |

`uv run python scripts/generate_policy.py && git diff --exit-code` is clean
after the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
