### PR TITLE
fix(compliance): resolve RSK030 through the reusable workflow the kit publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,8 @@ the changes listed under **Adopters must**.
   execute nothing. The rule requires the workflow to trigger on
   `pull_request` — the other three pass on one no pull request ever starts —
   and requires one executed command in `jobs.compliance.steps[*].run` to carry
-  `repo-check` in its argument list.
+  `repo-check` in its argument list, or the job to call this repository's
+  `compliance-reusable.yml`, which runs the checker in the caller's place.
   Policy owns the token, and the match is containment rather than an exact
   command, because an adopter runs a released checker with `uvx` while this
   repository runs its own working tree with `uv run` — both correct. The claim
@@ -343,6 +344,20 @@ the changes listed under **Adopters must**.
   this repository's own RSK011 entry lists twenty-one of them, which put a
   1,400-character line in front of a reader who needed the count.
   `--format json` still emits the full list.
+- **RSK030 rejected the reusable-workflow form this kit publishes.** A
+  `compliance` job whose `uses:` calls
+  `FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml`
+  declares no steps of its own, so the rule found no `run:` body to read and
+  reported `Job 'compliance' has no executable steps` — a required finding
+  against the shape `docs/compliance.md` §Alternative publishes as supported,
+  and against the same document's claim that the status does not depend on
+  whether the adopter calls a reusable workflow. The rule now resolves the
+  invocation through that call, because the called workflow is the invocation.
+  Recognition reads `owner/repo/path` only and never the ref, so the SHA RSK029
+  requires is free to change; another repository's reusable workflow, and a job
+  with neither steps nor such a call, still fail. The published caller example
+  gained the `permissions: contents: read` block RSK028 requires of it, which
+  it had been missing.
 - **`repo-adopt` left a stale version comment beside a SHA it had just
   changed.** Repinning `uses: actions/checkout@v4 # v4.2.2` wrote the starter's
   v7.0.1 SHA and kept `# v4.2.2` next to it, which Dependabot reads as the
@@ -394,11 +409,13 @@ to see what is left; the list below is what that repairs and what it cannot.
   repaired. `docs/quality-gates.md` §5 already required this job; only the
   structural checks are new.
 - Make sure that job actually runs the checker, on pull requests. **RSK030**
