### PR TITLE
fix: stop repo-adopt corrupting the repositories it upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,26 @@ the changes listed under **Adopters must**.
 - `repo-adopt` places new `pyproject.toml` tables in the order RSK025 declares
   rather than appending them, so `[dependency-groups]` no longer lands after
   `[build-system]` and `[tool.repo-standard]` no longer splits the Ruff tables.
+  Tables the repository already had are reordered too, so the manifest adoption
+  rewrites is not handed back failing a required rule.
+- **`repo-adopt` upgrades a repository adopted under standard 1 rather than
+  refusing it.** A stale `standard` major is reported, naming both majors, and
+  the run continues; only a profile this kit does not publish still asks for an
+  explicit `--profile`.
+- **`repo-adopt` reconciles a compliance job that calls a reusable workflow**
+  instead of appending steps beside its `uses:`, which produced a job GitHub
+  refuses to schedule. The call moves to `compliance-reusable.yml` at this
+  release and to the inputs that still exist; the SHA pin RSK029 wants stays
+  the maintainer's choice and is reported.
+- **`repo-adopt` selects only the lint families a `required` rule demands.**
+  Applying a `recommended` family unasked broke a passing `ruff check`, and
+  which recommendations to take is the maintainer's call.
+- `repo-adopt` keeps pre-commit hook arguments the hook shape does not model —
+  a `detect-secrets` baseline among them — and reports the difference instead
+  of silently deleting a load-bearing option.
+- A `README.md` section `repo-adopt` inserts states that it is empty. It used
+  to carry the starter's prose, which describes a repository `repo-init` has
+  just generated and leaves an established one text to delete.
 - `templates/README.md` states that its section order comes from RSK023 and is
   checked by `repo-check`, replacing the claim that adopters should keep their
   README aligned with `templates/` — a path no tooling reads. The same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,9 +238,11 @@ the changes listed under **Adopters must**.
 - `repo-adopt` keeps pre-commit hook arguments the hook shape does not model —
   a `detect-secrets` baseline among them — and reports the difference instead
   of silently deleting a load-bearing option.
-- A `README.md` section `repo-adopt` inserts states that it is empty. It used
-  to carry the starter's prose, which describes a repository `repo-init` has
-  just generated and leaves an established one text to delete.
+- A `README.md` section `repo-adopt` inserts states that it is empty, except
+  `License`, whose body adoption reads off the repository: the terms if a
+  `LICENSE` file states them, and what RSK018 asks for if none does. The
+  sections used to carry the starter's prose, which describes a repository
+  `repo-init` has just generated and leaves an established one text to delete.
 - `templates/README.md` states that its section order comes from RSK023 and is
   checked by `repo-check`, replacing the claim that adopters should keep their
   README aligned with `templates/` — a path no tooling reads. The same

