### PR TITLE
fix: disclose the step-condition limit, make suppression loud, and correct two false claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,20 @@ the changes listed under **Adopters must**.
   `--check-enforcement`, is not evaluated and is never reported this way.
   `repo-adopt` reports the same finding and applies the same rule to its own
   exit code.
+- **An exemption that suppressed something is reported too.** Every
+  `[tool.repo-check.ignore]` entry that silenced a finding emits one report
+  against `pyproject.toml` with the new `status` `suppressed`, at the rule's
+  own level, carrying the declared reason, how many findings it hid, and their
+  paths in `actual`. Before this, a suppressed required rule left no trace in
+  text or `--format json`, so a green `compliance` status was not evidence the
+  standard was met and no reviewer could tell the difference. The status keeps
+  it out of the exit code — silencing the failure is what the exemption is for
+  — and the last line of text output counts the rules an exemption silenced,
+  the way `pytest` counts skips. `repo-adopt`'s summary counts them on a line
+  of its own, apart from the findings it left unfixed, and its
+  clean-repository short circuit keys off the same `violation` rule, so a
+  report about the exemption configuration never makes adoption start
+  rewriting a repository that is clean by every rule.
 
 ### Changed
 
@@ -306,6 +320,15 @@ the changes listed under **Adopters must**.
   `README.md` and `AGENTS.md` name `repo-standard-kit` — and is deleted. The
   `RSK011` exemption stays; the kit really does ship the placeholder tokens it
   tests.
+- **`repo-adopt` left a stale version comment beside a SHA it had just
+  changed.** Repinning `uses: actions/checkout@v4 # v4.2.2` wrote the starter's
+  v7.0.1 SHA and kept `# v4.2.2` next to it, which Dependabot reads as the
+  pinned version, and where the adopter had no comment it added none — so the
+  version comment `docs/quality-gates.md` requires was missing or wrong either
+  way. A pin taken from the kit's own starter workflow now carries that
+  workflow's version comment with it. An action the kit does not pin is
+  reported as a conflict as before, and a SHA the repository chose itself
+  keeps its own comment untouched.
 
 ### Adopters must
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,11 @@ the changes listed under **Adopters must**.
   `repo-add-package` adds the first package, and notes that CI guards the same
   command with `compgen -G`. `docs/bootstrap-workflow.md` carried the same
   claim and is corrected with it.
+- Text output truncates a list-valued `actual` after four entries and counts
+  the rest. The active-exemption report above carries every silenced path, and
+  this repository's own RSK011 entry lists twenty-one of them, which put a
+  1,400-character line in front of a reader who needed the count.
+  `--format json` still emits the full list.
 - **`repo-adopt` left a stale version comment beside a SHA it had just
   changed.** Repinning `uses: actions/checkout@v4 # v4.2.2` wrote the starter's
   v7.0.1 SHA and kept `# v4.2.2` next to it, which Dependabot reads as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,24 @@ the changes listed under **Adopters must**.
   `README.md` and `AGENTS.md` name `repo-standard-kit` — and is deleted. The
   `RSK011` exemption stays; the kit really does ship the placeholder tokens it
   tests.
+- **The guard notes above promised more than the checker delivers.** They said
+  a required command behind "your own `if`" reports a finding, but in a
+  workflow that phrase reads as the step's `if:`, and the checker never sees
+  it: RSK006 and RSK030 collect `steps[*].run` bodies and model conditionals
+  found inside them. `if: false` on every gate step and on the `repo-check`
+  step leaves `repo-check . --strict` reporting `All checks passed!` at exit
+  0. The behaviour is unchanged and accepted — the kit is for internal
+  development, and the threat model does not cover an adopter disabling their
+  own workflow — but the notes are corrected and the limit is now stated in
+  `docs/quality-gates.md` §5 and `docs/compliance.md` §Structural Boundaries.
+- The `python-workspace` `AGENTS.md` called gate 4 "a documented no-op before
+  the workspace contains its first package". It is not: on a freshly generated
+  shell the build gate exits 2 with `Workspace does not contain any buildable
+  packages`. The gate chain is what policy declares
+  and does not change; the prose now says the gate fails until
+  `repo-add-package` adds the first package, and notes that CI guards the same
+  command with `compgen -G`. `docs/bootstrap-workflow.md` carried the same
+  claim and is corrected with it.
 
 ### Adopters must
 
@@ -351,8 +369,11 @@ to see what is left; the list below is what that repairs and what it cannot.
   requires the workflow to trigger on `pull_request` and one executed command
   in `jobs.compliance.steps[*].run` to contain `repo-check`, so a workflow
   reachable only by `workflow_dispatch`, a job that only checks out the