-  requires the workflow to trigger on `pull_request` and one executed command
-  in `jobs.compliance.steps[*].run` to contain `repo-check`, so a workflow
-  reachable only by `workflow_dispatch`, a job that only checks out the
-  repository, or an invocation guarded by a shell conditional inside the
-  `run:` body each report a required finding. A step's Actions-level `if:` is
+  requires the workflow to trigger on `pull_request` and either one executed
+  command in `jobs.compliance.steps[*].run` containing `repo-check` or a job
+  calling this repository's `compliance-reusable.yml`, so a workflow reachable
+  only by `workflow_dispatch`, a job that only checks out the repository, a job
+  that declares neither steps nor such a call, a job calling some other
+  repository's reusable workflow, or an invocation guarded by a shell
+  conditional inside the `run:` body each report a required finding. A step's Actions-level `if:` is
   not one of them: the checker reads `run:` bodies and nothing else, so a
   `repo-check` step carrying `if: false` or `continue-on-error: true` still
   satisfies RSK030. The prescribed form is the

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -232,12 +232,26 @@ name: Compliance
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   compliance:
     uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml@<full-sha>
     with:
       standard-ref: v2.0.0
 ```
+
+RSK030 requires the `compliance` job to run the checker, and a job that calls a
+reusable workflow declares no steps of its own to read. It resolves through the
+`uses:` instead: a job calling this repository's `compliance-reusable.yml` runs
+the checker, because that is what the called workflow does. Recognition is by
+`owner/repo/path` only, so the SHA RSK029 requires — or an immutable tag — is
+free to change without touching the rule. Nothing else counts: a `compliance`
+job that declares no steps and calls no such workflow still fails RSK030, and
+so does one calling some other repository's reusable workflow, which is no
+evidence the checker ever runs. The permissions block above is the caller's own
+RSK028 obligation; the called workflow declares its own least privilege too.
 
 This form is shorter and the runner is maintained centrally, at the cost of
 running exactly one command with no options. `standard-ref` is the sole input,

--- a/docs/policy-reference.md
+++ b/docs/policy-reference.md
@@ -469,7 +469,7 @@ Remediation: Pin every remote action and reusable workflow in the compliance wor
 
 Rationale: An existing, least-privileged, fully pinned compliance workflow can still execute nothing. This rule requires the compliance job to run the checker on pull requests.
 
-Remediation: Trigger the compliance workflow on pull_request, and run repo-check from a step of its compliance job, unguarded or under a condition policy declares for the profile.
+Remediation: Trigger the compliance workflow on pull_request, then either run repo-check from a step of its compliance job — unguarded or under a condition policy declares for the profile — or have that job call the reusable workflow this kit publishes, which runs the checker for it.
 
 | Profile | Permitted guard |
 | --- | --- |

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -174,7 +174,13 @@ checker on pull requests: the workflow shall trigger on `pull_request`, and
 some command in `jobs.compliance.steps[*].run` shall carry `repo-check` in its
 argument list. The trigger belongs to this rule because the other three are
 satisfied by a workflow no pull request ever starts, which leaves the SHALL
-above unmet. The match is containment rather than an
+above unmet. A job calling the reusable workflow `repo-standard-kit` publishes
+at `.github/workflows/compliance-reusable.yml` satisfies the second half
+instead, because that workflow runs the checker and leaves the caller no steps
+to read; the rule recognises it by `owner/repo/path` and not by the ref, which
+is RSK029's subject. No other repository's reusable workflow counts, and a job
+that declares neither steps nor such a call fails. The match is containment
+rather than an
 exact command, because an adopter runs a released checker with `uvx` while this
 standards repository runs its own working tree with `uv run`, and both are
 correct. The guard semantics above apply unchanged, and no profile declares a

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -180,10 +180,9 @@ instead, because that workflow runs the checker and leaves the caller no steps
 to read; the rule recognises it by `owner/repo/path` and not by the ref, which
 is RSK029's subject. No other repository's reusable workflow counts, and a job
 that declares neither steps nor such a call fails. The match is containment
-rather than an
-exact command, because an adopter runs a released checker with `uvx` while this
-standards repository runs its own working tree with `uv run`, and both are
-correct. The guard semantics above apply unchanged, and no profile declares a
+rather than an exact command, because an adopter runs a released checker with
+`uvx` while this standards repository runs its own working tree with `uv run`,
+and both are correct. The guard semantics above apply unchanged, and no profile declares a
 permitted guard for this rule, so the invocation shall be unguarded. What
 containment buys is honest but limited: it cannot tell a real compliance run
 from a command that merely names the token, and it establishes only that the

--- a/policy/base.yaml
+++ b/policy/base.yaml
@@ -602,6 +602,8 @@ rules:
         job: compliance
         trigger: pull_request
         token: repo-check
+        reusable_workflow: >-
+          FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml
         guards_by_profile:
           python-single: []
           python-workspace: []
@@ -610,6 +612,7 @@ rules:
       execute nothing. This rule requires the compliance job to run the checker
       on pull requests.
     remediation: >-
-      Trigger the compliance workflow on pull_request, and run repo-check from
-      a step of its compliance job, unguarded or under a condition policy
-      declares for the profile.
+      Trigger the compliance workflow on pull_request, then either run
+      repo-check from a step of its compliance job — unguarded or under a
+      condition policy declares for the profile — or have that job call the
+      reusable workflow this kit publishes, which runs the checker for it.

--- a/src/repo_standard/compliance/checks.py
+++ b/src/repo_standard/compliance/checks.py
@@ -627,6 +627,20 @@ def _job_shell_commands(
     return commands, None
 
 
+def _calls_workflow(job: dict[str, Any], workflow: str) -> bool:
+    """Whether the job delegates to `workflow`, at whatever ref it is pinned to.
+
+    The ref is deliberately not part of the identity: RSK029 already requires a
+    SHA and the standard also permits an immutable tag, so reading it here
+    would answer a different question from the one asked. GitHub resolves owner
+    and repository case-insensitively, so the comparison folds case.
+    """
+    uses = job.get("uses")
+    if not isinstance(uses, str):
+        return False
+    return uses.split("@", 1)[0].strip().casefold() == workflow.casefold()
+
+
 def _permitted_guards(declared: list[str]) -> set[tuple[str, ...]]:
     return {tuple(shlex.split(guard)) for guard in declared}
 
@@ -714,6 +728,12 @@ def _github_workflow_invocation(
     Containment can, at the cost of a weaker claim: the job satisfies the rule
     when an executed command's argument list contains the token, whatever else
     that command does.
+
+    A job may also delegate the whole invocation to the reusable workflow
+    policy names, which runs the checker itself and therefore leaves the caller
+    no steps to inspect. That call is the invocation, so it resolves the rule;
+    another repository's reusable workflow is no evidence of anything and does
+    not.
     """
     document, job, errors = _workflow_job(context, config)
     if errors:
@@ -734,11 +754,23 @@ def _github_workflow_invocation(
                 document.line("on"),
             )
         )
-    commands, error = _job_shell_commands(document, job, config)
-    if error is not None:
-        issues.append(error)
+    reusable = config["reusable_workflow"]
+    if _calls_workflow(job, reusable):
         return issues
     token = config["token"]
+    commands, error = _job_shell_commands(document, job, config)
+    if error is not None:
+        issues.append(
+            Issue(
+                config["path"],
+                f"Job {config['job']!r} has no executable steps and does not "
+                f"call {reusable}.",
+                job.get("uses", job.get("steps")),
+                [f"a step running {token}", f"uses: {reusable}"],
+                document.line("jobs", config["job"]),
+            )
+        )
+        return issues
     declared_guards = config["guards_by_profile"][context.profile]
     permitted = _permitted_guards(declared_guards)
     invocations = [command for command in commands if token in command.tokens]

--- a/src/repo_standard/policy/compiled.json
+++ b/src/repo_standard/policy/compiled.json
@@ -855,6 +855,7 @@
           },
           "job": "compliance",
           "path": ".github/workflows/compliance.yml",
+          "reusable_workflow": "FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml",
           "token": "repo-check",
           "trigger": "pull_request"
         },
@@ -868,7 +869,7 @@
         "python-workspace"
       ],
       "rationale": "An existing, least-privileged, fully pinned compliance workflow can still execute nothing. This rule requires the compliance job to run the checker on pull requests.",
-      "remediation": "Trigger the compliance workflow on pull_request, and run repo-check from a step of its compliance job, unguarded or under a condition policy declares for the profile.",
+      "remediation": "Trigger the compliance workflow on pull_request, then either run repo-check from a step of its compliance job \u2014 unguarded or under a condition policy declares for the profile \u2014 or have that job call the reusable workflow this kit publishes, which runs the checker for it.",
       "source": {
         "document": "docs/quality-gates.md",
         "section": "5. CI Pull Request Gates"

--- a/src/repo_standard/policy/models.py
+++ b/src/repo_standard/policy/models.py
@@ -56,7 +56,14 @@ CHECK_SCHEMAS: dict[str, tuple[set[str], set[str]]] = {
         set(),
     ),
     "github_workflow_invocation": (
-        {"path", "job", "trigger", "token", "guards_by_profile"},
+        {
+            "path",
+            "job",
+            "trigger",
+            "token",
+            "reusable_workflow",
+            "guards_by_profile",
+        },
         set(),
     ),
     "pre_commit_hooks": ({"path", "hooks"}, set()),
@@ -400,6 +407,7 @@ def _validate_check_config(kind: str, config: dict[str, Any], location: str) -> 
         "shape",
         "section",
         "token",
+        "reusable_workflow",
     ):
         if key in config:
             _string(config[key], f"{location}.{key}")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1081,11 +1081,14 @@ def test_rsk030_owns_the_invocation_token_and_declares_every_guard() -> None:
         "job": "compliance",
         "trigger": "pull_request",
         "token": "repo-check",
+        "reusable_workflow": (
+            "FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml"
+        ),
         "guards_by_profile": {"python-single": [], "python-workspace": []},
     }
-    assert rule.check.config["token"] not in inspect.getsource(
-        CHECK_HANDLERS[rule.check.kind]
-    )
+    source = inspect.getsource(CHECK_HANDLERS[rule.check.kind])
+    assert rule.check.config["token"] not in source
+    assert rule.check.config["reusable_workflow"] not in source
 
 
 def _rewrite_compliance_step(root: Path, run: str) -> None:
@@ -1175,6 +1178,71 @@ def test_rsk030_accepts_a_command_that_only_mentions_the_token(
     root = _minimal_repo(tmp_path)
     _rewrite_compliance_step(root, "      - run: echo repo-check\n")
     assert "RSK030" not in _rule_ids(check_repo(root, POLICY))
+
+
+def _write_reusable_call(root: Path, uses: str) -> None:
+    """Write the caller form docs/compliance.md publishes, pinned at `uses`."""
+    path = root / POLICY.rule("RSK030").check.config["path"]
+    path.write_text(
+        "name: Compliance\n"
+        "on:\n"
+        "  pull_request:\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "jobs:\n"
+        "  compliance:\n"
+        f"    uses: {uses}\n"
+        "    with:\n"
+        "      standard-ref: v2.0.0\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("ref", ["a" * 40, "v2.0.0"], ids=["sha", "tag"])
+def test_the_published_reusable_workflow_call_satisfies_rsk030(
+    tmp_path: Path, ref: str
+) -> None:
+    """The called workflow runs the checker, so the call is the invocation, and
+    which ref pins it is RSK029's question rather than this rule's."""
+    root = _minimal_repo(tmp_path)
+    workflow = POLICY.rule("RSK030").check.config["reusable_workflow"]
+    _write_reusable_call(root, f"{workflow}@{ref}")
+    assert "RSK030" not in _rule_ids(check_repo(root, POLICY))
+
+
+def _no_steps_message() -> str:
+    return (
+        "Job 'compliance' has no executable steps and does not call "
+        + POLICY.rule("RSK030").check.config["reusable_workflow"]
+        + "."
+    )
+
+
+def test_a_compliance_job_calling_a_foreign_reusable_workflow_reports_rsk030(
+    tmp_path: Path,
+) -> None:
+    """Another repository's reusable workflow is no evidence the checker runs."""
+    root = _minimal_repo(tmp_path)
+    uses = "other-org/other-kit/.github/workflows/compliance-reusable.yml@" + "a" * 40
+    _write_reusable_call(root, uses)
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK030"]
+    assert finding.message == _no_steps_message()
+    assert finding.actual == uses
+
+
+def test_a_compliance_job_that_runs_nothing_at_all_reports_rsk030(
+    tmp_path: Path,
+) -> None:
+    root = _minimal_repo(tmp_path)
+    path = root / POLICY.rule("RSK030").check.config["path"]
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "    steps:\n      - run: repo-check .\n", ""
+        ),
+        encoding="utf-8",
+    )
+    [finding] = [f for f in check_repo(root, POLICY) if f.rule_id == "RSK030"]
+    assert finding.message == _no_steps_message()
 
 
 def test_the_reusable_compliance_workflow_is_pinned_and_least_privileged() -> None:


### PR DESCRIPTION
Phase B3 of #85. Resolves #90 — closing keywords do not fire on a non-default base,
so **close #90 by hand when this merges**.

## The defect

`docs/compliance.md` publishes two ways to run the checker in CI and states an
adopter may use "either form". The second is a `compliance` job that calls this
repository's reusable workflow:

```yaml
jobs:
  compliance:
    uses: FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml@<full-sha>
    with:
      standard-ref: v2.0.0
