### PR TITLE
feat(compliance): make checker output and exemptions self-evident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,23 @@ the changes listed under **Adopters must**.
 - Both starter kits ship a `.gitignore`, so a freshly bootstrapped repository
   no longer starts with `.venv/`, `__pycache__/`, and other build and cache
   paths committable.
+- **`repo-check --version`** prints the running package version and the
+  `standard_version` and standard major compiled into its policy. Adopters pin
+  the checker by Git ref, so the first question about a disputed finding —
+  which checker produced it — now has an answer.
+- **An exemption that suppressed nothing is reported.** A declared
+  `[tool.repo-check.ignore]` entry whose rule this run evaluated and passed
+  emits a finding against `pyproject.toml` with the new `status`
+  `unused-exemption`, at the rule's own level. `level` keeps naming how binding
+  the rule is and `status` names what the finding is, so neither field means
+  two things; only a `violation` can reach exit code `1`, which leaves a dead
+  exemption visible and never blocking. Text output now prints the status
+  beside the rule ID whenever it is not `violation`, so an `indeterminate`
+  platform finding is also no longer read as a plain failure. A rule the
+  profile excludes, or a platform rule under a run without
+  `--check-enforcement`, is not evaluated and is never reported this way.
+  `repo-adopt` reports the same finding and applies the same rule to its own
+  exit code.
 
 ### Changed
 
@@ -247,6 +264,17 @@ the changes listed under **Adopters must**.
 - `docs/compliance.md` issued `SHALL` requirements while absent from the
   companion-document index, so a document declared non-normative was issuing
   requirements; it is now indexed in `docs/repo-standard.md`.
+- **A failing RSK005 printed the whole document it read.** The handler passed
+  the searched text as the finding's `actual`, so a `README.md` missing its
+  standard reference arrived as one repr'd line thousands of characters long —
+  the clarity attribute breaking exactly where it fires. The pattern it wanted
+  is the evidence, and the finding now carries only that. RSK005 also gained
+  the negative-path coverage it never had, including the deliberate silence on
+  a missing document, which RSK001 and RSK004 own.
+- This repository's own `RSK005` exemption suppressed nothing — both
+  `README.md` and `AGENTS.md` name `repo-standard-kit` — and is deleted. The
+  `RSK011` exemption stays; the kit really does ship the placeholder tokens it
+  tests.
 
 ### Adopters must
 
@@ -320,7 +348,9 @@ to see what is left; the list below is what that repairs and what it cannot.
   repository in that state gains a required finding it did not have.
 - Stop reading `severity` from `repo-check --format json`. The field is gone.
   Read `level` for how binding a finding is, and `status` for `indeterminate`
-  results.
+  results. `status` now also carries `unused-exemption`, so treat it as an
+  open set rather than matching two literals; a consumer that keys the exit
+  decision off it should act on `violation` alone.
 - Stop importing `load_rules` from `repo_standard.compliance.checks`. The v0.4
   compatibility alias is gone; call `load_policy`.
 - Nothing for RSK015. It moved to the new `advisory` level, so a

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -19,11 +19,16 @@ Options:
   active rulesets for RSK014.
 - `--strict` promotes recommended findings to failures. It does not promote
   advisory findings.
+- `--version` prints the running `repo-check` package version and the
+  `standard_version` and standard major compiled into its policy, then exits.
+  Adopters pin the checker by Git ref, so this is how a disputed finding is
+  attributed to a revision.
 
 Exit code `0` means no blocking findings. Exit code `1` means a required rule
 failed, or a recommended rule failed under `--strict`. Exit code `2` is a
 usage or indeterminate command error, including an explicitly requested
-platform check whose evidence could not be obtained.
+platform check whose evidence could not be obtained. Only a finding whose
+`status` is `violation` can produce exit code `1`.
 
 Required findings fail by default. Recommended findings are always visible but
 fail only under `--strict`. Advisory findings are always visible and never
@@ -55,11 +60,27 @@ checks execute for the best deterministic profile.
 
 Every finding includes the rule ID, title, canonical level, path and line when
 available, message, actual value, expected value, remediation, and status.