--- a/docs/bootstrap-workflow.md
+++ b/docs/bootstrap-workflow.md
@@ -15,10 +15,12 @@ uvx --from "git+ssh://git@github.com/FP-DevTools/repo-standard-kit.git" \
 ```
 
 Use `python-workspace` for a workspace root. When `--profile` is omitted,
-`repo-adopt` first uses valid `[tool.repo-standard]` metadata and then the
-canonical policy detection markers. It stops and requests an explicit profile
-if metadata is invalid or multiple profiles match; it never guesses through an
-ambiguity.
+`repo-adopt` first uses the profile named in `[tool.repo-standard]` and then
+the canonical policy detection markers. It stops and requests an explicit
+profile if that profile is not one this kit publishes or if multiple profiles
+match; it never guesses through an ambiguity. A `standard` major from an
+earlier release is what adoption exists to upgrade, not a reason to refuse: it
+is reported, naming both majors, and the run continues.
 
 After reviewing the preview, apply the reconciliation from a clean checkout:
 
@@ -47,14 +49,30 @@ the checkout:
   untouched; it is never merged with the starter's.
 - `pyproject.toml`, `.pre-commit-config.yaml`, and the quality workflow are
   structurally merged. Existing project dependencies, build settings,
-  services, custom hooks, and additional steps remain in place.
+  services, custom hooks, and additional steps remain in place. A workflow step
+  is matched by the commands it executes, so a gate the repository already runs
+  is reconciled rather than appended a second time under the same name. Hook
+  arguments the standard's hook shape does not model are load-bearing: they are
+  kept and reported, never dropped.
+- Lint families are selected only where a `required` rule demands one. A
+  `recommended` family is a judgement call that stays with the maintainer, so
+  adoption never turns a passing `ruff check` red to satisfy a recommendation.
+- Declared `pyproject.toml` tables are left in the order RSK025 declares, so
+  the manifest adoption rewrites does not come back as a required finding.
 - Mutable refs on known standard workflow actions are replaced by the immutable
   pins shipped by the selected kit; existing full-SHA pins remain intact. The
   isolated `repo-check` hook moves to the selected kit version. Unknown remote
   Actions without immutable pins are reported for a maintainer-selected SHA.
+- A job that declares `uses:` is a reusable-workflow call and never gains
+  steps, which would produce a job GitHub refuses to schedule. A call to this
+  kit's own reusable compliance workflow is reconciled to the released file and
+  the inputs it still accepts; one this kit does not publish is reported and
+  left untouched.
 - `README.md` and `AGENTS.md` remain project-owned. The adopter appends the
   standard reference and missing required sections, and reconciles the exact
-  policy-owned Quality Gates command list without replacing other prose.
+  policy-owned Quality Gates command list without replacing other prose. An
+  inserted `README.md` section states that it is empty rather than carrying
+  starter prose about a repository that does not exist.
 - A non-`uv_build` package backend is preserved and remains visible as the
   recommended RSK008 finding under strict checking. Unsupported standard
   metadata, malformed configuration, or another merge that changes project

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -34,11 +34,18 @@ from repo_standard.policy.models import LEVEL_ORDER
 from repo_standard.project_metadata import kit_version
 from repo_standard.repo_init import (
     PLACEHOLDERS,
-    UNLICENSED_NOTICE,
     resolve_starter_dir,
 )
 
 ADOPTED_LICENSE_NOTICE = "See [`LICENSE`](LICENSE) for the terms that apply."
+# `repo_init.UNLICENSED_NOTICE` sends the reader to `repo-init --license`,
+# which is not a command an existing repository can run. Adoption states the
+# same fact and names what it can actually do about it.
+ADOPTION_UNLICENSED_NOTICE = (
+    "Licence terms have not been selected for this repository yet, so no "
+    "`LICENSE` file is present. RSK018 recommends adding one: add the terms "
+    "your organisation has approved before sharing this repository."
+)
 
 _KIT_REPOSITORY = "FP-DevTools/repo-standard-kit"
 _STANDARDS_LINK = f"[repo-standard-kit]: https://github.com/{_KIT_REPOSITORY}"
@@ -233,7 +240,7 @@ def _project_values(root: Path, document: Any) -> dict[str, str]:
         "license_notice": (
             ADOPTED_LICENSE_NOTICE
             if (root / "LICENSE").is_file()
-            else UNLICENSED_NOTICE
+            else ADOPTION_UNLICENSED_NOTICE
         ),
     }
 
@@ -927,21 +934,30 @@ def _merge_agents(path: Path, profile: str, values: dict[str, str]) -> str:
 
 
 _README_GAP = "`repo-adopt` added this required heading; it has no content yet."
+# Sections whose body adoption can state as fact, keyed by the value that
+# carries it. Everything else describes what the repository is for, which only
+# the maintainer knows.
+_README_BODIES = {"license": "license_notice"}
 
 
-def _fill_missing_readme_sections(text: str, shape: Shape) -> str:
-    """Add every required README section as a stated gap.
+def _fill_missing_readme_sections(
+    text: str, shape: Shape, values: dict[str, str]
+) -> str:
+    """Add every required README section, as fact where there is one.
 
     The starter's bodies describe a repository `repo-init` has just generated
     -- add the first package, replace this section -- which is false of a
     repository that already exists and leaves the reader prose to delete. An
-    inserted section says it is empty and stops there.
+    inserted section says it is empty and stops there, unless adoption can read
+    the answer off the repository, as it can for the licence terms.
     """
     for section in shape.sections:
         if section.level != "required" or _section(text, section.heading) is not None:
             continue
+        value = _README_BODIES.get(section.id)
+        body = values[value] if value is not None else _README_GAP
         text = _insert_section(
-            text, shape, section.heading, f"## {section.heading}\n\n{_README_GAP}\n"
+            text, shape, section.heading, f"## {section.heading}\n\n{body}\n"
         )
     return text
 
@@ -951,7 +967,7 @@ def _merge_readme(path: Path, profile: str, values: dict[str, str]) -> str:
     if text is None:
         return _render(_read_starter(profile, "README.md"), values)
     shape = _shape_for("RSK023")
-    text = _fill_missing_readme_sections(text, shape)
+    text = _fill_missing_readme_sections(text, shape, values)
     return _ensure_standards_reference(text, shape)
 
 

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -22,7 +22,12 @@ from ruamel.yaml.error import YAMLError
 from tomlkit.exceptions import ParseError
 
 from repo_standard.bootstrap_defaults import DEFAULT_PYTHON_VERSION
-from repo_standard.compliance.checks import Finding, check_repo, load_policy
+from repo_standard.compliance.checks import (
+    Finding,
+    _shell_commands,
+    check_repo,
+    load_policy,
+)
 from repo_standard.github_references import is_full_commit_sha
 from repo_standard.policy import Shape
 from repo_standard.policy.models import LEVEL_ORDER
@@ -35,9 +40,12 @@ from repo_standard.repo_init import (
 
 ADOPTED_LICENSE_NOTICE = "See [`LICENSE`](LICENSE) for the terms that apply."
 
-_STANDARDS_LINK = (
-    "[repo-standard-kit]: https://github.com/FP-DevTools/repo-standard-kit"
-)
+_KIT_REPOSITORY = "FP-DevTools/repo-standard-kit"
+_STANDARDS_LINK = f"[repo-standard-kit]: https://github.com/{_KIT_REPOSITORY}"
+# Standard 2 moved the reusable workflow to its own file and left it one input,
+# so a caller written against an earlier release resolves to nothing.
+_REUSABLE_COMPLIANCE = f"{_KIT_REPOSITORY}/.github/workflows/compliance-reusable.yml"
+_REUSABLE_INPUTS = ("standard-ref",)
 # RSK005 wants an explicit, linked reference in both documents. Rather than
 # inventing a heading no shape declares, the note goes into a section the shape
 # already requires, so adoption never introduces a section shape of its own.
@@ -84,6 +92,9 @@ class AdoptionPlan:
     unchanged: tuple[str, ...]
     conflicts: tuple[str, ...]
     dependency_metadata_changed: bool
+    # Stated facts about the adoption that ask nothing of the maintainer, so
+    # they belong neither in the conflict list nor in the finding counts.
+    notices: tuple[str, ...] = ()
 
 
 _MANAGED_SURFACES = (
@@ -236,11 +247,13 @@ def _resolve_profile(root: Path, document: Any, override: str | None) -> str:
         if not isinstance(metadata, dict):
             raise AdoptionError("[tool.repo-standard] must be a TOML table")
         profile = metadata.get("profile")
-        standard = metadata.get("standard")
-        if profile not in policy.profile_ids or standard != policy.standard_major:
+        # A stale standard major is the upgrade adoption exists to perform, so
+        # only an unrecognized profile leaves the intended profile in doubt.
+        if profile not in policy.profile_ids:
             raise AdoptionError(
-                "existing [tool.repo-standard] metadata is invalid; pass --profile "
-                "to make the intended profile explicit"
+                f"[tool.repo-standard] profile {profile!r} is not a profile this "
+                f"kit knows ({', '.join(policy.profile_ids)}); pass --profile to "
+                "make the intended profile explicit"
             )
         return str(profile)
 
@@ -271,6 +284,25 @@ def _resolve_profile(root: Path, document: Any, override: str | None) -> str:
             "profile detection found no match and policy has no default"
         )
     return default
+
+
+def _standard_major_notice(document: Any) -> str | None:
+    """Name both standard majors when the repository is on an earlier one.
+
+    This is the state every repository adopted under an earlier major is in,
+    and it is what adoption repairs, so it is reported rather than refused.
+    """
+    metadata = document.get("tool", {}).get("repo-standard")
+    if not isinstance(metadata, dict):
+        return None
+    declared = metadata.get("standard")
+    current = load_policy().standard_major
+    if declared is None or str(declared) == current:
+        return None
+    return (
+        f"this repository declares standard {str(declared)!r} and this kit is "
+        f"standard {current!r}; adoption upgrades [tool.repo-standard] to it"
+    )
 
 
 def _sibling_order(shape: Shape, prefix: tuple[str, ...]) -> list[str]:
@@ -316,6 +348,57 @@ def _ensure_table(
     if not isinstance(value, dict):
         raise AdoptionError(f"cannot merge TOML key {key!r}: expected a table")
     return value
+
+
+def _reorder_tables(parent: Any, shape: Shape, prefix: tuple[str, ...] = ()) -> None:
+    """Put the shape's declared tables back into canonical order, in place.
+
+    Placing each new table correctly is not enough: a table the repository
+    already had can sit anywhere, and adoption has no business handing back a
+    manifest that fails the rule it just rewrote the file for. RSK025 reads
+    table headers as a subsequence, so only the declared ones move -- each
+    takes a slot a declared table already occupied, and a table the shape does
+    not list keeps its position.
+    """
+    order = _sibling_order(shape, prefix)
+    keys = list(parent)
+    declared = [name for name in order if name in keys]
+    slots = [index for index, name in enumerate(keys) if name in declared]
+    if [keys[index] for index in slots] != declared:
+        for index, name in zip(slots, declared, strict=True):
+            keys[index] = name
+        # tomlkit has no reorder and no insert-before, so every key is lifted
+        # out and put back; each carries its own contents and trivia.
+        lifted = {name: parent.pop(name) for name in list(parent)}
+        for name in keys:
+            parent[name] = lifted[name]
+    for name in order:
+        child = parent.get(name)
+        if isinstance(child, dict):
+            _reorder_tables(child, shape, (*prefix, name))
+
+
+# The families a rule of each kind names, so adoption reads the requirement
+# from policy rather than from whatever the starter happens to select.
+_RUFF_SELECT_KINDS = {"ruff_baseline": "required_select", "ruff_select": "values"}
+
+
+def _required_ruff_families() -> list[str]:
+    """Lint families a `required` rule demands, in policy order.
+
+    Adoption may repair a `required` rule unasked. A `recommended` family is
+    the maintainer's call and adding one has turned a passing `ruff check` red,
+    so the level decides rather than the starter's `select` list.
+    """
+    families: list[str] = []
+    for rule in load_policy().rules:
+        key = _RUFF_SELECT_KINDS.get(rule.check.kind)
+        if key is None or rule.level != "required":
+            continue
+        families.extend(
+            family for family in rule.check.config[key] if family not in families
+        )
+    return families
 
 
 def _merge_pyproject(
@@ -364,7 +447,7 @@ def _merge_pyproject(
         lint["select"] = select
     if not isinstance(select, list):
         raise AdoptionError("cannot merge tool.ruff.lint.select: expected an array")
-    for family in starter["tool"]["ruff"]["lint"]["select"]:
+    for family in _required_ruff_families():
         if family not in select:
             select.append(family)
 
@@ -379,11 +462,13 @@ def _merge_pyproject(
         elif not isinstance(build, dict):
             raise AdoptionError("cannot merge build-system: expected a table")
 
+    _reorder_tables(document, shape)
     return tomlkit.dumps(document), dependency_changed, conflicts
 
 
-def _merge_pre_commit(path: Path, profile: str) -> str:
+def _merge_pre_commit(path: Path, profile: str) -> tuple[str, list[str]]:
     current = _load_yaml(path)
+    conflicts: list[str] = []
     expected = _ROUND_TRIP_YAML.load(_read_starter(profile, ".pre-commit-config.yaml"))
     repos = current.setdefault("repos", [])
     if not isinstance(repos, list):
@@ -418,10 +503,19 @@ def _merge_pre_commit(path: Path, profile: str) -> str:
             if hook is None:
                 hooks.append(copy.deepcopy(expected_hook))
                 continue
-            if "args" not in expected_hook:
-                hook.pop("args", None)
+            # `args` the starter does not model are load-bearing: dropping the
+            # baseline from `detect-secrets` turned a clean gate into 98
+            # findings. RSK007 compares the whole argument list, so keeping
+            # them leaves a finding -- one the maintainer can answer, unlike a
+            # silent deletion.
+            if "args" in hook and "args" not in expected_hook:
+                conflicts.append(
+                    f"{path.name}: hook {hook['id']!r} keeps args "
+                    f"{[str(arg) for arg in hook['args']]}, which the standard's "
+                    "hook shape does not model; RSK007 reports the difference"
+                )
             hook.update(copy.deepcopy(expected_hook))
-    return _dump_yaml(current)
+    return _dump_yaml(current), conflicts
 
 
 def _ensure_trigger(workflow: dict[str, Any], trigger: str) -> None:
@@ -471,6 +565,63 @@ def _set_uses_comment(step: Any, comment: str) -> None:
     token[2].value = comment + existing[len(existing.split("\n", maxsplit=1)[0]) :]
 
 
+def _reconcile_reusable_call(path: Path, job: Any, called: str) -> list[str]:
+    """Reconcile a job that calls a reusable workflow instead of running steps.
+
+    Such a job has no steps of its own, and a `steps:` list beside its `uses:`
+    is a job GitHub refuses to schedule. What the kit can reconcile is what the
+    kit knows: where its own reusable workflow now lives and which inputs it
+    still accepts. Which revision to trust stays the maintainer's, so the
+    release tag goes in and the pin RSK029 wants is reported.
+    """
+    relative = path.relative_to(path.parents[2]).as_posix()
+    workflow, _, ref = called.rpartition("@")
+    if not workflow.startswith(f"{_KIT_REPOSITORY}/.github/workflows/"):
+        return [
+            f"{relative}: the job calls reusable workflow {called!r}, which this "
+            "kit does not publish; reconcile it by hand"
+        ]
+    conflicts: list[str] = []
+    version = f"v{kit_version()}"
+    if workflow != _REUSABLE_COMPLIANCE or not is_full_commit_sha(ref):
+        job["uses"] = f"{_REUSABLE_COMPLIANCE}@{version}"
+    if not is_full_commit_sha(str(job["uses"]).rsplit("@", maxsplit=1)[-1]):
+        conflicts.append(
+            f"{relative}: reusable workflow {job['uses']!r} needs a "
+            "maintainer-selected full commit SHA"
+        )
+    inputs = job.get("with")
+    if not isinstance(inputs, dict):
+        inputs = {}
+        job["with"] = inputs
+    dropped = sorted(set(inputs) - set(_REUSABLE_INPUTS))
+    for name in dropped:
+        del inputs[name]
+    inputs["standard-ref"] = version
+    if dropped:
+        conflicts.append(
+            f"{relative}: reusable workflow inputs {', '.join(dropped)} no longer "
+            "exist and were removed; own the command to keep what they asked for"
+        )
+    conflicts.append(
+        f"{relative}: the job calls the reusable workflow, so it runs repo-check "
+        "from the called workflow and no step of its own; RSK030 reports that"
+    )
+    return conflicts
+
+
+def _run_commands(run: str) -> set[tuple[str, ...]]:
+    """The commands a `run` scalar executes, whatever conditions gate them.
+
+    The same gate is spelled differently in different repositories -- a bare
+    `uv build --all-packages` against the starter's `compgen`-guarded form --
+    and comparing whole `run` bodies read those as two steps, so both were
+    written out under one name. Reusing the checker's own parser keeps one
+    answer to what a step executes.
+    """
+    return {command.tokens for command in _shell_commands(run)}
+
+
 def _merge_workflow(
     path: Path, profile: str, relative: str, job_name: str
 ) -> tuple[str, list[str]]:
@@ -499,6 +650,9 @@ def _merge_workflow(
         and current.get("permissions") != {"contents": "read"}
     ):
         job["permissions"] = {"contents": "read"}
+    if isinstance(job.get("uses"), str):
+        called_conflicts = _reconcile_reusable_call(path, job, job["uses"])
+        return _dump_yaml(current), called_conflicts
     steps = job.setdefault("steps", [])
     if not isinstance(steps, list):
         raise AdoptionError(f"cannot reconcile {path}: job steps must be a list")
@@ -521,14 +675,14 @@ def _merge_workflow(
                 None,
             )
         elif isinstance(expected_run, str):
-            expected_tokens = shlex.split(expected_run.replace("\n", " "))
+            expected_commands = _run_commands(expected_run)
             match = next(
                 (
                     step
                     for step in steps
                     if isinstance(step, dict)
                     and isinstance(step.get("run"), str)
-                    and shlex.split(step["run"].replace("\n", " ")) == expected_tokens
+                    and _run_commands(step["run"]) & expected_commands
                 ),
                 None,
             )
@@ -772,13 +926,32 @@ def _merge_agents(path: Path, profile: str, values: dict[str, str]) -> str:
     return _ensure_standards_reference(text, shape)
 
 
+_README_GAP = "`repo-adopt` added this required heading; it has no content yet."
+
+
+def _fill_missing_readme_sections(text: str, shape: Shape) -> str:
+    """Add every required README section as a stated gap.
+
+    The starter's bodies describe a repository `repo-init` has just generated
+    -- add the first package, replace this section -- which is false of a
+    repository that already exists and leaves the reader prose to delete. An
+    inserted section says it is empty and stops there.
+    """
+    for section in shape.sections:
+        if section.level != "required" or _section(text, section.heading) is not None:
+            continue
+        text = _insert_section(
+            text, shape, section.heading, f"## {section.heading}\n\n{_README_GAP}\n"
+        )
+    return text
+
+
 def _merge_readme(path: Path, profile: str, values: dict[str, str]) -> str:
-    reference = _render(_read_starter(profile, "README.md"), values)
     text = _existing(path)
     if text is None:
-        return reference
+        return _render(_read_starter(profile, "README.md"), values)
     shape = _shape_for("RSK023")
-    text = _fill_required_sections(text, shape, reference)
+    text = _fill_missing_readme_sections(text, shape)
     return _ensure_standards_reference(text, shape)
 
 
@@ -831,16 +1004,19 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
     changes: list[PlannedFile] = []
     unchanged: list[str] = []
     conflicts: list[str] = []
+    notices = [notice for notice in (_standard_major_notice(document),) if notice]
 
     pyproject, dependency_changed, pyproject_conflicts = _merge_pyproject(
         root / "pyproject.toml", document, selected
     )
     conflicts.extend(pyproject_conflicts)
+    pre_commit, pre_commit_conflicts = _merge_pre_commit(
+        root / ".pre-commit-config.yaml", selected
+    )
+    conflicts.extend(pre_commit_conflicts)
     generated: dict[str, str] = {
         "pyproject.toml": pyproject,
-        ".pre-commit-config.yaml": _merge_pre_commit(
-            root / ".pre-commit-config.yaml", selected
-        ),
+        ".pre-commit-config.yaml": pre_commit,
         ".pymarkdown.json": _merge_json(
             root / ".pymarkdown.json", selected, ".pymarkdown.json"
         ),
@@ -897,6 +1073,7 @@ def plan_adoption(root: Path, profile: str | None = None) -> AdoptionPlan:
         unchanged=tuple(sorted(set(unchanged))),
         conflicts=tuple(conflicts),
         dependency_metadata_changed=dependency_changed,
+        notices=tuple(notices),
     )
 
 
@@ -960,6 +1137,8 @@ def _remaining_findings(plan: AdoptionPlan) -> list[Finding]:
 
 
 def _print_summary(plan: AdoptionPlan, findings: list[Finding] | None) -> None:
+    for notice in plan.notices:
+        print(f"note: {notice}")
     for action in ("added", "updated"):
         paths = [
             change.path.as_posix() for change in plan.changes if change.action == action

--- a/src/repo_standard/repo_adopt.py
+++ b/src/repo_standard/repo_adopt.py
@@ -611,8 +611,9 @@ def _reconcile_reusable_call(path: Path, job: Any, called: str) -> list[str]:
             "exist and were removed; own the command to keep what they asked for"
         )
     conflicts.append(
-        f"{relative}: the job calls the reusable workflow, so it runs repo-check "
-        "from the called workflow and no step of its own; RSK030 reports that"
+        f"{relative}: the job calls the reusable workflow, so repo-check runs "
+        "there and this file declares no step of its own; own the command "
+        "instead to control how the checker is invoked"
     )
     return conflicts
 

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -62,6 +62,22 @@ def _write_minimal_repo(root: Path, profile: str) -> None:
         (root / "packages").mkdir()
 
 
+def _accept_recommended_ruff_families(root: Path) -> None:
+    """Select the families adoption leaves to the maintainer.
+
+    Adoption only repairs `required` rules, so a repository it has finished
+    with still carries the recommended ones. A test that needs a repository
+    with no findings at all makes that choice itself.
+    """
+    path = root / "pyproject.toml"
+    document = tomlkit.parse(path.read_text(encoding="utf-8"))
+    select = document["tool"]["ruff"]["lint"]["select"]
+    for family in load_policy().rule("RSK016").check.config["values"]:
+        if family not in select:
+            select.append(family)
+    path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+
 @pytest.mark.parametrize("profile", ["python-single", "python-workspace"])
 def test_adoption_reaches_zero_required_findings_and_is_idempotent(
     tmp_path: Path, profile: str
@@ -261,6 +277,7 @@ def test_fully_compliant_repository_still_gets_a_missing_gitignore(
     _write_minimal_repo(root, "python-single")
     apply_plan(plan_adoption(root, "python-single"))
     (root / "LICENSE").write_text("Approved license terms.\n", encoding="utf-8")
+    _accept_recommended_ruff_families(root)
     assert check_repo(root, load_policy(), profile="python-single") == []
     (root / ".gitignore").unlink()
 
@@ -276,6 +293,7 @@ def test_structurally_compliant_repository_is_a_no_op(tmp_path: Path) -> None:
     _write_minimal_repo(root, "python-single")
     apply_plan(plan_adoption(root, "python-single"))
     (root / "LICENSE").write_text("Approved license terms.\n", encoding="utf-8")
+    _accept_recommended_ruff_families(root)
 
     pre_commit = root / ".pre-commit-config.yaml"
     hooks = load_yaml(pre_commit.read_text(encoding="utf-8"))
@@ -793,3 +811,225 @@ def test_repinning_carries_the_starters_version_comment_across(
     # replaced comment token carried is still where it was.
     assert "v4.2.2" not in written
     assert "\n\n      - uses: astral-sh/setup-uv@" in written
+
+
+def _v1_compliance_caller(root: Path, uses: str, inputs: str) -> Path:
+    """The compliance workflow shape `docs/compliance.md` publishes as supported."""
+    workflow = root / ".github" / "workflows" / "compliance.yml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(
+        "name: Compliance\n"
+        "on:\n"
+        "  pull_request:\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "jobs:\n"
+        f"  compliance:\n    uses: {uses}\n    with:\n{inputs}",
+        encoding="utf-8",
+    )
+    return workflow
+
+
+def test_a_reusable_workflow_call_is_reconciled_and_never_gains_steps(
+    tmp_path: Path,
+) -> None:
+    """A job declaring both `uses:` and `steps:` is one GitHub refuses to run."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-workspace")
+    workflow = _v1_compliance_caller(
+        root,
+        "FP-DevTools/repo-standard-kit/.github/workflows/compliance.yml@v1.2.0",
+        "      standard-ref: v1.2.0\n      strict: true\n",
+    )
+
+    plan = plan_adoption(root, "python-workspace")
+    apply_plan(plan)
+
+    job = load_yaml(workflow.read_text(encoding="utf-8"))["jobs"]["compliance"]
+    assert "steps" not in job
+    assert job["uses"] == (
+        "FP-DevTools/repo-standard-kit/.github/workflows/"
+        f"compliance-reusable.yml@v{kit_version()}"
+    )
+    assert job["with"] == {"standard-ref": f"v{kit_version()}"}
+    assert any("full commit SHA" in conflict for conflict in plan.conflicts)
+    assert any("strict" in conflict for conflict in plan.conflicts)
+
+
+def test_a_reusable_workflow_this_kit_does_not_publish_is_left_alone(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-workspace")
+    uses = "vendor/ci/.github/workflows/compliance.yml@v3"
+    workflow = _v1_compliance_caller(root, uses, "      mode: strict\n")
+
+    plan = plan_adoption(root, "python-workspace")
+    apply_plan(plan)
+
+    job = load_yaml(workflow.read_text(encoding="utf-8"))["jobs"]["compliance"]
+    assert job == {"uses": uses, "with": {"mode": "strict"}}
+    assert any(uses in conflict for conflict in plan.conflicts)
+
+
+def test_hook_args_the_starter_does_not_model_are_kept_and_reported(
+    tmp_path: Path,
+) -> None:
+    """Dropping `--baseline` turned a clean gate into 98 detect-secrets findings."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    (root / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: detect-secrets\n"
+        "        name: detect secrets\n"
+        "        entry: uv run detect-secrets-hook\n"
+        "        args: ['--baseline', '.secrets.baseline']\n"
+        "        language: system\n"
+        "        types: [text]\n",
+        encoding="utf-8",
+    )
+
+    plan = plan_adoption(root, "python-single")
+    apply_plan(plan)
+
+    hook = next(
+        item
+        for repository in load_yaml(
+            (root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+        )["repos"]
+        for item in repository.get("hooks", [])
+        if item.get("id") == "detect-secrets"
+    )
+    assert hook["args"] == ["--baseline", ".secrets.baseline"]
+    assert any("detect-secrets" in conflict for conflict in plan.conflicts)
+
+
+def test_a_recommended_lint_family_is_left_to_the_maintainer(tmp_path: Path) -> None:
+    """Selecting `PT` unasked turned a clean `ruff check` into seven errors."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+
+    apply_plan(plan_adoption(root, "python-single"))
+
+    policy = load_policy()
+    document = tomlkit.parse((root / "pyproject.toml").read_text(encoding="utf-8"))
+    select = set(document["tool"]["ruff"]["lint"]["select"])
+    assert set(policy.rule("RSK010").check.config["required_select"]) <= select
+    assert not set(policy.rule("RSK016").check.config["values"]) & select
+
+
+def test_a_stale_standard_major_adopts_without_an_explicit_profile(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The state every earlier-major adopter is in is what adoption repairs."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    with (root / "pyproject.toml").open("a", encoding="utf-8") as stream:
+        stream.write(
+            '\n[tool.repo-standard]\nprofile = "python-single"\nstandard = "1"\n'
+        )
+    _commit_minimal_repo(root)
+
+    assert main([str(root), "--no-lock", "--no-install"]) == 0
+
+    major = load_policy().standard_major
+    output = capsys.readouterr().out
+    assert "standard '1'" in output
+    assert f"standard {major!r}" in output
+    document = tomlkit.parse((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert document["tool"]["repo-standard"]["standard"] == major
+
+
+def test_an_unknown_profile_still_asks_for_an_explicit_one(tmp_path: Path) -> None:
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    with (root / "pyproject.toml").open("a", encoding="utf-8") as stream:
+        stream.write('\n[tool.repo-standard]\nprofile = "python-elixir"\n')
+
+    with pytest.raises(AdoptionError, match="python-elixir"):
+        plan_adoption(root)
+
+
+def test_adoption_leaves_pyproject_in_canonical_table_order(tmp_path: Path) -> None:
+    """`updated: pyproject.toml` must not also mean `still failing RSK025`."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-single")
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8")
+        + '\n[tool.repo-standard]\nprofile = "python-single"\nstandard = "1"\n'
+        '\n[tool.ty.src]\nroot = "src"\n'
+        "\n[dependency-groups]\ndev = []\n"
+        '\n[tool.pytest.ini_options]\ntestpaths = ["tests"]\n',
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root))
+
+    policy = load_policy()
+    shape = policy.shape(policy.rule("RSK025").check.config["shape"])
+    tables = re.findall(
+        r"^\[\[?\s*([^\]\s]+)\s*\]\]?$",
+        pyproject.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert _is_subsequence(tables, shape.headings), f"table order is wrong: {tables}"
+    assert not [
+        finding
+        for finding in check_repo(root, policy, profile="python-single")
+        if finding.rule_id == "RSK025"
+    ]
+
+
+def test_an_equivalent_step_is_matched_rather_than_appended_again(
+    tmp_path: Path,
+) -> None:
+    """The starter guards the build; the adopter runs it plainly. One step."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-workspace")
+    workflow = root / ".github" / "workflows" / "quality.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "name: CI\n"
+        "on: pull_request\n"
+        "jobs:\n"
+        "  quality:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: Build packages\n"
+        "        run: uv build --all-packages\n",
+        encoding="utf-8",
+    )
+
+    apply_plan(plan_adoption(root, "python-workspace"))
+
+    steps = load_yaml(workflow.read_text(encoding="utf-8"))["jobs"]["quality"]["steps"]
+    names = [step["name"] for step in steps if "name" in step]
+    assert len(names) == len(set(names)), f"duplicate step names: {names}"
+    assert [step for step in steps if step.get("name") == "Build packages"] == [
+        {"name": "Build packages", "run": "uv build --all-packages"}
+    ]
+
+
+def test_an_inserted_readme_section_states_the_gap(tmp_path: Path) -> None:
+    """The starter's prose describes a repository `repo-init` has just generated."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-workspace")
+
+    apply_plan(plan_adoption(root, "python-workspace"))
+
+    policy = load_policy()
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    shape = policy.shape(policy.rule("RSK023").check.config["shape"])
+    assert "repo-add-package" not in readme
+    assert "Replace this section" not in readme
+    assert readme.count("it has no content yet.") == len(
+        [section for section in shape.sections if section.level == "required"]
+    )
+    assert not [
+        finding
+        for finding in check_repo(root, policy, profile="python-workspace")
+        if finding.rule_id == "RSK023"
+    ]

--- a/tests/test_repo_adopt.py
+++ b/tests/test_repo_adopt.py
@@ -15,6 +15,8 @@ from repo_standard.compliance.checks import Finding, check_repo, load_policy
 from repo_standard.policy.models import LEVEL_ORDER
 from repo_standard.project_metadata import kit_version
 from repo_standard.repo_adopt import (
+    ADOPTED_LICENSE_NOTICE,
+    ADOPTION_UNLICENSED_NOTICE,
     AdoptionError,
     AdoptionPlan,
     CommandError,
@@ -1025,11 +1027,41 @@ def test_an_inserted_readme_section_states_the_gap(tmp_path: Path) -> None:
     shape = policy.shape(policy.rule("RSK023").check.config["shape"])
     assert "repo-add-package" not in readme
     assert "Replace this section" not in readme
+    # Every required section but `License`, whose body adoption reads off the
+    # repository rather than leaving to the maintainer.
     assert readme.count("it has no content yet.") == len(
-        [section for section in shape.sections if section.level == "required"]
+        [
+            section
+            for section in shape.sections
+            if section.level == "required" and section.id != "license"
+        ]
     )
     assert not [
         finding
         for finding in check_repo(root, policy, profile="python-workspace")
         if finding.rule_id == "RSK023"
     ]
+
+
+@pytest.mark.parametrize(
+    ("licensed", "expected"),
+    [
+        (True, ADOPTED_LICENSE_NOTICE),
+        (False, ADOPTION_UNLICENSED_NOTICE),
+    ],
+)
+def test_an_inserted_license_section_states_the_terms(
+    tmp_path: Path, licensed: bool, expected: str
+) -> None:
+    """`License` is the one section adoption can answer from the repository."""
+    root = tmp_path / "existing"
+    _write_minimal_repo(root, "python-workspace")
+    if licensed:
+        (root / "LICENSE").write_text("Approved license terms.\n", encoding="utf-8")
+
+    apply_plan(plan_adoption(root, "python-workspace"))
+
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    assert f"## License\n\n{expected}\n" in readme
+    # `repo-init --license` is not a command an existing repository can run.
+    assert "rerun `repo-init`" not in readme


### PR DESCRIPTION
Phase B1 of #85 — findings 1, 2, 3, 4, 5, 7 and 8, all in
`src/repo_standard/repo_adopt.py`. Closes #86 by hand on merge (closing
keywords do not fire for a PR targeting a non-default branch).

Finding 6 (RSK025 requiring `[project]` from a uv virtual workspace root) is
**phase B2 / #87** and is untouched here; it is still present in the
end-to-end run below and B2 owns it.

## What each defect was, and what changed

### 1 — `steps:` appended beside a job-level `uses:` (`repo_adopt.py:502`)

`job.setdefault("steps", [])` never asked whether the job was a
reusable-workflow call, so a `steps:` list was created beside the existing
`uses:` and GitHub refused to schedule the workflow.

A job declaring `uses:` is now recognised as a call and never gains steps.
Where it calls **this kit's** reusable workflow, `_reconcile_reusable_call`
reconciles what the kit actually knows: the file moved to
`compliance-reusable.yml` in this release, and `standard-ref` is the only
input left, so `strict` / `check-enforcement` are removed. A call to a
reusable workflow the kit does not publish is reported and the job is left
byte-identical.

**Choice made:** #85 allowed either reconciling the call or reporting it and
leaving the file alone. Reconciling was picked because the two facts that
needed fixing — the rename and the input set — are the kit's own, and leaving
them stale leaves a caller that resolves to a 404. What is *not* the kit's to
choose is the pin: RSK029 wants a 40-character SHA and only the maintainer can
say which one, so the release tag goes in and the pin is reported as a
conflict. A pre-existing full-SHA pin on the canonical path is left alone.

**Also reported, deliberately:** the reusable-call form cannot satisfy
**RSK030**, which reads `run:` bodies from the job's own steps and therefore
sees none. That is a standing tension between `docs/compliance.md`
§"Alternative: calling the reusable workflow" and RSK030 in
`compliance/checks.py` — outside B1's surface, and not something adoption
should resolve by silently rewriting the maintainer's chosen form into the
uvx-direct one. `repo-adopt` now says so in one line instead of leaving the
adopter to discover it from a red status. See *Not fixed* below.

### 2 — hook `args` silently stripped (`repo_adopt.py:421`)

`if "args" not in expected_hook: hook.pop("args", None)` deleted the adopter's
`--baseline .secrets.baseline`, producing 98 `detect-secrets` findings with
`conflicts/manual actions: none` reported.

Args the starter does not model are now kept, and their presence is reported as
a conflict. Keeping them is the only option that leaves gate 1 working:
RSK007 compares the *whole* normalised argument list, so a baseline arg is a
required finding either way — but a reported finding is one the maintainer can
answer, and a deleted baseline is a gate that turns red for a reason nobody
was told about.

### 3 — `recommended` families applied unasked (`repo_adopt.py:367`)

The starter's whole `select` list was appended with no level gating, so `PT`
(RSK016, **recommended**) was added and `ruff check .` went from clean to 7
`PT018` errors.

Adoption now reads the requirement from policy rather than from the starter:
`_required_ruff_families()` walks `policy.rules` for `ruff_baseline` /
`ruff_select` checks at `required` level. Today that is RSK010's
`[E, F, I, B, UP]`. A recommended family stays the maintainer's call and is
reported by `repo-check` as before.

Side effect worth knowing: because adoption no longer repairs RSK016, a
repository it has finished with normally still carries that recommended
finding, so the "no findings ⇒ no planned changes" short circuit in
`plan_adoption` fires less often. The merges are idempotent, so this changes
nothing an adopter sees; two tests that needed a zero-finding repository now
select the recommended families themselves through
`_accept_recommended_ruff_families`.

### 4 — a stale standard major reported as invalid metadata (`repo_adopt.py:242`)

Every v1.x adopter met `existing [tool.repo-standard] metadata is invalid;
pass --profile`, which named neither the field nor the two values and sent the
reader to check a profile string that was correct.

The two conditions are now separated. An unrecognised profile still stops the
run and names the value and the profiles this kit publishes. A stale
`standard` major does not: it is the upgrade adoption exists to perform, so it
is reported on a `note:` line naming both majors and the run continues.

`AdoptionPlan` gained a `notices` field for this. A conflict would have been
wrong — it fails the run and asks the maintainer for something — and a bare
`updated: pyproject.toml` line says nothing about which of the two majors is
which.

### 5 — `pyproject.toml` rewritten and left failing required RSK025 (`repo_adopt.py:321`)

`_place` put *new* tables where the shape declares, but a table the repository
already had was never moved, so `[tool.repo-standard]` before
`[dependency-groups]` survived adoption as a required finding in a file that
had just been rewritten.

`_reorder_tables` now reads the same shape (`policy/shapes.yaml`, through
`_shape_for("RSK025")` — no second copy of the order) and permutes the
declared tables into canonical order. It is deliberately minimal: only
declared tables move, each into a slot a declared table already occupied, so
unlisted tables such as `[tool.coverage.*]` and `[tool.uv.workspace]` keep
their positions and every table keeps its own comments and trivia.

### 7 — duplicate step appended when an equivalent one exists (`repo_adopt.py:506`)

Step matching compared `shlex` tokens of the whole `run` body, so the
adopter's `uv build --all-packages` did not match the starter's
`compgen`-guarded form and a **second step of the same name** was appended.

Matching is now on the commands a step executes, via the checker's own
`_shell_commands` parser — the same notion of "what does this step run" that
RSK006 uses, rather than a second one. A guarded and an unguarded spelling of
the same command are one step.

### 8 — starter placeholder prose injected into an established README (`repo_adopt.py:775`)

`_merge_readme` filled missing required sections from the rendered starter,
which describes a repository `repo-init` has just generated — "Add the first
package with `repo-add-package`", "Replace this section with what the
workspace is actually for" — into a repository with four packages.

An inserted section now states the gap and stops:

```markdown
## Usage

