### PR TITLE
fix: guard pin drift across every workflow and run repo-check once in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  # The pins this repository hands to adopters live inside the starter kits, and
+  # Dependabot only expands `directory: /` into `.github/workflows`. Every other
+  # directory is scanned as-is, so each starter kit registers its workflow
+  # directory itself.
+  - package-ecosystem: github-actions
+    directory: /src/repo_standard/starter_kits/python-single/.github/workflows
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /src/repo_standard/starter_kits/python-workspace/.github/workflows
+    schedule:
+      interval: weekly

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
 
+      # repo-check runs once in CI, in the independently required compliance
+      # status. The hook stays for local feedback before push.
       - name: Run pre-commit
+        env:
+          SKIP: repo-check
         run: uv run pre-commit run --all-files
 
       - name: Run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,12 @@ repos:
         # policy/shapes.yaml. Linting them as standalone files reports MD041 on
         # every one. The rendered documents they produce are linted normally.
         exclude: ^templates/content/
+      # Adopters pin the published hook to a release. This repository is the
+      # release, so it checks its own working tree — the same invocation its
+      # compliance workflow runs. CI skips it there; see .github/workflows.
+      - id: repo-check
+        name: repo-check
+        entry: uv run repo-check .
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,32 @@ the changes listed under **Adopters must**.
   the other twenty-four rules already keep, and the limitation analysis RSK030
   carried was already stated in section 5 of `docs/quality-gates.md`, which is
   where it stays.
+- **Action pins are now compared across every governed workflow.** The
+  agreement check applied to the three `compliance.yml` files only, so a
+  Dependabot bump to the root `quality.yml` could leave both starter kits'
+  `quality.yml` on the previous SHA with the suite still green. One helper now
+  collects the pins from all five files — root `quality`, root `compliance`,
+  `compliance-reusable`, and both kits' pair — and every remote action must
+  resolve to a single SHA across them. `.github/dependabot.yml` also registers
+  each starter kit's workflow directory, because `directory: /` is the only
+  value Dependabot expands into `.github/workflows`; every other value is
+  scanned as given, so the kits' pins were never being offered updates at all.
+- **`repo-check` runs once in CI, in `compliance`.** It previously ran twice in
+  an adopting repository: inside `quality` through
+  `uv run pre-commit run --all-files`, and again in `compliance`. One
+  structural defect turned both required statuses red, and neither said which
+  of the two it had failed on. The starter quality workflows now set
+  `SKIP: repo-check` on the pre-commit step. Nothing is weakened — `compliance`
+  is an independently required status, so the defect still blocks the merge,
+  from one place. The hook itself stays in both kits, for the local feedback it
+  was always the better tool for, and `docs/compliance.md` describes it that
+  way instead of calling the duplication intentional.
+- This repository configures the hook too, as a `repo: local` hook running
+  `uv run repo-check .` — the invocation its own compliance workflow uses.
+  Pinning a `rev:` would have checked the working tree against a published
+  release rather than against itself, which is why the kit shipped a hook its
+  own home did not run. Its `quality.yml` sets the same `SKIP: repo-check`, so
+  the rule the standard states holds here as well.
 
 ### Removed
 
@@ -329,6 +355,11 @@ to see what is left; the list below is what that repairs and what it cannot.
   `--strict` on this alone starts passing.
 - Nothing for `docs/diagrams/`. The starter kits and `repo-adopt` no longer
   create it; an existing directory is untouched and no rule references it.
+- Optionally add `env: {SKIP: repo-check}` to the pre-commit step of your
+  `.github/workflows/quality.yml`, so a structural defect fails `compliance`
+  alone rather than both required statuses. No rule requires it, and
+  `repo-adopt` leaves a pre-commit step it already matches untouched, so this
+  one is a hand edit.
 
 ## [1.2.0] - 2026-08-20
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -102,11 +102,11 @@ adopter calls a reusable workflow — nor on whether a ref input was supplied.
 Together with the `quality` job, this gives every adopting repository the same
 two required status names and therefore the same branch-protection ruleset.
 
-### Optional pre-commit feedback
+### Local pre-commit feedback
 
-The pre-commit hook provides earlier local feedback. When it is configured,
-the quality workflow repeats the structural check before the independently
-required compliance job; that defense-in-depth duplication is intentional.
+The pre-commit hook exists for local feedback: it reports a structural defect
+before the push rather than after the pull request opens. Both starter kits
+wire it in.
 
 ```yaml
 repos:
@@ -115,6 +115,19 @@ repos:
     hooks:
       - id: repo-check
 ```
+
+In CI the check runs once, in `compliance`. The starter quality workflows set
+`SKIP: repo-check` on the pre-commit step, because running every hook is itself
+a gate and would otherwise run the same check a second time. A single
+compliance defect would then turn both required statuses red, and neither
+status would say which of the two it failed on. Skipping the hook in
+`quality` weakens nothing: `compliance` is independently required, so the
+defect still blocks the merge, and it blocks it in exactly one place.
+
+This repository configures the hook as a `repo: local` hook running
+`uv run repo-check .`, the invocation its own compliance workflow uses. Pinning
+a `rev:` here would check the working tree against a published release rather
+than against itself.
 
 ### Required CI workflow
 