-  repository, or an invocation sitting behind your own `if` each report a
-  required finding. The prescribed form is the
+  repository, or an invocation guarded by a shell conditional inside the
+  `run:` body each report a required finding. A step's Actions-level `if:` is
+  not one of them: the checker reads `run:` bodies and nothing else, so a
+  `repo-check` step carrying `if: false` or `continue-on-error: true` still
+  satisfies RSK030. The prescribed form is the
   one in `docs/compliance.md` §Required CI workflow, which the starter kits
   ship; `repo-adopt` appends the starter's invocation step when it finds none.
 - Move any caller of this repository's reusable workflow from
@@ -367,13 +388,16 @@ to see what is left; the list below is what that repairs and what it cannot.
   may report its status check under a concatenated name rather than as
   `compliance`, which **RSK014** requires verbatim. `docs/compliance.md`
   records what is and is not known about that.
-- Re-check every conditional in `.github/workflows/quality.yml`. RSK006 no
-  longer accepts a required command that is reachable only under a condition
-  policy does not declare, so a gate-chain command behind your own `if`, an
-  `else` or `elif` branch, a loop, or a `case` arm is now unproven and reports
-  a required finding. The permitted guard per profile is published in
-  `docs/policy-reference.md`; `python-single` permits none, and
-  `python-workspace` permits only the packages-present guard.
+- Re-check every shell conditional in `.github/workflows/quality.yml`. RSK006
+  no longer accepts a required command that is reachable only under a shell
+  condition policy does not declare, so a gate-chain command behind an
+  undeclared shell `if`, an `else` or `elif` branch, a loop, or a `case` arm
+  is now unproven and reports a required finding. The permitted guard per
+  profile is published in `docs/policy-reference.md`; `python-single` permits
+  none, and `python-workspace` permits only the packages-present guard. This
+  reaches inside `run:` bodies only. A step's Actions-level `if:` and
+  `continue-on-error:` are unread, so a gate step disabled that way still
+  passes RSK006.
 - Expect a new RSK020 finding if you have no `quality.yml` or it does not
   parse. The rule previously discarded that error and passed silently, so a
   repository in that state gains a required finding it did not have.

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -318,7 +318,15 @@ values here.
 - `AGENTS.md` is concrete enough to use immediately, with no generic filler
 - `repo-check .` reports no required findings, and the full
   `docs/quality-gates.md` chain passes on the `uv.lock` the default path
-  produces
+  produces, with the one `python-workspace` exception below
+
+A generated `python-workspace` shell holds no packages yet, so its fourth
+gate, `uv build --all-packages`, exits 2 with `Workspace does not contain any
+buildable packages` until the first `repo-add-package` run. Add the package
+before running the chain locally. CI is unaffected: the workspace quality
+workflow wraps that command in `compgen -G "packages/*/pyproject.toml"`. The
+chain in `AGENTS.md` stays unguarded because RSK003 requires it to be the
+exact ordered chain the standard declares for the profile.
 
 The generated compliance workflow runs the released checker through `uvx` in
 an isolated tool environment. It does not add `repo-standard-kit` to the new

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -66,6 +66,8 @@ what *this* finding is:
 - `violation` — the rule failed. The only status that can reach exit code `1`.
 - `indeterminate` — an explicitly requested platform command produced no
   usable evidence. Exit code `2`.
+- `suppressed` — an exemption silenced the findings this rule produced.
+  Reported below, and never blocking.
 - `unused-exemption` — the rule passed while an exemption for it was declared.
   Reported below, and never blocking.
 
@@ -76,7 +78,8 @@ as `platform`, is removed in v2; read `level` and `status` instead.
 
 Text output prints the status beside the rule ID as `RSK012
 [unused-exemption]` whenever it is not `violation`, so the level column is
-never read as a failure that did not happen.
+never read as a failure that did not happen. Its last line counts the findings
+printed and, when any exemption is active, how many rules it silenced.
 
 `actual` is omitted where quoting it is not evidence: a rule that searches a
 whole document for a pattern reports the pattern it wanted, not the document
@@ -98,6 +101,17 @@ Only a known rule ID with a non-empty string reason suppresses findings. Empty
 reasons, unknown IDs, malformed TOML, and non-string values suppress nothing.
 Owner, expiry, and reference metadata remain deferred.
 