```

`.github/workflows/compliance-reusable.yml` does run `repo-check .`. But RSK030
(`github_workflow_invocation`, **required**) looked for its `repo-check` token
in a `run:` body of the adopter's own `compliance` job, and a job that calls a
reusable workflow has no steps of its own by construction. The published form
was therefore permanently red on a required rule:

```text
REQUIRED RSK030 .github/workflows/compliance.yml  Job 'compliance' has no executable steps.
```

`docs/compliance.md` separately asserts the resulting status does not depend on
"whether the adopter calls a reusable workflow", which was only true once the
check agreed.

## Resolution taken

The recommended one: **teach the check to accept the call**, not delete the
published form. The rule's subject is whether the checker runs on pull
requests, and when the job delegates to a workflow that runs it, it does. The
alternative — dropping the form from the docs — would have removed a supported
shape to fit a check that was asking about file layout rather than about the
contract.

## What changed

- `policy/base.yaml`: RSK030 gains a `reusable_workflow` config key naming
  `FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml`.
  Remediation now states both accepted forms. `compiled.json` and
  `docs/policy-reference.md` regenerated.
- `src/repo_standard/policy/models.py`: the key joins the
  `github_workflow_invocation` schema and the string-valued validation list.
- `src/repo_standard/compliance/checks.py`: new `_calls_workflow` helper;
  `_github_workflow_invocation` returns clean when the job's `uses:` names that
  workflow. **Identity is `owner/repo/path` with the ref stripped and case
  folded** — the ref varies by design (RSK029 requires a SHA, the standard also
  permits an immutable tag), so reading it would answer a different question
  from the one asked, and GitHub resolves owner/repo case-insensitively.
  Recognition is exact otherwise: another repository's reusable workflow is no
  evidence of anything.
- The no-steps message is now RSK030's own and names both accepted forms:
  `Job 'compliance' has no executable steps and does not call
  FP-DevTools/repo-standard-kit/.github/workflows/compliance-reusable.yml.`
  (`_job_shell_commands`' generic message still serves RSK006 unchanged.)
- `docs/compliance.md`: the §Alternative section states how RSK030 resolves the
  call and what still fails. **The published caller example also gained
  `permissions: contents: read`** — without it that snippet failed RSK028, a
  second, smaller disagreement in the same block, found while verifying this.
- `docs/quality-gates.md` §5 and `CHANGELOG.md` (RSK030 entry, Adopters must
  entry, and a new Fixed entry) state the same contract.
- `tests/test_compliance.py`: regression coverage both ways — see below.

## Regression tests

| Test | Asserts |
| --- | --- |
| `test_the_published_reusable_workflow_call_satisfies_rsk030[sha]` | the published caller form passes RSK030, no exemption |
| `test_the_published_reusable_workflow_call_satisfies_rsk030[tag]` | recognition does not depend on the ref |
| `test_a_compliance_job_calling_a_foreign_reusable_workflow_reports_rsk030` | another repository's reusable workflow still fails, and `actual` carries the offending `uses:` |
| `test_a_compliance_job_that_runs_nothing_at_all_reports_rsk030` | a job with neither steps nor such a call still fails |
| `test_rsk030_owns_the_invocation_token_and_declares_every_guard` (extended) | policy owns both the token and the workflow path; neither is hardcoded in the handler |

## Verification

| Command | Result |
| --- | --- |
| `uv sync --locked` | `Checked 39 packages` |
| `uv run pre-commit run --all-files` | 14 hooks, all Passed |
| `uv run pytest` | **464 passed** in 14.61s (was 460) |
| `uv build` | `repo_standard_kit-2.0.0.tar.gz` + `-py3-none-any.whl` |
| `uv run repo-check . --strict` | exit 0 — `1 finding(s), 1 rule(s) suppressed` (the pre-existing RSK011 exemption) |

### End to end against the adopter

`wombat_configs` `chore/adopt-repo-standard-kit` at `100d259`, adopted from a
throwaway merge of `origin/fix/b1-repo-adopt-upgrade-path` (#89),
`origin/fix/b2-shape-profile-scope` (#88) and this branch — 481 passed on that
merge. The adopter worktree was left reset and nothing was committed there; the
merge is not part of this PR.

`repo-adopt` leaves the caller form at the renamed path, and RSK030 is gone:

```text
remaining required findings: 2
  - RSK007 .pre-commit-config.yaml: Hook 'detect-secrets' is missing or has incompatible command/fields.
  - RSK029 .github/workflows/compliance.yml: Remote reference is not pinned to a full commit SHA: …compliance-reusable.yml@v2.0.0.
```

Both are maintainer decisions, as #90 predicted. Substituting a 40-hex SHA for
the tag by hand leaves `4 finding(s)` — RSK007, RSK015, RSK016, RSK018 — with
no required finding against the compliance workflow at all.

## Follow-up already applied

An earlier revision of this description flagged that `repo-adopt` still printed
a conflict line this PR falsifies — `"… the job calls the reusable workflow, so
it runs repo-check from the called workflow and no step of its own; RSK030
reports that"`. RSK030 no longer reports it.

That line was reworded on #89 before it merged, and is on
`chore/release-v2.0.0` at `src/repo_standard/repo_adopt.py:613-617`:

```text
- .github/workflows/compliance.yml: the job calls the reusable workflow, so
  repo-check runs there and this file declares no step of its own; own the
  command instead to control how the checker is invoked
```

Reworded rather than deleted: what the line is for — repo-check runs in the
called workflow, this file declares no step, owning the command is how to
control the invocation — is true whether or not RSK030 resolves through the
call. Only the clause naming RSK030 was falsified. That also removed the
ordering hazard, since the line now reads correctly whichever of #88, #89 and
this merged last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2onG9HFZqvfudUKeGsUkg