--- a/src/repo_standard/starter_kits/python-single/.github/workflows/quality.yml
+++ b/src/repo_standard/starter_kits/python-single/.github/workflows/quality.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
 
+      # repo-check runs once in CI, in the independently required compliance
+      # status. The hook stays for local feedback before push.
       - name: Run pre-commit
+        env:
+          SKIP: repo-check
         run: uv run pre-commit run --all-files
 
       - name: Run pytest

--- a/src/repo_standard/starter_kits/python-workspace/.github/workflows/quality.yml
+++ b/src/repo_standard/starter_kits/python-workspace/.github/workflows/quality.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
 
+      # repo-check runs once in CI, in the independently required compliance
+      # status. The hook stays for local feedback before push.
       - name: Run pre-commit
+        env:
+          SKIP: repo-check
         run: uv run pre-commit run --all-files
 
       - name: Run pytest

--- a/tests/test_repo_init.py
+++ b/tests/test_repo_init.py
@@ -7,6 +7,7 @@ import subprocess
 import tarfile
 import tomllib
 import zipfile
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
@@ -63,9 +64,36 @@ REUSABLE_COMPLIANCE_WORKFLOW = (
 
 STARTER_KIT_ROOT = Path("src") / "repo_standard" / "starter_kits"
 
+ACTION_PIN = re.compile(r"uses: ([^@\s]+)@([0-9a-f]{40})")
+
 
 def starter_kit_dir(profile: str) -> Path:
     return Path(__file__).resolve().parents[1] / STARTER_KIT_ROOT / profile
+
+
+def starter_workflow_dir(profile: str) -> Path:
+    return starter_kit_dir(profile) / ".github" / "workflows"
+
+
+GOVERNED_WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "quality.yml",
+    REPO_ROOT / ".github" / "workflows" / "compliance.yml",
+    REUSABLE_COMPLIANCE_WORKFLOW,
+    *(
+        starter_workflow_dir(profile) / name
+        for profile in STARTER_KIT_PROFILES
+        for name in ("quality.yml", "compliance.yml")
+    ),
+)
+
+
+def action_pins(paths: Iterable[Path]) -> dict[str, set[str]]:
+    """Map each pinned remote action to every SHA the given workflows pin it to."""
+    pins: dict[str, set[str]] = {}
+    for path in paths:
+        for action, sha in ACTION_PIN.findall(path.read_text(encoding="utf-8")):
+            pins.setdefault(action, set()).add(sha)
+    return pins
 
 
 def test_bootstrap_repo_renders_python_single_starter(tmp_path: Path) -> None:
@@ -352,20 +380,59 @@ def test_python_single_starter_build_requirement_matches_bootstrap_default() -> 
     assert data["build-system"]["requires"] == [DEFAULT_UV_BUILD_REQUIREMENT]
 
 
-def test_quality_workflows_use_mandatory_ci_gate_set() -> None:
-    repo_root = Path(__file__).resolve().parents[1]
-    workflow_paths = [
-        repo_root / ".github" / "workflows" / "quality.yml",
-        *(
-            starter_kit_dir(profile) / ".github" / "workflows" / "quality.yml"
-            for profile in STARTER_KIT_PROFILES
-        ),
-    ]
+QUALITY_WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "quality.yml",
+    *(
+        starter_workflow_dir(profile) / "quality.yml"
+        for profile in STARTER_KIT_PROFILES
+    ),
+)
 
-    for workflow_path in workflow_paths:
+
+def test_quality_workflows_use_mandatory_ci_gate_set() -> None:
+    for workflow_path in QUALITY_WORKFLOWS:
         workflow_text = workflow_path.read_text(encoding="utf-8")
         for command in MANDATORY_CI_COMMANDS:
             assert command in workflow_text
+
+
+def test_quality_workflows_leave_repo_check_to_the_compliance_status() -> None:
+    """Two required statuses failing on one defect cannot say which failed."""
+    for workflow_path in QUALITY_WORKFLOWS:
+        workflow = load_yaml(workflow_path.read_text(encoding="utf-8"))
+        step = next(
+            step
+            for step in workflow["jobs"]["quality"]["steps"]
+            if "pre-commit run" in str(step.get("run", ""))
+        )
+        assert step.get("env") == {"SKIP": "repo-check"}, workflow_path
+
+
+def test_governed_workflows_pin_each_action_to_a_single_sha() -> None:
+    """A bump to one workflow must not leave a sibling on the old pin."""
+    drifted = {
+        action: sorted(shas)
+        for action, shas in action_pins(GOVERNED_WORKFLOWS).items()
+        if len(shas) > 1
+    }
+
+    assert not drifted, f"action pins disagree across governed workflows: {drifted}"
+
+
+def test_dependabot_watches_every_workflow_directory_the_kit_ships() -> None:
+    """`directory: /` only expands to the root `.github/workflows`."""
+    config = load_yaml((REPO_ROOT / ".github" / "dependabot.yml").read_text("utf-8"))
+    watched = {
+        update["directory"]
+        for update in config["updates"]
+        if update["package-ecosystem"] == "github-actions"
+    }
+
+    expected = {"/"} | {
+        "/" + starter_workflow_dir(profile).relative_to(REPO_ROOT).as_posix()
+        for profile in STARTER_KIT_PROFILES
+    }
+    assert watched == expected
 
 
 def test_compliance_workflows_emit_an_independent_required_status() -> None:
