### PR TITLE
fix: let a uv virtual workspace root satisfy RSK025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,14 @@ the changes listed under **Adopters must**.
   (`pyproject.toml` table order), all three **required**. Every shape is
   checked as a subsequence: sections the shape does not declare stay legal
   anywhere, optional sections may be absent, and what a shape forbids is
-  reordering. Markdown shapes govern level-two headings only.
+  reordering. Markdown shapes govern level-two headings only. A required
+  section may name the profiles it is relaxed for, listed in the shape table's
+  *May be absent in* column; the relaxation covers presence only, so a
+  repository that carries the section is still held to the declared order.
+  `pyproject.toml`'s `project` table is relaxed for `python-workspace`, because
+  a uv virtual workspace root is a container for its members rather than a
+  distribution of its own, and RSK025 would otherwise be unsatisfiable for a
+  layout uv documents.
 - `repo-init --license {proprietary,mit,apache-2.0}` writes the full licence
   text to `LICENSE` and declares `license` and `license-files` in
   `pyproject.toml`. Omitted, no `LICENSE` is written and the README's `License`

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -39,20 +39,20 @@ documents are produced by walking it in the order below.
 - Undeclared sections: allowed
 - Heading level: `2`
 
-| Section | Name | Level |
-| --- | --- | --- |
-| `repository-purpose` | `Repository Purpose` | `required` |
-| `repository-context` | `Repository Context` | `required` |
-| `human-and-agent-responsibilities` | `Human And Agent Responsibilities` | `required` |
-| `agent-operating-mode` | `Agent Operating Mode` | `required` |
-| `single-source-of-truth` | `Single Source Of Truth` | `required` |
-| `workflow` | `Workflow` | `required` |
-| `quality-gates` | `Quality Gates` | `required` |
-| `coding-standards` | `Coding Standards` | `required` |
-| `testing-policy` | `Testing Policy` | `required` |
-| `documentation-rules` | `Documentation Rules` | `required` |
-| `repository-layout` | `Repository Layout` | `required` |
-| `change-control-notes` | `Change Control Notes` | `required` |
+| Section | Name | Level | May be absent in |
+| --- | --- | --- | --- |
+| `repository-purpose` | `Repository Purpose` | `required` | - |
+| `repository-context` | `Repository Context` | `required` | - |
+| `human-and-agent-responsibilities` | `Human And Agent Responsibilities` | `required` | - |
+| `agent-operating-mode` | `Agent Operating Mode` | `required` | - |
+| `single-source-of-truth` | `Single Source Of Truth` | `required` | - |
+| `workflow` | `Workflow` | `required` | - |
+| `quality-gates` | `Quality Gates` | `required` | - |
+| `coding-standards` | `Coding Standards` | `required` | - |
+| `testing-policy` | `Testing Policy` | `required` | - |
+| `documentation-rules` | `Documentation Rules` | `required` | - |
+| `repository-layout` | `Repository Layout` | `required` | - |
+| `change-control-notes` | `Change Control Notes` | `required` | - |
 
 ### readme
 
@@ -62,20 +62,20 @@ documents are produced by walking it in the order below.
 - Undeclared sections: allowed
 - Heading level: `2`
 
-| Section | Name | Level |
-| --- | --- | --- |
-| `at-a-glance` | `At A Glance` | `optional` |
-| `overview` | `Overview` | `required` |
-| `install` | `Install` | `required` |
-| `first-10-minutes` | `First 10 Minutes` | `optional` |
-| `configuration` | `Configuration` | `optional` |
-| `usage` | `Usage` | `required` |
-| `repo-structure` | `Repo Structure` | `optional` |
-| `development` | `Development` | `required` |
-| `deployment` | `Deployment` | `optional` |
-| `compatibility-and-versioning` | `Compatibility And Versioning` | `optional` |
-| `maintainers-and-support` | `Maintainers And Support` | `optional` |
-| `license` | `License` | `required` |
+| Section | Name | Level | May be absent in |
+| --- | --- | --- | --- |
+| `at-a-glance` | `At A Glance` | `optional` | - |
+| `overview` | `Overview` | `required` | - |
+| `install` | `Install` | `required` | - |
+| `first-10-minutes` | `First 10 Minutes` | `optional` | - |
+| `configuration` | `Configuration` | `optional` | - |
+| `usage` | `Usage` | `required` | - |
+| `repo-structure` | `Repo Structure` | `optional` | - |
+| `development` | `Development` | `required` | - |
+| `deployment` | `Deployment` | `optional` | - |
+| `compatibility-and-versioning` | `Compatibility And Versioning` | `optional` | - |
+| `maintainers-and-support` | `Maintainers And Support` | `optional` | - |
+| `license` | `License` | `required` | - |
 
 ### changelog
 