`repo-adopt` added this required heading; it has no content yet.
```

**Choice made:** the line is generic rather than per-section. A per-section
dictionary would go stale the moment the README shape gains a section, and the
shape is declared data. `AGENTS.md` keeps filling from the starter, whose
bodies are instructions that are true of any repository; the README's are not.
`## License` loses the computed `See LICENSE for the terms that apply.` line
under this rule — the trade for one rule instead of a per-section exception
list, and RSK018 still reports a missing `LICENSE`.

## Regression coverage

Nine tests added to `tests/test_repo_adopt.py`, one per defect plus the two
paths that must keep refusing:

| Test | Covers |
| --- | --- |
| `test_a_reusable_workflow_call_is_reconciled_and_never_gains_steps` | 1 |
| `test_a_reusable_workflow_this_kit_does_not_publish_is_left_alone` | 1 |
| `test_hook_args_the_starter_does_not_model_are_kept_and_reported` | 2 |
| `test_a_recommended_lint_family_is_left_to_the_maintainer` | 3 |
| `test_a_stale_standard_major_adopts_without_an_explicit_profile` | 4 |
| `test_an_unknown_profile_still_asks_for_an_explicit_one` | 4 |
| `test_adoption_leaves_pyproject_in_canonical_table_order` | 5 |
| `test_an_equivalent_step_is_matched_rather_than_appended_again` | 7 |
| `test_an_inserted_readme_section_states_the_gap` | 8 |