-`level` is the sole name for how binding a finding is, and `status` reports
-`violation` or, for an unavailable platform command, `indeterminate`. The
-legacy `severity` field that restated `level` as `shall` or `should`, and an
-unavailable platform command as `platform`, is removed in v2; read `level` and
-`status` instead.
+`level` is the sole name for how binding the *rule* is, and `status` reports
+what *this* finding is:
+
+- `violation` — the rule failed. The only status that can reach exit code `1`.
+- `indeterminate` — an explicitly requested platform command produced no
+  usable evidence. Exit code `2`.
+- `unused-exemption` — the rule passed while an exemption for it was declared.
+  Reported below, and never blocking.
+
+`level` never changes to express one of these; a finding for a required rule
+reports `required` whatever its status. The legacy `severity` field that
+restated `level` as `shall` or `should`, and an unavailable platform command
+as `platform`, is removed in v2; read `level` and `status` instead.
+
+Text output prints the status beside the rule ID as `RSK012
+[unused-exemption]` whenever it is not `violation`, so the level column is
+never read as a failure that did not happen.
+
+`actual` is omitted where quoting it is not evidence: a rule that searches a
+whole document for a pattern reports the pattern it wanted, not the document
+it read.
 
 YAML and TOML parse failures report parser locations. Workflow findings report
 the relevant node line when the YAML parser exposes one.
@@ -70,12 +91,27 @@ The v2 exception shape remains deliberately small:
 
 ```toml
 [tool.repo-check.ignore]
-RSK005 = "This repository is the standard's own home."
+RSK012 = "This repository records decisions in its own decision log."
 ```
 
 Only a known rule ID with a non-empty string reason suppresses findings. Empty
 reasons, unknown IDs, malformed TOML, and non-string values suppress nothing.
 Owner, expiry, and reference metadata remain deferred.
+
+An exemption that suppressed nothing is reported. When a rule this run
+evaluated produced no finding and an exemption for it is declared, `repo-check`
+emits a finding against `pyproject.toml` with status `unused-exemption`, at the
+rule's own level, remediating to deleting the entry. It never affects the exit
+code: a dead exemption is information about the configuration, not a rule the
+repository broke. A rule the resolved profile excludes, and a platform rule
+under a run without `--check-enforcement`, are not evaluated and so are never
+reported this way.
+
+The report exists because an exemption is a claim, and a claim nothing
+exercises stops being reviewed. The `Single Source Of Truth` section every
+`AGENTS.md` carries requires one home per fact and treats deleting the stale
+copy as part of the change: an exemption that outlives the finding it was
+written for is a second, silently wrong statement about the repository.
 
 ## Consumption Surfaces
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ select = ["E", "F", "I", "B", "UP", "PT"]
 testpaths = ["tests"]
 
 [tool.repo-check.ignore]
-RSK005 = "repo-standard-kit is the standard's own home, not an adopting repository; asking it to link to itself is meaningless."
 RSK011 = "This repository defines, tests, and ships these placeholder tokens for repo-init's templating; they are not leftovers from an unfinished bootstrap."
 
 [tool.ty.src]

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -432,6 +432,15 @@ def _agents_operating_dials(
 
 
 def _text_pattern_each(context: CheckContext, config: dict[str, Any]) -> list[Issue]:
+    """Report each declared path whose text does not match the pattern.
+
+    A **missing** path yields no issue: the path's own existence rule owns
+    absence, and every path this kind reads is covered by one — RSK001 and
+    RSK004 today. Reporting absence here too would name one fact twice.
+
+    `actual` stays `None` deliberately. The searched text is the whole file,
+    and the message and `expected` already carry everything actionable.
+    """
     pattern = re.compile(config["pattern"])
     issues = []
     for relative in config["paths"]:
@@ -441,8 +450,7 @@ def _text_pattern_each(context: CheckContext, config: dict[str, Any]) -> list[Is
                 Issue(
                     relative,
                     f"{relative} does not match {pattern.pattern!r}.",
-                    text,
-                    pattern.pattern,
+                    expected=pattern.pattern,
                 )
             )
     return issues
@@ -1737,6 +1745,30 @@ def _load_ignore_config(root: Path, policy: Policy) -> dict[str, str]:
     }
 
 