@@ -85,10 +85,10 @@ documents are produced by walking it in the order below.
 - Undeclared sections: allowed
 - Heading level: `2`
 
-| Section | Name | Level |
-| --- | --- | --- |
-| `compatibility-policy` | `Compatibility Policy` | `optional` |
-| `unreleased` | `[Unreleased]` | `required` |
+| Section | Name | Level | May be absent in |
+| --- | --- | --- | --- |
+| `compatibility-policy` | `Compatibility Policy` | `optional` | - |
+| `unreleased` | `[Unreleased]` | `required` | - |
 
 ### pyproject
 
@@ -97,19 +97,19 @@ documents are produced by walking it in the order below.
 - Enforced by: `RSK025`
 - Undeclared sections: allowed
 
-| Section | Name | Level |
-| --- | --- | --- |
-| `project` | `project` | `required` |
-| `project-scripts` | `project.scripts` | `optional` |
-| `dependency-groups` | `dependency-groups` | `optional` |
-| `build-system` | `build-system` | `optional` |
-| `tool-uv-build-backend` | `tool.uv.build-backend` | `optional` |
-| `tool-repo-standard` | `tool.repo-standard` | `optional` |
-| `tool-ruff` | `tool.ruff` | `optional` |
-| `tool-ruff-lint` | `tool.ruff.lint` | `optional` |
-| `tool-pytest-ini-options` | `tool.pytest.ini_options` | `optional` |
-| `tool-repo-check-ignore` | `tool.repo-check.ignore` | `optional` |
-| `tool-ty-src` | `tool.ty.src` | `optional` |
+| Section | Name | Level | May be absent in |
+| --- | --- | --- | --- |
+| `project` | `project` | `required` | `python-workspace` |
+| `project-scripts` | `project.scripts` | `optional` | - |
+| `dependency-groups` | `dependency-groups` | `optional` | - |
+| `build-system` | `build-system` | `optional` | - |
+| `tool-uv-build-backend` | `tool.uv.build-backend` | `optional` | - |
+| `tool-repo-standard` | `tool.repo-standard` | `optional` | - |
+| `tool-ruff` | `tool.ruff` | `optional` | - |
+| `tool-ruff-lint` | `tool.ruff.lint` | `optional` | - |
+| `tool-pytest-ini-options` | `tool.pytest.ini_options` | `optional` | - |
+| `tool-repo-check-ignore` | `tool.repo-check.ignore` | `optional` | - |
+| `tool-ty-src` | `tool.ty.src` | `optional` | - |
 
 ## Rules
 

--- a/docs/repo-standard.md
+++ b/docs/repo-standard.md
@@ -182,3 +182,10 @@ each refer to their generated shape table. The tables distinguish required from
 optional sections; undeclared sections and tables stay legal in any position.
 RSK023, RSK024, and RSK025 enforce their respective shapes at the **required**
 level.
+
+A required section may be relaxed for named profiles, listed in the shape
+table's *May be absent in* column. The relaxation covers presence only: a
+repository on such a profile may omit the section, and one that carries it is
+still held to the declared order. `pyproject.toml`'s `project` table is relaxed
+for `python-workspace`, because a uv virtual workspace root is a container for
+its members rather than a distribution of its own.

--- a/policy/shapes.yaml
+++ b/policy/shapes.yaml
@@ -111,6 +111,10 @@ shapes:
       - id: project
         heading: project
         level: required
+        # A uv virtual workspace root is a container for its members, not a
+        # distribution, so it declares no [project]. A workspace root that is
+        # itself a distribution still declares one, in this position.
+        allow_missing_profiles: [python-workspace]
       - id: project-scripts
         heading: project.scripts
         level: optional

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -219,25 +219,29 @@ def _path_exists(context: CheckContext, config: dict[str, Any]) -> list[Issue]:
     return [Issue(config["path"], f"Required {kind} is missing.", "missing", kind)]
 
 