Every one of them fails on `chore/release-v2.0.0`.

`CHANGELOG.md` and `docs/bootstrap-workflow.md` are updated: the changelog
already claimed "`repo-adopt` reorders the declared tables while retaining
unlisted tables", which was not true until finding 5 was fixed, and the
bootstrap doc's profile-resolution paragraph described the behaviour finding 4
replaces. `policy/` is untouched, so nothing needed regenerating.

## Verification

### This repository

| Gate | Result |
| --- | --- |
| `uv sync --locked` | Resolved 39 packages, checked 39 |
| `uv run pre-commit run --all-files` | 14/14 hooks Passed |
| `uv run pytest` | **469 passed** in 40.28s (460 before) |
| `uv build` | `repo_standard_kit-2.0.0` sdist + wheel |
| `uv run repo-check . --strict` | exit 0 — 1 finding, RSK011, pre-existing `[tool.repo-check.ignore]` exemption |

### End to end against the adopter

`FP-DevTools/wombat_configs` `chore/adopt-repo-standard-kit` at `100d259`
(`origin/main` merged), clean tree, run with
`repo-adopt <target> --profile python-workspace --no-install`:

```text
repo-standard-kit 2.0.0; profile python-workspace
note: this repository declares standard '1' and this kit is standard '2'; adoption upgrades [tool.repo-standard] to it
added: none
updated: pyproject.toml, .pre-commit-config.yaml, AGENTS.md, README.md, .github/workflows/compliance.yml
unchanged: .github/dependabot.yml, .github/workflows/quality.yml, .gitignore, .pymarkdown.json, CHANGELOG.md, docs/adr
conflicts/manual actions:
  - .pre-commit-config.yaml: hook 'detect-secrets' keeps args ['--baseline', '.secrets.baseline'], which the standard's hook shape does not model; RSK007 reports the difference
  - .github/workflows/compliance.yml: reusable workflow 'FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml@v2.0.0' needs a maintainer-selected full commit SHA
  - .github/workflows/compliance.yml: the job calls the reusable workflow, so it runs repo-check from the called workflow and no step of its own; RSK030 reports that
remaining required findings: 4
  - RSK007 .pre-commit-config.yaml: Hook 'detect-secrets' is missing or has incompatible command/fields.
  - RSK025 pyproject.toml: Missing required sections: project.
  - RSK029 .github/workflows/compliance.yml: Remote reference is not pinned to a full commit SHA: ...compliance-reusable.yml@v2.0.0.
  - RSK030 .github/workflows/compliance.yml: Job 'compliance' has no executable steps.
remaining recommended findings: 2
  - RSK016 pyproject.toml: Ruff omits recommended families: ['PT'].
  - RSK018 LICENSE: Required file is missing.
remaining advisory findings: 1
  - RSK015 pyproject.toml: Ruff line-length differs from the recommendation.
suppressed by [tool.repo-check.ignore]: 0
```