+An exemption that suppressed something is reported. `repo-check` emits one
+finding against `pyproject.toml` per exemption that silenced anything, with
+status `suppressed`, at the rule's own level, carrying the declared reason,
+how many findings it hid, and the paths in `actual`. It is reported once
+beside the exemption rather than once per silenced finding, so the entry a
+reviewer has to weigh is not buried under what it hid. It never affects the
+exit code — silencing the failure is what the exemption is for — but a green
+run and a run that only looks green stop being the same output, in text and in
+`--format json` alike. `repo-adopt` counts the same reports on a line of its
+own, apart from the findings it left unfixed.
+
 An exemption that suppressed nothing is reported. When a rule this run
 evaluated produced no finding and an exemption for it is declared, `repo-check`
 emits a finding against `pyproject.toml` with status `unused-exemption`, at the
@@ -107,7 +121,7 @@ repository broke. A rule the resolved profile excludes, and a platform rule
 under a run without `--check-enforcement`, are not evaluated and so are never
 reported this way.
 
-The report exists because an exemption is a claim, and a claim nothing
+That second report exists because an exemption is a claim, and a claim nothing
 exercises stops being reviewed. The `Single Source Of Truth` section every
 `AGENTS.md` carries requires one home per fact and treats deleting the stale
 copy as part of the change: an exemption that outlives the finding it was

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -289,8 +289,15 @@ remediation. Markdown explains policy but supplies no executable values.
   `on` remains a string. RSK006 inspects only executable
   `jobs.quality.steps[*].run` nodes. Comments, echo, unrelated fields, and
   shell-wrapper strings do not satisfy commands, and neither does a command
-  reachable only under a condition the policy does not declare for the
+  reachable only under a shell condition the policy does not declare for the
   profile.