-def _shape_issues(shape: Shape, path: str, actual: list[str]) -> list[Issue]:
+def _shape_issues(
+    shape: Shape, path: str, actual: list[str], profile: str
+) -> list[Issue]:
     """Compare observed section names against one canonical shape.
 
-    Presence is checked for required sections only. Order is checked as a
-    subsequence: sections the shape does not list are ignored entirely, and a
-    listed section that is absent simply drops out of the comparison. A
-    declared section that appears more than once is reported in its own right,
-    because the subsequence comparison keeps only the first occurrence and
-    would otherwise accept a repeat sitting anywhere in the document.
+    Presence is checked for the sections required of `profile` only. Order is
+    checked as a subsequence: sections the shape does not list are ignored
+    entirely, and a listed section that is absent simply drops out of the
+    comparison. A declared section that appears more than once is reported in
+    its own right, because the subsequence comparison keeps only the first
+    occurrence and would otherwise accept a repeat sitting anywhere in the
+    document.
     """
     issues: list[Issue] = []
-    missing = [heading for heading in shape.required if heading not in actual]
+    required = shape.required_for(profile)
+    missing = [heading for heading in required if heading not in actual]
     if missing:
         issues.append(
             Issue(
                 path,
                 f"Missing required sections: {', '.join(missing)}.",
                 actual,
-                list(shape.required),
+                list(required),
             )
         )
     listed = set(shape.headings)