Compare with #85: the `steps:` corruption, the stripped baseline, the added
`PT`, the refusal to run without `--profile`, the RSK025 table-order finding,
the duplicate `Build packages` step and the placeholder README prose are all
gone. The four remaining required findings are the two the maintainer's own
choices produce (RSK007, and RSK029+RSK030 from the reusable-call form), plus
B2's.

Adopted tree, from inside the adopter:

| Check | Result |
| --- | --- |
| `compliance.yml` parses; no job declares both `uses:` and `steps:` | **pass** — asserted with PyYAML over all four workflow files |
| no duplicate step names in `quality.yml` | **pass** — `quality` 10 named steps, `diagnostics-wheel` 4, all unique; `quality.yml` was reported `unchanged` |
| `uv run ruff check .` | **All checks passed!** (was 7 `PT018` errors) |
| `uv run pytest` | **460 passed** in 274s, coverage 75.98% ≥ 70% |
| `uv build --all-packages` | 6 artifacts built (`wombat_configs`, `wombat_diagnostics`, `wombat_diagreport_contract`) |
| `uv run detect-secrets-hook --baseline .secrets.baseline` on the five changed files | exit 0 (was 98 findings) |
| `repo-adopt` with `standard = "1"` and **no** `--profile` | resolves `python-workspace`, prints the `note:` line, proceeds |
| re-running `repo-adopt` on the adopted tree | `updated: none` — idempotent |