+- Step conditions are unmodelled. Only `run:` is collected, so a step's `if:`
+  and `continue-on-error:` are invisible to every workflow rule, RSK006 and
+  RSK030 included: a workflow whose gate steps all carry `if: false` passes
+  `--strict`. These rules prove the workflow spells the required commands, not
+  that a pull request runs them. See
+  [quality-gates.md](quality-gates.md#5-ci-pull-request-gates) for why the gap
+  is disclosed rather than closed.
 - Pre-commit is parsed structurally. RSK007 matches hook IDs, normalized entry
   and argument tokens, and policy-owned material fields such as filters and
   `pass_filenames`.
@@ -313,7 +320,7 @@ remediation. Markdown explains policy but supplies no executable values.
   invokes the checker, not that the invocation is meaningful: a contrived
   command naming the token passes, while a token inside a comment or a
   shell-wrapper string does not, and neither does an invocation reachable only
-  under a guard policy does not declare.
+  under a shell guard policy does not declare.
 - RSK014 requires pull request protection, stale approval dismissal, required
   status checks, strict up-to-date branches, conversation resolution, and
   administrator enforcement when platform checks are requested, but permits a

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -124,6 +124,18 @@ the guard the [policy reference](policy-reference.md#rsk006-quality-workflow-exe
 declares for the resolved profile. Any other condition, an `else` or `elif`
 branch, a loop body, and a `case` arm leave the command unproven.
 
+That reach ends at the shell. The conditionals modelled above are the ones
+written inside a `run:` body; a step's own `if:` and `continue-on-error:` are
+never read, because only `run:` is collected. A gate step carrying `if: false`
+or `continue-on-error: true` therefore satisfies RSK006, and the same holds
+for the RSK030 invocation below. The rules prove that the workflow spells the
+chain correctly, not that a pull request executes it. Closing that would mean
+evaluating Actions expressions, which the checker does not do, so the gap is
+disclosed rather than fixed: this standard is for internal development, where
+a repository disabling its own gates is a review problem rather than an
+adversary. Read a green `quality` status as evidence only alongside the
+workflow diff that produced it.
+
 Every pull request shall also run an independent `compliance` job that checks
 the repository against repo-standard-kit. The separate status prevents a
 quality workflow from weakening or removing required gates while still

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -1769,6 +1769,30 @@ def _unused_exemption(rule: Rule) -> Finding:
     )
 
 
+def _active_exemption(rule: Rule, reason: str, silenced: list[Finding]) -> Finding:
+    """Report what a declared exemption suppressed this run.
+
+    Twin of `_unused_exemption`, with the same split: `level` stays the rule's
+    canonical level and `status` carries what this line reports, which keeps
+    it out of the exit code. Reporting once beside the exemption rather than
+    once per silenced finding keeps the entry — the thing a reviewer weighs —
+    from being buried under the findings it hid; `actual` carries where.
+    """
+    return Finding(
+        rule.id,
+        rule.title,
+        rule.level,
+        "pyproject.toml",
+        None,
+        f"{rule.id} is exempted in [tool.repo-check.ignore] and suppressed "
+        f"{len(silenced)} finding(s) this run: {reason}",
+        sorted({finding.path for finding in silenced}),
+        None,
+        rule.remediation,
+        "suppressed",
+    )
+
+
 def check_repo(
     root: Path,
     policy: Policy,
@@ -1793,6 +1817,18 @@ def check_repo(
         )
     ignored = _load_ignore_config(root, policy)
     kept = [finding for finding in findings if finding.rule_id not in ignored]
+    # A suppression that leaves no trace makes a green run and a run that only
+    # looks green the same output, so every exemption that silenced something
+    # reports it.
+    silenced = set(ignored) & {finding.rule_id for finding in findings}
+    kept.extend(
+        _active_exemption(
+            policy.rule(rule_id),
+            ignored[rule_id],
+            [finding for finding in findings if finding.rule_id == rule_id],
+        )
+        for rule_id in sorted(silenced)
+    )
     # Only a rule this run actually evaluated can be reported as suppressing
     # nothing: a rule the profile excludes, or a platform rule nobody asked
     # for, had no finding to suppress in the first place.

--- a/src/repo_standard/compliance/cli.py
+++ b/src/repo_standard/compliance/cli.py
@@ -92,7 +92,13 @@ def _format_text(findings: list[Finding], *, color: bool) -> str:
         if finding.expected is not None:
             lines.append(f"  expected: {finding.expected!r}")
         lines.append(f"  remediation: {finding.remediation}")
-    lines.append(f"\n{len(findings)} finding(s).")
+    # A reader scanning the last line must see that an exemption is active
+    # without reading every finding above it, the way pytest reports skips.
+    suppressed = sum(1 for finding in findings if finding.status == "suppressed")
+    summary = f"{len(findings)} finding(s)"
+    if suppressed:
+        summary += f", {suppressed} rule(s) suppressed by [tool.repo-check.ignore]"
+    lines.append(f"\n{summary}.")
     return "\n".join(lines) + "\n"
 
 
@@ -145,7 +151,8 @@ def main(argv: list[str] | None = None) -> int:
     # `advisory` belongs to neither set: those findings are always printed
     # above and never reach the exit code, not even under `--strict`. Only a
     # `violation` can fail a run at all — an `unused-exemption` is a report
-    # about the configuration, not a rule the repository broke.
+    # about the configuration, not a rule the repository broke, and a
+    # `suppressed` finding is one the adopter's exemption already answered.
     levels = STRICT_LEVELS if args.strict else DEFAULT_LEVELS
     if any(
         finding.level in levels and finding.status == "violation"

--- a/src/repo_standard/compliance/cli.py
+++ b/src/repo_standard/compliance/cli.py
@@ -70,6 +70,19 @@ def _supports_color() -> bool:
     return sys.stdout.isatty()
 
 
+def _render(value: object, *, limit: int = 4) -> str:
+    """Render a finding value, keeping a long list readable on one line.
+
+    A list-valued `actual` is a set of locations, and the whole set can run to
+    dozens. Text output is read by a person, so it carries enough to act on and
+    a count of the rest; `--format json` still emits every entry.
+    """
+    if isinstance(value, list) and len(value) > limit:
+        shown = ", ".join(repr(item) for item in value[:limit])
+        return f"[{shown}, +{len(value) - limit} more]"
+    return repr(value)
+
+
 def _format_text(findings: list[Finding], *, color: bool) -> str:
     if not findings:
         message = "All checks passed!"
@@ -88,7 +101,7 @@ def _format_text(findings: list[Finding], *, color: bool) -> str:
             f"{finding.title}: {finding.message}"
         )
         if finding.actual is not None:
-            lines.append(f"  actual: {finding.actual!r}")
+            lines.append(f"  actual: {_render(finding.actual)}")
         if finding.expected is not None:
             lines.append(f"  expected: {finding.expected!r}")
         lines.append(f"  remediation: {finding.remediation}")

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -444,6 +444,33 @@ def _action_family(value: str) -> str:
     return value.split("@", maxsplit=1)[0]
 
 
+def _uses_comment(step: Any) -> str | None:
+    """The `# v7.0.1` version annotation beside a step's `uses` value."""
+    comments = getattr(step, "ca", None)
+    token = comments.items.get("uses") if comments is not None else None
+    value = token[2].value if token is not None and token[2] is not None else ""
+    return value.split("\n", maxsplit=1)[0].strip() or None
+
+
+def _set_uses_comment(step: Any, comment: str) -> None:
+    """Rewrite the version annotation the repinned SHA just invalidated.
+
+    A stale annotation is worse than an absent one, because Dependabot reads
+    it as the pinned version. The existing token also carries whatever blank
+    line followed the step, so only its first line is replaced.
+    """
+    comments = getattr(step, "ca", None)
+    token = comments.items.get("uses") if comments is not None else None
+    if token is None or token[2] is None:
+        # Column 0 lets the emitter place the comment one space after the
+        # value; leaving the column to ruamel aligns it to whatever it last
+        # saw, which is not the same file twice.
+        step.yaml_add_eol_comment(comment, "uses", column=0)
+        return
+    existing = token[2].value
+    token[2].value = comment + existing[len(existing.split("\n", maxsplit=1)[0]) :]
+
+
 def _merge_workflow(
     path: Path, profile: str, relative: str, job_name: str
 ) -> tuple[str, list[str]]:
@@ -533,6 +560,12 @@ def _merge_workflow(
             current_ref = str(match["uses"]).rsplit("@", maxsplit=1)[-1]
             if not is_full_commit_sha(current_ref):
                 match["uses"] = expected_uses
+                # The starter's SHA and its version comment are one fact, so
+                # the pin carries the comment across rather than leaving the
+                # adopter's annotation describing the ref it replaced.
+                starter_comment = _uses_comment(expected_step)
+                if starter_comment is not None:
+                    _set_uses_comment(match, starter_comment)
         elif job_name == "compliance" and update_run:
             match["run"] = expected_run
 
@@ -767,12 +800,20 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
     selected = _resolve_profile(root, document, profile)
     policy = load_policy()
     # The short circuit below returns an empty plan when `check_repo` finds
-    # nothing. No rule checks .gitignore -- a file this repo-specific is a poor
-    # fit for a structural rule -- so a repository can be clean by every rule
-    # and still have none, which is why presence is asked here rather than
-    # inferred from the findings.
+    # nothing to repair. No rule checks .gitignore -- a file this repo-specific
+    # is a poor fit for a structural rule -- so a repository can be clean by
+    # every rule and still have none, which is why presence is asked here
+    # rather than inferred from the findings.
     gitignore_present = (root / ".gitignore").is_file()
-    if not check_repo(root, policy, profile=selected) and gitignore_present:
+    # Only a `violation` names something adoption could repair: a report about
+    # the exemption configuration, active or dead, must not turn a repository
+    # that is clean by every rule into one adoption starts rewriting.
+    repairable = [
+        finding
+        for finding in check_repo(root, policy, profile=selected)
+        if finding.status == "violation"
+    ]
+    if not repairable and gitignore_present:
         unchanged = tuple(
             relative for relative in _MANAGED_SURFACES if (root / relative).exists()
         )
@@ -936,11 +977,22 @@ def _print_summary(plan: AdoptionPlan, findings: list[Finding] | None) -> None:
         return
     # Walking the declared levels keeps this summary complete when policy gains
     # one; naming them here is how `advisory` findings went unreported.
+    suppressed = [finding for finding in findings if finding.status == "suppressed"]
     for level in LEVEL_ORDER:
-        matching = [finding for finding in findings if finding.level == level]
+        matching = [
+            finding
+            for finding in findings
+            if finding.level == level and finding.status != "suppressed"
+        ]
         print(f"remaining {level} findings: {len(matching)}")
         for finding in matching:
             print(f"  - {finding.rule_id} {finding.path}: {finding.message}")
+    # A silenced finding counted as remaining would contradict the exit code,
+    # and dropped from the summary it is the same blind spot `repo-check` just
+    # closed, so it is reported on a line of its own.
+    print(f"suppressed by [tool.repo-check.ignore]: {len(suppressed)}")
+    for finding in suppressed:
+        print(f"  - {finding.rule_id} {finding.path}: {finding.message}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/repo_standard/starter_kits/python-workspace/AGENTS.md
+++ b/src/repo_standard/starter_kits/python-workspace/AGENTS.md
@@ -182,8 +182,12 @@ Run from repo root:
 3. `uv run pytest`
 4. `uv build --all-packages`
 
-The build step is a documented no-op before the workspace contains its first
-package, matching the workspace quality workflow.
+The build step fails until `packages/` holds its first package: on an empty
+workspace it exits 2 with `Workspace does not contain any buildable packages`.
+Add a package with `repo-add-package` and the chain passes. The quality
+workflow guards that step behind `compgen -G "packages/*/pyproject.toml"`, so
+CI skips it meanwhile; the chain above is listed unguarded because it is the
+exact chain the standard declares.
 
 The quality job's effective permissions must be exactly `contents: read`, and
 every remote action or reusable workflow must be pinned to a full 40-character

--- a/templates/content/AGENTS/quality-gates.python-workspace.md
+++ b/templates/content/AGENTS/quality-gates.python-workspace.md
@@ -2,8 +2,12 @@ Run from repo root:
 
 __GATE_CHAIN__
 
-The build step is a documented no-op before the workspace contains its first
-package, matching the workspace quality workflow.
+The build step fails until `packages/` holds its first package: on an empty
+workspace it exits 2 with `Workspace does not contain any buildable packages`.
+Add a package with `repo-add-package` and the chain passes. The quality
+workflow guards that step behind `compgen -G "packages/*/pyproject.toml"`, so
+CI skips it meanwhile; the chain above is listed unguarded because it is the
+exact chain the standard declares.
 
 The quality job's effective permissions must be exactly `contents: read`, and
 every remote action or reusable workflow must be pinned to a full 40-character

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1891,6 +1891,30 @@ def test_success_output_uses_positive_brand_color() -> None:
     )
 
 
+def test_a_long_list_value_stays_readable_in_text_output() -> None:
+    """Text output is read by a person; JSON keeps every entry."""
+    finding = Finding(
+        "RSK011",
+        "Bootstrap placeholders are fully rendered",
+        "required",
+        "pyproject.toml",
+        None,
+        "message",
+        [f"path{index}.md" for index in range(21)],
+        None,
+        "remediation",
+        "suppressed",
+    )
+
+    text = cli._format_text([finding], color=False)
+
+    assert (
+        "  actual: ['path0.md', 'path1.md', 'path2.md', 'path3.md', +17 more]" in text
+    )
+    assert "path20.md" not in text
+    assert json.loads(cli._format_json([finding]))[0]["actual"][-1] == "path20.md"
+
+
 def test_strict_mode_only_promotes_recommended_findings(tmp_path: Path) -> None:
     root = _minimal_repo(tmp_path)
     (root / "docs" / "adr").rmdir()

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -48,6 +48,11 @@ def _rule_ids(findings: list[Finding]) -> set[str]:
     return {finding.rule_id for finding in findings}
 
 
+def _status_of(findings: list[Finding], rule_id: str) -> str:
+    [finding] = [finding for finding in findings if finding.rule_id == rule_id]
+    return finding.status
+
+
 def _write_pre_commit(root: Path, hooks: list[dict[str, object]]) -> None:
     data = {"repos": [{"repo": "local", "hooks": hooks}]}
     (root / ".pre-commit-config.yaml").write_text(dump_yaml(data), encoding="utf-8")
@@ -1763,14 +1768,14 @@ def test_only_known_nonempty_ignore_reasons_suppress(tmp_path: Path) -> None:
     (root / "README.md").unlink()
     path = root / "pyproject.toml"
     _ignore(root, 'RSK004 = " "\nRSK999 = "Unknown"')
-    assert "RSK004" in _rule_ids(check_repo(root, POLICY))
+    assert _status_of(check_repo(root, POLICY), "RSK004") == "violation"
     path.write_text(
         path.read_text(encoding="utf-8").replace(
             'RSK004 = " "', 'RSK004 = "Approved reason"'
         ),
         encoding="utf-8",
     )
-    assert "RSK004" not in _rule_ids(check_repo(root, POLICY))
+    assert _status_of(check_repo(root, POLICY), "RSK004") == "suppressed"
 
 
 def test_an_exemption_that_suppressed_nothing_is_reported_but_never_blocks(
@@ -1800,13 +1805,38 @@ def test_an_exemption_that_suppressed_nothing_is_reported_but_never_blocks(
     assert item["status"] == "unused-exemption"
 
 
-def test_an_exemption_that_suppressed_a_finding_is_not_reported(
-    tmp_path: Path,
+def test_an_exemption_that_suppressed_findings_reports_them_but_never_blocks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     root = _minimal_repo(tmp_path)
     (root / "README.md").unlink()
-    _ignore(root, 'RSK004 = "Documented reason."')
-    assert "RSK004" not in _rule_ids(check_repo(root, POLICY))
+    (root / "CHANGELOG.md").unlink()
+    _ignore(root, 'RSK004 = "Documented reason."\nRSK017 = "Second reason."')
+
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK004"]
+    assert finding.status == "suppressed"
+    # `level` keeps naming the rule's canonical level, exactly as it does for
+    # an unused exemption; the report sits beside the exemption it came from,
+    # states how much it hid, and says where.
+    assert finding.level == POLICY.rule("RSK004").level == "required"
+    assert finding.path == "pyproject.toml"
+    assert "suppressed 1 finding(s)" in finding.message
+    assert "Documented reason." in finding.message
+    assert finding.actual == ["README.md"]
+
+    assert cli.main([str(root), "--strict"]) == 0
+    output = capsys.readouterr().out
+    assert "RSK004 [suppressed]" in output
+    # A reader who scans only the summary must still see the suppression.
+    assert "2 finding(s), 2 rule(s) suppressed by [tool.repo-check.ignore]." in output
+
+    assert cli.main([str(root), "--format", "json"]) == 0
+    [item] = [
+        item
+        for item in json.loads(capsys.readouterr().out)
+        if item["rule_id"] == "RSK004"
+    ]
+    assert (item["level"], item["status"]) == ("required", "suppressed")
 
 
 def test_an_exemption_for_a_rule_this_run_never_evaluated_is_not_reported(
@@ -1922,7 +1952,13 @@ def test_generated_repos_pass_repo_check(profile: str, tmp_path: Path) -> None:
 
 
 def test_repository_passes_repo_check_strictly() -> None:
-    assert check_repo(REPO_ROOT, POLICY) == []
+    findings = check_repo(REPO_ROOT, POLICY)
+    assert [finding for finding in findings if finding.status == "violation"] == []
+    # This repository ships the placeholder tokens RSK011 looks for, so its
+    # own run is the first place its active exemption has to be visible.
+    assert [(finding.rule_id, finding.status) for finding in findings] == [
+        ("RSK011", "suppressed")
+    ]
 
 
 def test_repo_check_console_script_runs_end_to_end(tmp_path: Path) -> None:

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -23,6 +23,7 @@ from repo_standard.repo_adopt import (
     _merge_readme,
     _print_summary,
     _project_values,
+    _read_starter,
     _run,
     apply_plan,
     main,
@@ -709,3 +710,86 @@ def test_summary_reports_every_declared_level(
     for level in LEVEL_ORDER:
         assert f"remaining {level} findings: 1" in output
         assert f"{level} message" in output
+
+
+def test_summary_counts_a_suppressed_finding_apart_from_remaining_ones(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A silenced required rule the summary omits is a silently green adoption."""
+    plan = AdoptionPlan(
+        root=tmp_path,
+        profile="python-single",
+        version="0.0.0",
+        changes=(),
+        unchanged=(),
+        conflicts=(),
+        dependency_metadata_changed=False,
+    )
+    findings = [
+        Finding(
+            rule_id="RSK004",
+            title="title",
+            level="required",
+            path="README.md",
+            line=None,
+            message=(
+                "Required file is missing. Suppressed by "
+                "[tool.repo-check.ignore]: Docs live in the wiki."
+            ),
+            actual=None,
+            expected=None,
+            remediation="remediate",
+            status="suppressed",
+        )
+    ]
+
+    _print_summary(plan, findings)
+
+    output = capsys.readouterr().out
+    assert "remaining required findings: 0" in output
+    assert "suppressed by [tool.repo-check.ignore]: 1" in output
+    assert "  - RSK004 README.md:" in output
+
+
+def _starter_pinned_uses(profile: str, relative: str) -> list[str]:
+    """Every `uses: <action>@<sha> # <version>` line the starter workflow pins."""
+    return [
+        line.strip()
+        for line in _read_starter(profile, relative).splitlines()
+        if line.lstrip().startswith("uses:") and "#" in line
+    ]
+
+
+def test_repinning_carries_the_starters_version_comment_across(
+    tmp_path: Path,
+) -> None:
+    """A stale annotation beside a fresh SHA is what Dependabot reads as current."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    workflow = root / ".github" / "workflows" / "quality.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "on: pull_request\n"
+        "jobs:\n"
+        "  quality:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v4 # v4.2.2\n"
+        "\n"
+        "      - uses: astral-sh/setup-uv@v3\n",
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    # ruamel round-trips comments as attached tokens, so assert on the bytes
+    # written rather than on the reloaded document.
+    written = workflow.read_text(encoding="utf-8")
+    pinned = _starter_pinned_uses("python-single", ".github/workflows/quality.yml")
+    assert len(pinned) == 2
+    for line in pinned:
+        assert line in written
+    # The annotation the repin invalidated is gone, and the blank line the
+    # replaced comment token carried is still where it was.
+    assert "v4.2.2" not in written
+    assert "\n\n      - uses: astral-sh/setup-uv@" in written


### PR DESCRIPTION
Closes the final revision stage. Part of #83 — all four items, implemented on two branches and combined here.

## 1. The workflow-condition limit is disclosed, not fixed

`repo-check` cannot see a step's `if:` or `continue-on-error:`. `_job_shell_commands` collects `steps[*].run` only; the guard machinery models Bash conditionals *inside* a `run:` body. Reproduced on a generated repo with `if: false` on all four gate steps and the checker step — `repo-check . --strict` returned `All checks passed!` at exit 0.

**Behaviour is unchanged by decision.** The kit is for internal development and the threat model does not cover an adopter disabling their own workflow. What changes is that the release notes stopped promising otherwise: `CHANGELOG.md` said a command behind "your own `if`" reports a required finding, and in a workflow that phrase reads as the step condition. Both bullets are corrected, and the limit is now stated in `docs/quality-gates.md` §5 and `docs/compliance.md` §Structural Boundaries:

> The rules prove that the workflow spells the chain correctly, not that a pull request executes it.

## 2. A silenced rule is now loud

`[tool.repo-check.ignore]` suppressed required rules and left no trace in text or JSON, so a green `compliance` status and a status that only looked green were the same output.

An active exemption now reports at `status: suppressed` — the twin of the existing `unused-exemption`, keeping `level` as the rule's canonical level and carrying the meaning in `status`, so the exit code is untouched. One line per exemption entry rather than per silenced finding (per-finding was implemented first and rejected: this repo's own RSK011 exemption printed 21 findings and repeated its reason 21 times). The summary line counts them the way `pytest` counts skips, and `repo-adopt`'s summary gained the mirrored block.

```console
$ repo-check . --strict
REQUIRED    RSK011 [suppressed]  pyproject.toml  Bootstrap placeholders are fully rendered:
RSK011 is exempted in [tool.repo-check.ignore] and suppressed 21 finding(s) this run: ...
  actual: ['CHANGELOG.md', 'policy/base.yaml', ..., +17 more]

1 finding(s), 1 rule(s) suppressed by [tool.repo-check.ignore].
EXIT=0
```

This repository dogfoods it: its own run no longer prints `All checks passed!`, because it holds a real RSK011 exemption. `test_repository_passes_repo_check_strictly` asserts that exact finding rather than an empty list.

## 3. The workspace gate-4 claim was false

`AGENTS.md` called `uv build --all-packages` "a documented no-op before the workspace contains its first package". On a freshly generated shell it exits 2 with `Workspace does not contain any buildable packages` — verified independently, twice.

The chain is what policy declares and does not change: RSK003 requires `AGENTS.md` to state the exact ordered chain, and `[tool.uv] package = false` on the workspace root is deliberate. So the prose is corrected instead — the gate fails until `repo-add-package` adds the first package, CI guards the same command with `compgen -G`, and `docs/bootstrap-workflow.md` carried the same claim and is corrected with it.

## 4. `repo-adopt` no longer leaves a stale version comment

Repinning `uses: actions/checkout@v4 # v4.2.2` wrote the v7.0.1 SHA and kept `# v4.2.2` beside it — which Dependabot reads as the pinned version — and where the adopter had no comment it added none. Either way the version comment `docs/quality-gates.md` requires was missing or wrong.

The comment is rewritten, not deleted: deleting would stop it misleading while violating the standard's own requirement. A pin taken from the kit's own starter workflow now carries that workflow's version comment across. A SHA the repository chose itself keeps its own comment untouched, and an action the kit does not pin is reported as a conflict as before.

## Follow-up found while auditing

The active-exemption report carries every silenced path, and this repository's RSK011 entry lists twenty-one — a 1,400-character line in front of a reader whose question was answered by the count beside it. Text output now truncates a list-valued `actual` after four entries and counts the rest; `--format json` still emits the full list.

## Gates

| Gate | Result |
| --- | --- |
| `uv sync --locked` | pass |
| `uv run pre-commit run --all-files` | pass, 14 hooks |
| `uv run pytest` | 460 passed |
| `uv build` | sdist + wheel, no version warning |
| `uv run repo-check . --strict` | exit 0, reporting the kit's own active exemption |

`scripts/generate_docs.py` re-run clean after commit. Two behaviour changes worth a reviewer's eye, both intentional and both covered by rewritten tests: `plan_adoption`'s short circuit is now gated on `status == "violation"` (an exemption report must not make adoption start rewriting a clean repository), and this repository's own `repo-check` output is no longer empty.