@@ -378,27 +445,18 @@ def test_compliance_workflows_emit_an_independent_required_status() -> None:
         ),
     ]
 
-    checkout_refs: set[str] = set()
-    setup_uv_refs: set[str] = set()
     for workflow_path in workflow_paths:
         assert workflow_path.name == "compliance.yml"
         workflow_text = workflow_path.read_text(encoding="utf-8")
         assert "  pull_request:\n" in workflow_text
         assert "permissions:\n  contents: read\n" in workflow_text
         assert "  compliance:\n    name: compliance\n" in workflow_text
-        checkout_match = re.search(
-            r"uses: (actions/checkout@[0-9a-f]{40})", workflow_text
-        )
-        setup_uv_match = re.search(
-            r"uses: (astral-sh/setup-uv@[0-9a-f]{40})", workflow_text
-        )
-        assert checkout_match
-        assert setup_uv_match
-        checkout_refs.add(checkout_match.group(1))
-        setup_uv_refs.add(setup_uv_match.group(1))
-
-    assert len(checkout_refs) == 1
-    assert len(setup_uv_refs) == 1
+        # Agreement between files is a separate claim, made across every
+        # governed workflow rather than only these three.
+        assert set(action_pins([workflow_path])) == {
+            "actions/checkout",
+            "astral-sh/setup-uv",
+        }
 
     root_workflow = workflow_paths[0].read_text(encoding="utf-8")
     assert "  workflow_call:\n" not in root_workflow


### PR DESCRIPTION
Part of #73.

## 5a — pin drift

`test_compliance_workflows_emit_an_independent_required_status` compared pins
across the three `compliance.yml` files only, so a Dependabot bump to the root
`quality.yml` left both starter kits' `quality.yml` stale with a green suite.

- `action_pins()` in `tests/test_repo_init.py` collects every
  `uses: <action>@<sha>` pin from a set of workflows. The compliance test now
  uses it for the per-file claim (both actions present and SHA-pinned), and
  `test_governed_workflows_pin_each_action_to_a_single_sha` makes the agreement
  claim across all five governed files: root `quality`, root `compliance`,
  `compliance-reusable`, and both kits' pair.
- `.github/dependabot.yml` registers each starter kit's workflow directory.
  Dependabot expands `directory: /` into `.github/workflows`; every other value
  is scanned as given
  ([`github_actions/file_fetcher.rb`](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_fetcher.rb)
  sets `workflows_dir = "."` off the root), so the registered path is the
  workflows directory itself, not the kit root.
  `test_dependabot_watches_every_workflow_directory_the_kit_ships` derives the
  expected set from `STARTER_KIT_PROFILES`, so a third kit cannot be added
  without registering it.

`repo_adopt._merge_dependabot` needed no change: it merges the starter's
`.github/dependabot.yml` (still `directory: /` only, which is correct for an
adopter with no starter kits inside it) and keys on the
`(package-ecosystem, directory)` pair, so extra entries are already tolerated.

Proof the guard can fail — one SHA altered in the root `quality.yml`:

```
AssertionError: action pins disagree across governed workflows:
{'actions/checkout': ['0000000000000000000000000000000000000000',
                      '3d3c42e5aac5ba805825da76410c181273ba90b1']}
```

## 5b — repo-check runs once in CI

- The hook stays in both starter kits' `.pre-commit-config.yaml`.
- Both starter `quality.yml` files set `SKIP: repo-check` as step-level `env:`
  on `Run pre-commit`.
- This repository gains the hook as a `repo: local` hook running
  `uv run repo-check .` — the invocation its own `compliance.yml` already uses —
  and the same `SKIP` on its own `quality.yml`, so the principle holds here too.
- `docs/compliance.md` §`Local pre-commit feedback` replaces the
  "defense in depth is intentional" claim.

RSK006 and RSK007 are undisturbed: `uv run repo-check . --strict` passes here
with the extra hook and the `env:`, and a freshly bootstrapped repo from each
kit reports only the expected RSK009/RSK018 findings from `--no-lock` and no
licence — no RSK006, no RSK007. RSK006 reads
`jobs.quality.steps[*].run` (`_job_shell_commands`, `checks.py:601-618`) and
never looks at step `env`; RSK007 iterates the required hooks and asks whether
each has a match (`_pre_commit_hooks`, `checks.py:855-870`), so extras pass.

## Gates

`uv sync --locked`, `uv run pre-commit run --all-files`, `uv run pytest`
(449 passed), `uv build`, `uv run repo-check . --strict` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