`uv run pre-commit run --all-files`, with the `repo-check` hook `rev:`
temporarily pointed at `3049bd5` (the `v2.0.0` tag does not exist yet):

```text
check yaml ... Passed          ruff check ......... Passed
check toml ... Passed          ruff format ........ Passed
check json ... Passed          ty check ........... Passed
trim trailing whitespace ...   uv lock check ...... Passed
             Passed            markdown lint ...... Failed  (pre-existing)
fix final newline .. Passed    repo-check ......... Failed  (4 required findings above)
check merge conflict Passed
detect private keys  Passed
detect secrets ..... see note
prevent oversized .. Passed
```

Two notes on that table, both verified rather than assumed:

- **`markdown lint`** fails on `docs/dod_generator_design.md:74` (MD038), a
  file adoption does not touch. Confirmed pre-existing by running the hook
  against the stashed, pristine tree — it arrived with wombat PR #73, merged
  from `origin/main` after #85 was written.
- **`detect secrets`** flags `.pre-commit-config.yaml:92` as a "Hex High
  Entropy String" *only* while the `rev:` workaround puts a 40-character SHA
  on that line. With the shipped `rev: v2.0.0` it passes; verified by running
  `detect-secrets-hook --baseline .secrets.baseline` directly over the five
  files adoption changed → exit 0.

