### PR TITLE
fix: accept any 0.12 uv_build backend, not just the newest patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,10 +112,15 @@ the changes listed under **Adopters must**.
 
 ### Changed
 
-- **The shipped `uv_build` pin widens from `>=0.11.20,<0.12` to `>=0.12.5,<0.13`**
+- **The shipped `uv_build` pin widens from `>=0.11.20,<0.12` to `>=0.12,<0.13`**
   so `uv build` no longer warns against current `uv` releases; this reaches
   every repository `repo-init` creates and every package `repo-add-package`
-  adds.
+  adds. The floor accepts any `0.12` backend rather than the newest patch
+  `uv init` would generate, so an adopter a few patches behind builds without
+  a warning too. The upper bound stays: `uv` documents it as what "ensures
+  that your package continues to build correctly as new versions are
+  released", and the backend follows `uv`'s own versioning policy, so a
+  `0.13` backend may read `[tool.uv.build-backend]` differently.
 - **The standard major moves to `2`.** Every adopting repository must declare
   `standard = "2"` under `[tool.repo-standard]`; `standard = "1"` is now an
   RSK019 required finding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.12.5,<0.13"]
+requires = ["uv_build>=0.12,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/src/repo_standard/bootstrap_defaults.py
+++ b/src/repo_standard/bootstrap_defaults.py
@@ -6,4 +6,4 @@ dependency version pin.
 """
 
 DEFAULT_PYTHON_VERSION = "3.12"
-DEFAULT_UV_BUILD_REQUIREMENT = "uv_build>=0.12.5,<0.13"
+DEFAULT_UV_BUILD_REQUIREMENT = "uv_build>=0.12,<0.13"

--- a/src/repo_standard/starter_kits/python-single/pyproject.toml
+++ b/src/repo_standard/starter_kits/python-single/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.12.5,<0.13"]
+requires = ["uv_build>=0.12,<0.13"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
Follow-up to #77 (A1), part of #68.

`uv init --build-backend uv` generates the newest patch as the floor, and #77 matched that: `uv_build>=0.12.5,<0.13`. The consequence is that `uv build` warns for anyone whose local `uv` is 0.12.0–0.12.4, because the warning fires when the local version falls outside `requires`. Nothing here needs a 0.12.5 backend specifically, so the floor moves to `>=0.12`.

**The upper bound stays.** `uv`'s build-backend documentation recommends `requires = ["uv_build>=0.12.5,<0.13"]` and states that "Including an upper bound on the `uv_build` version ensures that your package continues to build correctly as new versions are released." The backend follows `uv`'s own versioning policy, and this repository depends on backend-specific configuration (`module-name`, `source-include`, `source-exclude`), so an unbounded range would let a `0.13` backend change what the sdist and wheel contain with no change here.

Known consequence, recorded rather than hidden: the cap goes stale when `uv 0.13` ships, and every adopting repository starts warning again until the bound moves. That is the same recurrence #77 fixed, and it is the price of the guarantee the bound buys.

Changed in all three homes of the constant — `bootstrap_defaults.py` (canonical), the root manifest, and the `python-single` starter — plus the `## [2.0.0]` changelog entry, which described the release being tagged and would otherwise state a value that never shipped.

## Gates

| Gate | Result |
| --- | --- |
| `uv sync --locked` | pass |
| `uv run pre-commit run --all-files` | pass, 13 hooks |
| `uv run pytest` | 446 passed |
| `uv build` | pass, no version warning |
| `uv run repo-check . --strict` | All checks passed! |