+def _unused_exemption(rule: Rule) -> Finding:
+    """Report a declared exemption that suppressed nothing this run.
+
+    `level` stays the rule's canonical level, because that is the one thing
+    `level` names anywhere else; `status` carries what this line reports. The
+    status keeps it out of the exit code, so a dead exemption is visible
+    without becoming a failure.
+    """
+    return Finding(
+        rule.id,
+        rule.title,
+        rule.level,
+        "pyproject.toml",
+        None,
+        f"{rule.id} is exempted in [tool.repo-check.ignore] but suppressed no "
+        "finding this run.",
+        None,
+        None,
+        f"Delete the {rule.id} entry from [tool.repo-check.ignore], or keep it "
+        "only with a reason that says why it must outlive what it suppressed.",
+        "unused-exemption",
+    )
+
+
 def check_repo(
     root: Path,
     policy: Policy,
@@ -1748,14 +1780,22 @@ def check_repo(
     resolved_profile = resolve_profile(root, policy, profile)
     context = CheckContext(root=root, policy=policy, profile=resolved_profile)
     findings: list[Finding] = []
+    evaluated: set[str] = set()
     for rule in policy.rules:
         if resolved_profile not in rule.profiles:
             continue
         if rule.enforcement == "platform" and not include_platform:
             continue
+        evaluated.add(rule.id)
         handler = CHECK_HANDLERS[rule.check.kind]
         findings.extend(
             _finding(rule, issue) for issue in handler(context, rule.check.config)
         )
     ignored = _load_ignore_config(root, policy)
-    return [finding for finding in findings if finding.rule_id not in ignored]
+    kept = [finding for finding in findings if finding.rule_id not in ignored]
+    # Only a rule this run actually evaluated can be reported as suppressing
+    # nothing: a rule the profile excludes, or a platform rule nobody asked
+    # for, had no finding to suppress in the first place.
+    unused = (evaluated & set(ignored)) - {finding.rule_id for finding in findings}
+    kept.extend(_unused_exemption(policy.rule(rule_id)) for rule_id in sorted(unused))
+    return kept

--- a/src/repo_standard/compliance/cli.py
+++ b/src/repo_standard/compliance/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from repo_standard.compliance.checks import Finding, check_repo, load_policy
 from repo_standard.policy.models import DEFAULT_LEVELS, STRICT_LEVELS
+from repo_standard.project_metadata import kit_version
 
 _POSITIVE = "\033[38;2;35;209;111m"
 _RESET = "\033[0m"
@@ -42,6 +43,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Treat recommended findings as failures too. Advisory never fails.",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        # Adopters pin by Git ref, so a disputed finding starts with which
+        # checker ran and which compiled policy it carried.
+        version=(
+            f"repo-check {kit_version()} (standard {policy.standard_version}, "
+            f"standard major {policy.standard_major})"
+        ),
+        help="Print the checker and compiled standard versions, then exit.",
+    )
     return parser
 
 
@@ -67,8 +79,12 @@ def _format_text(findings: list[Finding], *, color: bool) -> str:
         location = finding.path + (
             f":{finding.line}" if finding.line is not None else ""
         )
+        # The level column names how binding the rule is; a status other than
+        # `violation` means this line is not the rule failing, so say so
+        # rather than let the column read as a failure.
+        status = "" if finding.status == "violation" else f" [{finding.status}]"
         lines.append(
-            f"{finding.level.upper():11} {finding.rule_id}  {location}  "
+            f"{finding.level.upper():11} {finding.rule_id}{status}  {location}  "
             f"{finding.title}: {finding.message}"
         )
         if finding.actual is not None:
@@ -127,9 +143,14 @@ def main(argv: list[str] | None = None) -> int:
     if any(finding.status == "indeterminate" for finding in findings):
         return 2
     # `advisory` belongs to neither set: those findings are always printed
-    # above and never reach the exit code, not even under `--strict`.
+    # above and never reach the exit code, not even under `--strict`. Only a
+    # `violation` can fail a run at all — an `unused-exemption` is a report
+    # about the configuration, not a rule the repository broke.
     levels = STRICT_LEVELS if args.strict else DEFAULT_LEVELS
-    if any(finding.level in levels for finding in findings):
+    if any(
+        finding.level in levels and finding.status == "violation"
+        for finding in findings
+    ):
         return 1
     return 0
 

--- a/src/repo_standard/project_metadata.py
+++ b/src/repo_standard/project_metadata.py
@@ -2,10 +2,28 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+import tomllib
 from pathlib import Path
 
 import tomlkit
 from tomlkit.exceptions import ParseError
+
+
+def kit_version() -> str:
+    """Return the running `repo-standard-kit` version.
+
+    Installed metadata is the source: a wheel ships no `pyproject.toml`, so
+    reading that file is only the fallback for a source checkout that has not
+    been installed.
+    """
+    try:
+        return importlib.metadata.version("repo-standard-kit")
+    except importlib.metadata.PackageNotFoundError:
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        return str(
+            tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+        )
 
 
 def validate_package_name(package_name: str) -> None:

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-import importlib.metadata
 import json
 import os
 import re
@@ -27,6 +26,7 @@ from repo_standard.compliance.checks import Finding, check_repo, load_policy
 from repo_standard.github_references import is_full_commit_sha
 from repo_standard.policy import Shape
 from repo_standard.policy.models import LEVEL_ORDER
+from repo_standard.project_metadata import kit_version
 from repo_standard.repo_init import (
     PLACEHOLDERS,
     UNLICENSED_NOTICE,
@@ -112,16 +112,6 @@ _ROUND_TRIP_YAML = YAML()
 _ROUND_TRIP_YAML.preserve_quotes = True
 _ROUND_TRIP_YAML.width = 88
 _ROUND_TRIP_YAML.indent(mapping=2, sequence=4, offset=2)
-
-
-def _kit_version() -> str:
-    try:
-        return importlib.metadata.version("repo-standard-kit")
-    except importlib.metadata.PackageNotFoundError:
-        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
-        return str(
-            tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
-        )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -789,7 +779,7 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
         return AdoptionPlan(
             root=root,
             profile=selected,
-            version=_kit_version(),
+            version=kit_version(),
             changes=(),
             unchanged=unchanged,
             conflicts=(),
@@ -861,7 +851,7 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
     return AdoptionPlan(
         root=root,
         profile=selected,
-        version=_kit_version(),
+        version=kit_version(),
         changes=tuple(changes),
         unchanged=tuple(sorted(set(unchanged))),
         conflicts=tuple(conflicts),
@@ -985,9 +975,15 @@ def main(argv: list[str] | None = None) -> int:
                 _run(shlex.split(command), root, native_tls=args.native_tls)
         findings = _remaining_findings(plan)
         _print_summary(plan, findings)
-        return (
-            1 if plan.conflicts or any(f.level == "required" for f in findings) else 0
-        )
+        # Same rule `repo-check` applies: only a `violation` can fail a run.
+        # An `unused-exemption` is reported at its rule's canonical level and
+        # must not turn adoption into a failure.
+        blocking = [
+            finding
+            for finding in findings
+            if finding.level == "required" and finding.status == "violation"
+        ]
+        return 1 if plan.conflicts or blocking else 0
     except AdoptionError as error:
         print(f"repo-adopt: {error}", file=sys.stderr)
         return 2

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -37,6 +37,7 @@ from repo_standard.policy.models import (
     LEVELS,
     RATIONALE_MAX_LENGTH,
 )
+from repo_standard.project_metadata import kit_version
 from repo_standard.repo_init import bootstrap_repo
 
 POLICY = load_policy()
@@ -609,6 +610,39 @@ def test_finding_contains_actionable_contract_fields(tmp_path: Path) -> None:
     assert finding.actual == "missing"
     assert finding.expected == "file"
     assert finding.remediation
+
+
+@pytest.mark.parametrize("relative", ["README.md", "AGENTS.md"])
+def test_rsk005_reports_the_document_without_quoting_it(
+    tmp_path: Path, relative: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _minimal_repo(tmp_path)
+    document = root / relative
+    text = document.read_text(encoding="utf-8")
+    reference = POLICY.rule("RSK005").check.config["pattern"]
+    assert reference in text
+    document.write_text(text.replace(reference, "the-kit"), encoding="utf-8")
+
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK005"]
+    assert finding.path == relative
+    assert finding.expected == reference
+    # The searched text is the whole file; quoting it back is not evidence.
+    assert finding.actual is None
+    assert cli.main([str(root)]) == 1
+    output = capsys.readouterr().out
+    assert "RSK005" in output
+    assert "actual:" not in output
+    assert max(len(line) for line in output.splitlines()) < 120
+
+
+def test_rsk005_leaves_a_missing_document_to_the_rule_that_owns_absence(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    (root / "README.md").unlink()
+    rule_ids = _rule_ids(check_repo(root, POLICY))
+    assert "RSK004" in rule_ids
+    assert "RSK005" not in rule_ids
 
 
 def test_non_uv_build_backend_is_a_strict_only_recommendation(
@@ -1719,12 +1753,16 @@ def test_unsupported_branch_protection_response_is_a_violation(
     assert finding.status == "violation"
 
 
+def _ignore(root: Path, entries: str) -> None:
+    with (root / "pyproject.toml").open("a", encoding="utf-8") as stream:
+        stream.write(f"\n[tool.repo-check.ignore]\n{entries}\n")
+
+
 def test_only_known_nonempty_ignore_reasons_suppress(tmp_path: Path) -> None:
     root = _minimal_repo(tmp_path)
     (root / "README.md").unlink()
     path = root / "pyproject.toml"
-    with path.open("a", encoding="utf-8") as stream:
-        stream.write('\n[tool.repo-check.ignore]\nRSK004 = " "\nRSK999 = "Unknown"\n')
+    _ignore(root, 'RSK004 = " "\nRSK999 = "Unknown"')
     assert "RSK004" in _rule_ids(check_repo(root, POLICY))
     path.write_text(
         path.read_text(encoding="utf-8").replace(
@@ -1733,6 +1771,65 @@ def test_only_known_nonempty_ignore_reasons_suppress(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert "RSK004" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_an_exemption_that_suppressed_nothing_is_reported_but_never_blocks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _ignore(root, 'RSK012 = "Documented reason."')
+
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK012"]
+    assert finding.status == "unused-exemption"
+    # `level` keeps naming the rule's canonical level; `status` carries what
+    # this line reports, so neither field means two things.
+    assert finding.level == POLICY.rule("RSK012").level
+    assert finding.path == "pyproject.toml"
+    assert finding.remediation != POLICY.rule("RSK012").remediation
+
+    assert cli.main([str(root)]) == 0
+    assert "RSK012 [unused-exemption]" in capsys.readouterr().out
+    # Information, never a failure — not even when the exempted rule is
+    # required and strict checking is requested.
+    assert cli.main([str(root), "--strict", "--format", "json"]) == 0
+    [item] = [
+        item
+        for item in json.loads(capsys.readouterr().out)
+        if item["rule_id"] == "RSK012"
+    ]
+    assert item["status"] == "unused-exemption"
+
+
+def test_an_exemption_that_suppressed_a_finding_is_not_reported(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    (root / "README.md").unlink()
+    _ignore(root, 'RSK004 = "Documented reason."')
+    assert "RSK004" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_an_exemption_for_a_rule_this_run_never_evaluated_is_not_reported(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    _ignore(root, 'RSK014 = "Documented reason."')
+    assert POLICY.rule("RSK014").enforcement == "platform"
+    # Without --check-enforcement RSK014 never ran, so it had nothing to
+    # suppress and the exemption is not yet demonstrably dead.
+    assert "RSK014" not in _rule_ids(check_repo(root, POLICY))
+
+
+def test_version_reports_the_package_and_the_compiled_standard(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["--version"])
+    assert exit_info.value.code == 0
+    output = capsys.readouterr().out
+    assert kit_version() in output
+    assert POLICY.standard_version in output
+    assert POLICY.standard_major in output
 
 
 def test_json_output_carries_actionable_fields_and_no_legacy_severity(
@@ -2018,9 +2115,7 @@ def test_unlisted_pyproject_tables_stay_legal_in_any_position(
     tmp_path: Path,
 ) -> None:
     root = _minimal_repo(tmp_path)
-    path = root / "pyproject.toml"
-    with path.open("a", encoding="utf-8") as stream:
-        stream.write('\n[tool.repo-check.ignore]\nRSK012 = "Documented reason."\n')
+    _ignore(root, 'RSK012 = "Documented reason."')
     assert "RSK025" not in _rule_ids(check_repo(root, POLICY))
 
 

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -13,11 +13,11 @@ from conftest import REPO_ROOT, dump_yaml, load_yaml
 
 from repo_standard.compliance.checks import Finding, check_repo, load_policy
 from repo_standard.policy.models import LEVEL_ORDER
+from repo_standard.project_metadata import kit_version
 from repo_standard.repo_adopt import (
     AdoptionError,
     AdoptionPlan,
     CommandError,
-    _kit_version,
     _merge_agents,
     _merge_pyproject,
     _merge_readme,
@@ -292,9 +292,7 @@ def test_structurally_compliant_repository_is_a_no_op(tmp_path: Path) -> None:
     assert plan.conflicts == ()
 
 
-def test_dirty_checkout_is_refused_without_writes(tmp_path: Path) -> None:
-    root = tmp_path / "existing"
-    _write_minimal_repo(root, "python-single")
+def _commit_minimal_repo(root: Path) -> None:
     subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
     subprocess.run(
         ["git", "config", "user.email", "test@example.com"], cwd=root, check=True
@@ -308,6 +306,12 @@ def test_dirty_checkout_is_refused_without_writes(tmp_path: Path) -> None:
     subprocess.run(
         ["git", "commit", "-m", "initial"], cwd=root, check=True, capture_output=True
     )
+
+
+def test_dirty_checkout_is_refused_without_writes(tmp_path: Path) -> None:
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    _commit_minimal_repo(root)
     (root / "README.md").write_text("dirty\n", encoding="utf-8")
 
     assert (
@@ -317,22 +321,29 @@ def test_dirty_checkout_is_refused_without_writes(tmp_path: Path) -> None:
     assert not (root / ".github").exists()
 
 
+def test_an_unused_exemption_is_reported_without_failing_adoption(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    with (root / "pyproject.toml").open("a", encoding="utf-8") as stream:
+        stream.write('\n[tool.repo-check.ignore]\nRSK005 = "Suppresses nothing."\n')
+    _commit_minimal_repo(root)
+
+    result = main(
+        [str(root), "--profile", "python-single", "--no-lock", "--no-install"]
+    )
+
+    # Adoption writes the RSK005 reference, so the exemption is left dead; it
+    # is reported at RSK005's required level and still must not fail the run.
+    assert "RSK005" in capsys.readouterr().out
+    assert result == 0
+
+
 def test_apply_cli_leaves_changes_unstaged_and_uncommitted(tmp_path: Path) -> None:
     root = tmp_path / "existing"
     _write_minimal_repo(root, "python-single")
-    subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"], cwd=root, check=True
-    )
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
-    subprocess.run(
-        ["git", "add", "pyproject.toml", "uv.lock", "README.md", "AGENTS.md"],
-        cwd=root,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "commit", "-m", "initial"], cwd=root, check=True, capture_output=True
-    )
+    _commit_minimal_repo(root)
 
     result = main(
         [str(root), "--profile", "python-single", "--no-lock", "--no-install"]
@@ -427,7 +438,7 @@ def test_recognized_older_compliance_step_is_updated_in_place(tmp_path: Path) ->
         step for step in steps if step.get("name") == "Check repository compliance"
     ]
     assert len(compliance_steps) == 1
-    assert f"@v{_kit_version()}" in compliance_steps[0]["run"]
+    assert f"@v{kit_version()}" in compliance_steps[0]["run"]
 
 
 def test_a_compliance_job_that_invokes_nothing_gains_the_invocation(


### PR DESCRIPTION
Part of #72.

Four defects in the "clear errors" attribute, all in the checker. The theme: a
finding is only as useful as what it prints, and a suppression nobody can see
is worse than no suppression at all.

## 1. A failing RSK005 no longer prints the file it read

`_text_pattern_each` passed the whole file as the finding's `actual`, and the
text formatter prints `actual: {finding.actual!r}` — so a failing RSK005 emitted
an entire `README.md` as one repr'd line. `actual` is now `None`: the message
and `expected` already carry everything actionable.

The handler also grew a docstring for the behaviour that was silent before —
a **missing** path yields no issue, because the path's own existence rule
(RSK001, RSK004) owns absence, and reporting it here would name one fact twice.

## 2. The `RSK005` exemption is gone from `pyproject.toml`

It suppressed nothing. RSK005 is a substring search for `repo-standard-kit`,
and both `README.md` and `AGENTS.md` contain it, so the rule passed with or
without the entry. The `RSK011` entry stays — that one is real.

## 3. An exemption that suppresses nothing is now reported

The durable half of the above, and it applies to every adopter. The ignore
loader filtered exemptions to known rule IDs with non-empty reasons and then
never reported one that matched no finding, so dead exemptions accumulated
silently — the failure mode `AGENTS.md § Single Source Of Truth` exists to
prevent.

**The contract decision:** `level` stays the rule's canonical level and a new
`status` value, `unused-exemption`, carries what the line reports. Emitting a
synthetic `advisory` finding for a rule whose canonical level is `required`
would have made `level` mean two different things depending on the row, and
`level` is the field adopters read to decide how binding something is. `status`
already existed for exactly this — distinguishing "the rule failed" from
"something else is true about this rule" — and already carried
`indeterminate`.

Consequences carried through:

- only a `violation` can reach the exit code now, in **both** `repo-check` and
  `repo-adopt`. A dead exemption is a report about the configuration, not a
  rule the repository broke, and it must not fail adoption either.
- the text formatter appends `[status]` when the status is not `violation`, so
  the `REQUIRED` column cannot be misread as a failure.
- only a rule this run actually evaluated can be reported as unused — a rule
  the profile excludes, or a platform rule nobody requested, had no finding to
  suppress in the first place.
- `docs/compliance.md § Suppressing A Rule` documents it.

## 4. `repo-check --version`

Adopters pin by Git ref, so a disputed finding starts with which checker ran
and which compiled policy it carried. It reports both.

`_kit_version` moved out of `repo_adopt` into `project_metadata.kit_version`
so adoption and `--version` share one implementation rather than growing a
second. It reads installed metadata first, because a wheel ships no
`pyproject.toml`; reading that file is only the source-checkout fallback.

## Verification

The branch was pushed before its gates ran, so they were run against
`2afbc3e` afterwards rather than being reported from the authoring session.

| Gate | Result |
| --- | --- |
| `uv sync --locked` | pass |
| `uv run pre-commit run --all-files` | pass, 13 hooks |
| `uv run pytest` | 454 passed |
| `uv build` | sdist + wheel, no version warning |
| `uv run repo-check . --strict` | `All checks passed!`, exit 0 |

Merged together with #80 on top of `chore/release-v2.0.0`: no conflict, 457
passed, 14 hooks, `repo-check . --strict` clean.

The three behaviours, demonstrated rather than asserted:

```console
$ repo-check --version
repo-check 2.0.0 (standard 2.0.0, standard major 2)
```

```console
$ # RSK005 re-added to [tool.repo-check.ignore], where it suppresses nothing
$ repo-check .
REQUIRED    RSK005 [unused-exemption]  pyproject.toml  Standard references are
present: RSK005 is exempted in [tool.repo-check.ignore] but suppressed no
finding this run.
  remediation: Delete the RSK005 entry from [tool.repo-check.ignore], or keep
  it only with a reason that says why it must outlive what it suppresses.

1 finding(s).
$ echo $?
0
```

```console
$ # every `repo-standard-kit` mention stripped from README.md
$ repo-check .
REQUIRED    RSK005  README.md  Standard references are present: README.md does
not match 'repo-standard-kit'.
  expected: 'repo-standard-kit'
  remediation: Link repo-standard-kit from README.md and AGENTS.md.
```

The second is the exit-code claim: reported, never blocking. The third is the
first defect: no file dump.