The adopter worktree was reset with `git checkout -- .` and is clean at
`100d259`. Nothing was committed or pushed there.

## Not fixed, and why

- **RSK030 rejects the reusable-workflow form.** `docs/compliance.md` publishes
  that form as supported, but `_job_shell_commands` in
  `compliance/checks.py` reads `run:` bodies from the job's own steps, so a
  caller job reports `Job 'compliance' has no executable steps` — and the
  called workflow then runs `repo-check`, which reports it. A repository on
  that form is red whatever `repo-adopt` does. Fixing it means either teaching
  RSK030 that a `uses:` to the kit's reusable workflow satisfies the rule, or
  retiring the alternative form from the docs. Both are policy-shaped calls
  outside B1's surface (`checks.py` / `docs/`), so `repo-adopt` reports the
  situation rather than deciding it.
- **RSK007 rejects any option the hook shape does not model**, including a
  `detect-secrets` baseline. That is the pre-existing wombat defect #85 already
  records. Relaxing it is `policy/base.yaml`, which B1 must not edit.
- **The `SKIP: repo-check` env from the starter's `Run pre-commit` step is not
  applied to a matched existing step.** Adoption reconciles the step's
  identity, not its environment, so wombat's quality job still runs
  `repo-check` through the hook as well as through the compliance status. Not
  one of #85's eight findings; flagging it because A5 is what made that env
  meaningful.
- One cosmetic wart: lifting tables out and back leaves a double blank line
  where a moved table met its neighbour (visible once in the adopter's
  `pyproject.toml`). `check-toml` passes and re-running adoption is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qs4eZrQVJjNUHCjCZRvP2