@@ -291,7 +295,7 @@ def _markdown_shape(context: CheckContext, config: dict[str, Any]) -> list[Issue
         return []
     marks = "#" * (shape.heading_level or 2)
     actual = re.findall(rf"^{marks}\s+(.+?)\s*$", text, re.MULTILINE)
-    return _shape_issues(shape, shape.path, actual)
+    return _shape_issues(shape, shape.path, actual, context.profile)
 
 
 def _toml_table_names(text: str) -> list[str]:
@@ -324,7 +328,7 @@ def _toml_table_order(context: CheckContext, config: dict[str, Any]) -> list[Iss
     _data, error = _load_toml(path)
     if error is not None:
         return [error]
-    return _shape_issues(shape, shape.path, _toml_table_names(text))
+    return _shape_issues(shape, shape.path, _toml_table_names(text), context.profile)
 
 
 def _text_contains_all(context: CheckContext, config: dict[str, Any]) -> list[Issue]:

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -887,61 +887,73 @@
       "rule": "RSK002",
       "sections": [
         {
+          "allow_missing_profiles": [],
           "heading": "Repository Purpose",
           "id": "repository-purpose",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Repository Context",
           "id": "repository-context",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Human And Agent Responsibilities",
           "id": "human-and-agent-responsibilities",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Agent Operating Mode",
           "id": "agent-operating-mode",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Single Source Of Truth",
           "id": "single-source-of-truth",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Workflow",
           "id": "workflow",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Quality Gates",
           "id": "quality-gates",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Coding Standards",
           "id": "coding-standards",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Testing Policy",
           "id": "testing-policy",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Documentation Rules",
           "id": "documentation-rules",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Repository Layout",
           "id": "repository-layout",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Change Control Notes",
           "id": "change-control-notes",
           "level": "required"
@@ -957,61 +969,73 @@
       "rule": "RSK023",
       "sections": [
         {
+          "allow_missing_profiles": [],
           "heading": "At A Glance",
           "id": "at-a-glance",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Overview",
           "id": "overview",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Install",
           "id": "install",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "First 10 Minutes",
           "id": "first-10-minutes",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Configuration",
           "id": "configuration",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Usage",
           "id": "usage",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Repo Structure",
           "id": "repo-structure",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Development",
           "id": "development",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Deployment",
           "id": "deployment",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Compatibility And Versioning",
           "id": "compatibility-and-versioning",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "Maintainers And Support",
           "id": "maintainers-and-support",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "License",
           "id": "license",
           "level": "required"
@@ -1027,11 +1051,13 @@
       "rule": "RSK024",
       "sections": [
         {
+          "allow_missing_profiles": [],
           "heading": "Compatibility Policy",
           "id": "compatibility-policy",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "[Unreleased]",
           "id": "unreleased",
           "level": "required"
@@ -1047,56 +1073,69 @@
       "rule": "RSK025",
       "sections": [
         {
+          "allow_missing_profiles": [
+            "python-workspace"
+          ],
           "heading": "project",
           "id": "project",
           "level": "required"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "project.scripts",
           "id": "project-scripts",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "dependency-groups",
           "id": "dependency-groups",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "build-system",
           "id": "build-system",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.uv.build-backend",
           "id": "tool-uv-build-backend",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.repo-standard",
           "id": "tool-repo-standard",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.ruff",
           "id": "tool-ruff",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.ruff.lint",
           "id": "tool-ruff-lint",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.pytest.ini_options",
           "id": "tool-pytest-ini-options",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.repo-check.ignore",
           "id": "tool-repo-check-ignore",
           "level": "optional"
         },
         {
+          "allow_missing_profiles": [],
           "heading": "tool.ty.src",
           "id": "tool-ty-src",
           "level": "optional"

--- a/src/repo_standard/policy/compiler.py
+++ b/src/repo_standard/policy/compiler.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import json
 
-from repo_standard.policy.models import Policy
+from repo_standard.policy.models import Policy, ShapeSection
 
 
 def render_compiled(policy: Policy) -> str:
     return json.dumps(policy.to_data(), indent=2, sort_keys=True) + "\n"
+
+
+def _absent_in(section: ShapeSection) -> str:
+    """Name the profiles a required section is relaxed for, if any."""
+    if not section.allow_missing_profiles:
+        return "-"
+    return ", ".join(f"`{profile}`" for profile in section.allow_missing_profiles)
 
 
 def render_reference(policy: Policy) -> str:
@@ -72,9 +79,16 @@ def render_reference(policy: Policy) -> str:
         )
         if shape.heading_level is not None:
             lines.append(f"- Heading level: `{shape.heading_level}`")
-        lines.extend(["", "| Section | Name | Level |", "| --- | --- | --- |"])
         lines.extend(
-            f"| `{section.id}` | `{section.heading}` | `{section.level}` |"
+            [
+                "",
+                "| Section | Name | Level | May be absent in |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        lines.extend(
+            f"| `{section.id}` | `{section.heading}` | `{section.level}` | "
+            f"{_absent_in(section)} |"
             for section in shape.sections
         )
         lines.append("")

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -219,23 +219,52 @@ class Profile:
 
 @dataclass(frozen=True)
 class ShapeSection:
-    """One ordered, addressable part of a governed document."""
+    """One ordered, addressable part of a governed document.
+
+    `allow_missing_profiles` relaxes presence, not position: a profile named
+    there may omit the section and is still held to the declared order when it
+    carries one. It mirrors the key of the same name on `uv_build_backend`, so
+    a layout a profile cannot express stays a property of the section it is
+    about rather than becoming a second rule about the same file.
+    """
 
     id: str
     heading: str
     level: str
+    allow_missing_profiles: tuple[str, ...] = ()
+
+    def is_required_for(self, profile: str) -> bool:
+        return self.level == "required" and profile not in self.allow_missing_profiles
 
     @classmethod
     def from_data(cls, value: Any, location: str) -> ShapeSection:
         data = _mapping(value, location)
-        _keys(data, location, required={"id", "heading", "level"})
+        _keys(
+            data,
+            location,
+            required={"id", "heading", "level"},
+            optional={"allow_missing_profiles"},
+        )
         level = _string(data["level"], f"{location}.level")
         if level not in SECTION_LEVELS:
             _fail(f"{location}.level", f"unknown section level {level!r}")
+        allowed = _strings(
+            data.get("allow_missing_profiles", []),
+            f"{location}.allow_missing_profiles",
+            non_empty=False,
+        )
+        # An optional section may already be omitted by every profile, so a
+        # relaxation on one names a requirement that is not there to relax.
+        if allowed and level != "required":
+            _fail(
+                f"{location}.allow_missing_profiles",
+                f"unsupported for a {level!r} section",
+            )
         return cls(
             id=_string(data["id"], f"{location}.id"),
             heading=_string(data["heading"], f"{location}.heading"),
             level=level,
+            allow_missing_profiles=allowed,
         )
 
 
@@ -260,11 +289,12 @@ class Shape:
     def headings(self) -> tuple[str, ...]:
         return tuple(section.heading for section in self.sections)
 
-    @property
-    def required(self) -> tuple[str, ...]:
-        """Headings a conforming document must carry, in canonical order."""
+    def required_for(self, profile: str) -> tuple[str, ...]:
+        """Headings a conforming `profile` document must carry, in order."""
         return tuple(
-            section.heading for section in self.sections if section.level == "required"
+            section.heading
+            for section in self.sections
+            if section.is_required_for(profile)
         )
 
     @property
@@ -741,8 +771,19 @@ class Policy:
             shape_location = f"{location}.shapes.{shape.id}.rule"
             if shape.rule not in set(rule_ids):
                 _fail(shape_location, f"unknown rule {shape.rule!r}")
-            if self.rule(shape.rule).check.config.get("shape") != shape.id:
+            rule = self.rule(shape.rule)
+            if rule.check.config.get("shape") != shape.id:
                 _fail(shape_location, f"rule {shape.rule} does not enforce this shape")
+            # A section may only be relaxed for a profile its rule is checked
+            # against; anywhere else the relaxation would never be consulted.
+            for section in shape.sections:
+                out_of_scope = set(section.allow_missing_profiles) - set(rule.profiles)
+                if out_of_scope:
+                    _fail(
+                        f"{location}.shapes.{shape.id}.sections.{section.id}"
+                        ".allow_missing_profiles",
+                        f"profiles {shape.rule} does not check: {sorted(out_of_scope)}",
+                    )
 
 
 def _safe_yaml(path: Path) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,8 @@ def mandatory_ci_commands(profile: str = "python-single") -> list[str]:
     return list(rule.check.config["commands_by_profile"][profile])
 
 
-def required_agents_sections() -> list[str]:
-    return list(shape_of("RSK002").required)
+def required_agents_sections(profile: str = "python-single") -> list[str]:
+    return list(shape_of("RSK002").required_for(profile))
 
 
 def shape_of(rule_id: str) -> Shape:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -98,10 +98,12 @@ def _shape(rule_id: str) -> Shape:
     return POLICY.shape(POLICY.rule(rule_id).check.config["shape"])
 
 
-def _markdown_shaped(title: str, body: str = "Detail.") -> str:
+def _markdown_shaped(
+    title: str, body: str = "Detail.", profile: str = "python-single"
+) -> str:
     """Render a document carrying exactly the required sections of a shape."""
     sections = "\n\n".join(
-        f"## {heading}\n\n{body}" for heading in _shape(title).required
+        f"## {heading}\n\n{body}" for heading in _shape(title).required_for(profile)
     )
     return sections
 
@@ -109,7 +111,7 @@ def _markdown_shaped(title: str, body: str = "Detail.") -> str:
 def _minimal_repo(tmp_path: Path, profile: str = "python-single") -> Path:
     root = tmp_path / "compliant-repo"
     root.mkdir()
-    headings = _shape("RSK002").required
+    headings = _shape("RSK002").required_for(profile)
     gate_chain = "\n".join(
         f"{index}. `{command}`"
         for index, command in enumerate(
@@ -2026,7 +2028,7 @@ def test_rsk002_uses_the_shared_agents_shape_record() -> None:
     shape = _shape("RSK002")
     assert shape.path == "AGENTS.md"
     assert shape.heading_level == 2
-    assert shape.required == shape.headings
+    assert shape.required_for("python-single") == shape.headings
     assert POLICY.rule("RSK002").level == "required"
 
 
@@ -2039,8 +2041,58 @@ def test_shape_rules_are_required_for_v2(
 
 def test_readme_shape_distinguishes_required_sections() -> None:
     shape = _shape("RSK023")
-    assert shape.required
-    assert set(shape.required).issubset(shape.headings)
+    required = shape.required_for("python-single")
+    assert required
+    assert set(required).issubset(shape.headings)
+
+
+def _rsk025_messages(root: Path, profile: str) -> list[str]:
+    return [
+        finding.message
+        for finding in check_repo(root, POLICY, profile=profile)
+        if finding.rule_id == "RSK025"
+    ]
+
+
+def _drop_project_table(root: Path, tail: str = "") -> None:
+    """Rewrite pyproject.toml as a root that declares no distribution."""
+    path = root / "pyproject.toml"
+    text = path.read_text(encoding="utf-8")
+    body = text.split("\n\n", 1)[1]
+    path.write_text(f"{body}{tail}", encoding="utf-8")
+
+
+def test_virtual_workspace_root_needs_no_project_table(tmp_path: Path) -> None:
+    """uv's workspace container carries no distribution of its own."""
+    root = _minimal_repo(tmp_path, "python-workspace")
+    _drop_project_table(root, '\n[tool.uv.workspace]\nmembers = ["packages/*"]\n')
+    assert _rsk025_messages(root, "python-workspace") == []
+
+
+def test_workspace_root_that_is_a_distribution_still_conforms(tmp_path: Path) -> None:
+    """The relaxation permits both workspace roots; it forbids neither."""
+    root = _minimal_repo(tmp_path, "python-workspace")
+    assert _rsk025_messages(root, "python-workspace") == []
+
+
+def test_workspace_root_project_table_is_still_ordered(tmp_path: Path) -> None:
+    """Relaxing presence must not relax position."""
+    root = _minimal_repo(tmp_path, "python-workspace")
+    path = root / "pyproject.toml"
+    head, _, body = path.read_text(encoding="utf-8").partition("\n\n")
+    path.write_text(f"{body}\n{head}\n", encoding="utf-8")
+    assert _rsk025_messages(root, "python-workspace") == [
+        "Declared sections are out of canonical order."
+    ]
+
+
+def test_single_package_root_still_requires_a_project_table(tmp_path: Path) -> None:
+    """The relaxation is scoped to one profile, not removed from the rule."""
+    root = _minimal_repo(tmp_path, "python-single")
+    _drop_project_table(root)
+    assert _rsk025_messages(root, "python-single") == [
+        "Missing required sections: project."
+    ]
 
 
 def test_missing_required_section_reports_its_shape_rule(tmp_path: Path) -> None:
@@ -2227,6 +2279,18 @@ def _retype_agents_shape_as_toml(data: dict[str, object]) -> None:
         (
             lambda data: data["shapes"][1].update({"path": "AGENTS.md"}),
             "two shapes govern the same path",
+        ),
+        (
+            lambda data: data["shapes"][0]["sections"][0].update(
+                {"allow_missing_profiles": ["no-such-profile"]}
+            ),
+            "profiles RSK002 does not check",
+        ),
+        (
+            lambda data: data["shapes"][1]["sections"][0].update(
+                {"allow_missing_profiles": ["python-workspace"]}
+            ),
+            "unsupported for a 'optional' section",
         ),
     ],
 )


### PR DESCRIPTION
Phase B2 of #85 — finding 6. Closes #87 by hand on merge (closing keywords do
not fire for a PR targeting a non-default branch).

## The defect

The `pyproject` shape marked its `project` section `level: required`, and shapes
have no profile scoping, so RSK025 — a **required** rule for both Python
profiles — demanded `[project]` from every root. A uv **virtual workspace
root**, a root declaring `[tool.uv.workspace]` with no distribution of its own,
is uv's documented layout for a workspace container and has no `[project]` to
declare. `repo-check` rejected it:

```text
REQUIRED RSK025 pyproject.toml  Missing required sections: project.
```

The kit never met this because its own `python-workspace` starter root *is* a
distribution and carries `[project]`.

## Design choice

**Chosen: extend `ShapeSection` with `allow_missing_profiles`**, the key
`uv_build_backend` already uses for exactly this purpose (`policy/base.yaml`
relaxes RSK008 for `python-workspace` the same way).

```yaml
      - id: project
        heading: project
        level: required
        allow_missing_profiles: [python-workspace]
```

The alternative was to mark `project` optional in the shape and re-require it
from `python-single` through a separate rule. Three reasons against it:

- **It splits one file's contract across two rules.** `pyproject.toml` would be
  governed by RSK025 *and* a new rule, and a reader asking "must my root declare
  `[project]`?" would have to consult both. The shape stops being the single
  source for the file it names.
- **It makes the generated shape table lie.** `docs/policy-reference.md` renders
  the section list from the shape; `project` would read `optional` there while a
  `python-single` repository is in fact required to carry it. The relaxation
  approach keeps the level honest and adds a *May be absent in* column that says
  precisely who is exempt.
- **It adds a second vocabulary for one idea.** `allow_missing_profiles` already
  exists and already means "this profile may omit this"; reusing it leaves one
  concept to learn rather than two.

The relaxation is deliberately about **presence, not position**: a
`python-workspace` root that *is* a distribution keeps declaring `[project]`,
and is still held to the canonical order when it does — so both legitimate
workspace-root layouts pass, and neither is forbidden. `python-single` is
unchanged and still fails RSK025 without `[project]`, which the regression test
pins.

## Changes

| File | Change |
| --- | --- |
| `policy/shapes.yaml` | `project` declares `allow_missing_profiles: [python-workspace]` |
| `src/repo_standard/policy/models.py` | `ShapeSection.allow_missing_profiles` + `is_required_for`; `Shape.required` → `Shape.required_for(profile)`; rejects a relaxation on an `optional` section, or one naming a profile the enforcing rule does not check |
| `src/repo_standard/compliance/checks.py` | `_shape_issues` takes the resolved profile and compares against `required_for(profile)` |
| `src/repo_standard/policy/compiler.py` | shape tables gain a *May be absent in* column |
| `docs/repo-standard.md` | states the relaxation contract under **File Shapes** |
| `CHANGELOG.md` | recorded in the `2.0.0` entry beside the shapes feature |
| `tests/` | regression coverage (below); `required` call sites updated |
| regenerated | `src/repo_standard/policy/compiled.json`, `docs/policy-reference.md` |

`Shape.required` became `Shape.required_for(profile)` rather than gaining a
sibling: required-ness is now genuinely profile-dependent, so leaving a
profile-blind property in place would have been a trap for the next caller.

`src/repo_standard/repo_adopt.py` is untouched — phase B1 owns it.

### Regression tests

- `test_virtual_workspace_root_needs_no_project_table` — a `python-workspace`
  root with `[tool.uv.workspace]` and no `[project]` reports no RSK025 finding.
- `test_workspace_root_that_is_a_distribution_still_conforms` — a workspace root
  that *does* declare `[project]` still passes.
- `test_workspace_root_project_table_is_still_ordered` — moving `[project]` out
  of position in a workspace root is still reported, so the relaxation did not
  leak into ordering.
- `test_single_package_root_still_requires_a_project_table` — a `python-single`
  root without `[project]` still fails with
  `Missing required sections: project.`
- two cases added to `test_invalid_shape_policy_is_rejected` — a relaxation on an
  `optional` section, and one naming a profile the enforcing rule does not check,
  are both refused at policy load.

## Verification

Run from the kit worktree at `1bb561b`.

| Gate | Result |
| --- | --- |
| `uv sync --locked` | Resolved 39 packages, checked 39 packages |
| `uv run pre-commit run --all-files` | 14 hooks, all **Passed** (incl. `ruff check`, `ruff format`, `ty check`, `markdown lint`, `repo-check`) |
| `uv run pytest` | **466 passed** in 47.01s (460 before; +6 new) |
| `uv build` | built `repo_standard_kit-2.0.0.tar.gz` and `-py3-none-any.whl` |
| `uv run repo-check . --strict` | exit 0 — 1 finding, the pre-existing RSK011 suppressed by `[tool.repo-check.ignore]` |

### Against the real adopter

`uv run --project <kit> repo-check "C:/Users/thomazo/dev/wc-adopt"` —
`FP-DevTools/wombat_configs`, branch `chore/adopt-repo-standard-kit`, a virtual
workspace root. Read-only; nothing in that tree was modified.

| | Findings | RSK025 |
| --- | --- | --- |
| before (`3049bd5`) | 12 | `Missing required sections: project.` **and** `Declared sections are out of canonical order.` |
| after (`1bb561b`) | 11 | `Declared sections are out of canonical order.` only |

The two runs are otherwise line-for-line identical: RSK002, RSK007, RSK015,
RSK016, RSK018, RSK019, RSK023, RSK026, RSK029, RSK030 are unchanged. The
remaining RSK025 finding (table order), the missing LICENSE and the advisory
ruff line-length are out of scope here — the ordering one is phase B1.
